### PR TITLE
fixed argument quoting to support jar files containing spaces

### DIFF
--- a/bin/btracer
+++ b/bin/btracer
@@ -92,7 +92,7 @@ if [ "${JAVA_HOME}" != "" ]; then
     done
 
     if [ -f "${BTRACE_HOME}/build/btrace-agent.jar" ] ; then
-        ${JAVA_HOME}/bin/java -Xshare:off -javaagent:${BTRACE_HOME}/build/btrace-agent.jar=$OPTIONS,script=$1 $2 $3 $4 $5 $6 $7 $8 $9
+        ${JAVA_HOME}/bin/java -Xshare:off -javaagent:${BTRACE_HOME}/build/btrace-agent.jar=$OPTIONS,script="$@"
     else
         echo "Please set BTRACE_HOME before running this script"
     fi


### PR DESCRIPTION
btracer did fail for jar files containing a space in their name, because there was no quoting around $2. This commit fixes the quoting and even supports more possible arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/319)
<!-- Reviewable:end -->
