### PR TITLE
fix sample JdbcQueries.java

### DIFF
--- a/samples/JdbcQueries.java
+++ b/samples/JdbcQueries.java
@@ -112,7 +112,7 @@ public class JdbcQueries {
     public static void onExecute(@Self Object currentStatement, AnyType[] args) {
         if (args.length == 0) {
             // No SQL argument; lookup the SQL from the prepared statement
-            executingStatement = Collections.get(preparedStatementDescriptions, currentStatement);
+            executingStatement = Collections.get(preparedStatementDescriptions, (Statement) currentStatement);
         } else {
             // Direct SQL in the first argument
             executingStatement = useStackTrace ? Threads.jstackStr() : str(args[0]);


### PR DESCRIPTION
Run `samples/JdbcQueries.java` with `btrace 1.3.9` will produce compilation error:

```
samples/JdbcQueries.java:115: error: method get in class com.sun.btrace.BTraceUtils.Collections cannot be applied to given types;
            executingStatement = Collections.get(preparedStatementDescriptions, currentStatement);
                                            ^
  required: java.util.Map<K,V>,K
  found: java.util.Map<java.sql.Statement,java.lang.String>,java.lang.Object
  reason: inferred type does not conform to lower bound(s)
    inferred: java.sql.Statement
    lower bound(s): java.lang.Object
error: samples/JdbcQueries.java:115:method calls are not allowed - only calls to BTraceUtils are allowed
BTrace compilation failed
```

Explicitly convert `currentStatement` to `java.sql.Statement` could fix this error.