### PR TITLE
Fixing fileRollMaxRolls and fileRollMilliseconds

### DIFF
--- a/src/share/classes/com/sun/btrace/agent/Client.java
+++ b/src/share/classes/com/sun/btrace/agent/Client.java
@@ -131,7 +131,7 @@ abstract class Client implements CommandListener {
             if (outputFile.equals("::stdout")) {
                 out = new PrintWriter(System.out);
             } else {
-                if (SharedSettings.GLOBAL.getFileRollMilliseconds() > 0) {
+                if (settings.getFileRollMilliseconds() > 0) {
                     out = new PrintWriter(new BufferedWriter(
                         TraceOutputWriter.rollingFileWriter(new File(outputFile), settings)
                     ));

--- a/src/share/classes/com/sun/btrace/agent/Main.java
+++ b/src/share/classes/com/sun/btrace/agent/Main.java
@@ -290,7 +290,6 @@ public final class Main {
                 fileRollMilliseconds = null;
             }
             if (fileRollMilliseconds != null) {
-                debugPrint("fileRollMilliseconds is " + settings.isUnsafe());
                 settings.setFileRollMilliseconds(fileRollMilliseconds.intValue());
                 if (isDebug()) {
                     debugPrint("fileRollMilliseconds is " + fileRollMilliseconds);

--- a/src/share/classes/com/sun/btrace/agent/Main.java
+++ b/src/share/classes/com/sun/btrace/agent/Main.java
@@ -290,9 +290,25 @@ public final class Main {
                 fileRollMilliseconds = null;
             }
             if (fileRollMilliseconds != null) {
+                debugPrint("fileRollMilliseconds is " + settings.isUnsafe());
+                settings.setFileRollMilliseconds(fileRollMilliseconds.intValue());
                 if (isDebug()) {
                     debugPrint("fileRollMilliseconds is " + fileRollMilliseconds);
                 }
+            }
+        }
+
+        p = argMap.get("fileRollMaxRolls");
+        if (p != null && p.length() > 0) {
+            Integer rolls = null;
+            try {
+                rolls = Integer.parseInt(p);
+            } catch (NumberFormatException nfe) {
+                rolls = null;
+            }
+
+            if (rolls != null) {
+                settings.setFileRollMaxRolls(rolls);
             }
         }
         p = argMap.get("unsafe");

--- a/src/share/classes/com/sun/btrace/agent/TraceOutputWriter.java
+++ b/src/share/classes/com/sun/btrace/agent/TraceOutputWriter.java
@@ -149,7 +149,7 @@ abstract class TraceOutputWriter extends Writer {
         private FileWriter getNextWriter() throws IOException {
         	currentFileWriter.close();
         	File scriptOutputFile_renameFrom = new File(path + File.separator + baseName);
-        	File scriptOutputFile_renameTo = new File(path + File.separator + baseName + "." + (counter++));
+        	File scriptOutputFile_renameTo = new File(path + File.separator + baseName.substring(0, baseName.indexOf("-")) + ".btrace." + (counter++));
 
             if (scriptOutputFile_renameTo.exists()) {
             	scriptOutputFile_renameTo.delete();
@@ -210,7 +210,7 @@ abstract class TraceOutputWriter extends Writer {
     public static TraceOutputWriter rollingFileWriter(File output, SharedSettings settings) {
         TraceOutputWriter instance = null;
         try {
-            instance = new TimeBasedRollingFileWriter(null, settings);
+            instance = new TimeBasedRollingFileWriter(output, settings);
         } catch (IOException e) {
             // ignore
         }

--- a/src/share/classes/com/sun/btrace/agent/TraceOutputWriter.java
+++ b/src/share/classes/com/sun/btrace/agent/TraceOutputWriter.java
@@ -149,7 +149,7 @@ abstract class TraceOutputWriter extends Writer {
         private FileWriter getNextWriter() throws IOException {
         	currentFileWriter.close();
         	File scriptOutputFile_renameFrom = new File(path + File.separator + baseName);
-        	File scriptOutputFile_renameTo = new File(path + File.separator + baseName.substring(0, baseName.indexOf("-")) + ".btrace." + (counter++));
+        	File scriptOutputFile_renameTo = new File(path + File.separator + baseName + "." + (counter++));
 
             if (scriptOutputFile_renameTo.exists()) {
             	scriptOutputFile_renameTo.delete();


### PR DESCRIPTION
- Fixing fileRollMaxRolls, reading in from command-line args
- Fixing fileRollMilliseconds, adding to settings and using from settings (instead of GLOBAL)
- Fixing naming of the file-rolled filenames to make them easier to read in systematically

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/221)
<!-- Reviewable:end -->
