### PR TITLE
Print toString() of all exceptions in the chain.

### DIFF
--- a/src/share/classes/com/sun/btrace/BTraceUtils.java
+++ b/src/share/classes/com/sun/btrace/BTraceUtils.java
@@ -3419,11 +3419,12 @@ public class BTraceUtils {
                 return;
             }
             StackTraceElement[] st = exception.getStackTrace();
-            println(exception);
+            println(exception.toString());
             BTraceRuntime.stackTrace("\t", st, 0, numFrames);
             Throwable cause = exception.getCause();
             while (cause != null) {
-                println("Caused by:");
+                print("Caused by: ");
+                println(cause.toString());
                 st = cause.getStackTrace();
                 BTraceRuntime.stackTrace("\t", st, 0, numFrames);
                 cause = cause.getCause();


### PR DESCRIPTION
In the current implementation, Threads.jstack() is not printing exception type and message for all but the top exception in a chain. This PR fixes that. It also prints toString() of an exception instead of the exception itself, making sure that in all cases, exception type and messages are printed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/233)
<!-- Reviewable:end -->
