### PR TITLE
A complex fix try-catch handler problems. Fixes #335

### DIFF
--- a/src/share/classes/com/sun/btrace/runtime/BTraceMethodVisitor.java
+++ b/src/share/classes/com/sun/btrace/runtime/BTraceMethodVisitor.java
@@ -24,6 +24,10 @@ public class BTraceMethodVisitor extends MethodVisitor {
         return index;
     }
 
+    public final void addTryCatchHandler(Label start, Label handler) {
+        mHelper.addTryCatchHandler(start, handler);
+    }
+
     public void insertFrameReplaceStack(Label l, Type... stack) {
         mHelper.insertFrameReplaceStack(l, stack);
     }

--- a/src/share/classes/com/sun/btrace/runtime/InstrumentingMethodVisitor.java
+++ b/src/share/classes/com/sun/btrace/runtime/InstrumentingMethodVisitor.java
@@ -1179,7 +1179,7 @@ public final class InstrumentingMethodVisitor extends MethodVisitor implements M
 
     @Override
     public void visitTryCatchBlock(Label start, Label end, Label handler, String exception) {
-        tryCatchHandlerMap.put(start, handler);
+        addTryCatchHandler(start, handler);
         super.visitTryCatchBlock(start, end, handler, exception);
     }
 
@@ -1277,6 +1277,11 @@ public final class InstrumentingMethodVisitor extends MethodVisitor implements M
         Object[] stackSlots = stack.toArray(true);
 
         super.visitFrame(F_NEW, localsArr.length, localsArr, stackSlots.length, stackSlots);
+    }
+
+    @Override
+    public void addTryCatchHandler(Label start, Label handler) {
+        tryCatchHandlerMap.put(start, handler);
     }
 
     @Override

--- a/src/share/classes/com/sun/btrace/runtime/MethodInstrumentorHelper.java
+++ b/src/share/classes/com/sun/btrace/runtime/MethodInstrumentorHelper.java
@@ -11,6 +11,7 @@ public interface MethodInstrumentorHelper {
     void insertFrameReplaceStack(Label l,Type ... stack);
     void insertFrameAppendStack(Label l, Type ... stack);
     void insertFrameSameStack(Label l);
+    void addTryCatchHandler(Label start, Label handler);
     int newVar(Type t);
     int storeAsNew();
 }

--- a/src/share/classes/com/sun/btrace/runtime/instr/ErrorReturnInstrumentor.java
+++ b/src/share/classes/com/sun/btrace/runtime/instr/ErrorReturnInstrumentor.java
@@ -52,13 +52,14 @@ public class ErrorReturnInstrumentor extends MethodReturnInstrumentor {
 
     @Override
     protected void visitMethodPrologue() {
-        visitTryCatchBlock(start, end, end, THROWABLE_INTERNAL);
+        addTryCatchHandler(start, end);
         visitLabel(start);
         super.visitMethodPrologue();
     }
 
     @Override
     public void visitMaxs(int maxStack, int maxLocals) {
+        visitTryCatchBlock(start, end, end, THROWABLE_INTERNAL);
         visitLabel(end);
         insertFrameReplaceStack(end, THROWABLE_TYPE);
         onErrorReturn();

--- a/src/test/java/com/sun/btrace/runtime/BTRACE69Test.java
+++ b/src/test/java/com/sun/btrace/runtime/BTRACE69Test.java
@@ -37,27 +37,18 @@ public class BTRACE69Test extends InstrumentorTestBase {
         originalBC = loadTargetClass("OnMethodTest");
         transform("issues/BTRACE69");
         checkTransformation(
-            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
-            "TRYCATCHBLOCK L0 L2 L2 java/lang/Throwable\n" +
-            "TRYCATCHBLOCK L3 L4 L5 null\n" +
-            "TRYCATCHBLOCK L5 L6 L5 null\n" +
-            "L0\n" +
-            "LINENUMBER 108 L0\n" +
+            "TRYCATCHBLOCK L4 L5 L5 java/lang/Throwable\n" +
+            "TRYCATCHBLOCK L4 L6 L6 java/lang/Throwable\n" +
             "DUP\n" +
             "ASTORE 2\n" +
             "ALOAD 2\n" +
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$issues$BTRACE69$onSyncEntry (Ljava/lang/Object;)V\n" +
-            "L3\n" +
-            "LINENUMBER 109 L3\n" +
             "L7\n" +
             "LINENUMBER 110 L7\n" +
-            "ALOAD 1\n" +
             "DUP\n" +
             "ASTORE 3\n" +
             "ALOAD 3\n" +
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$issues$BTRACE69$onSyncExit (Ljava/lang/Object;)V\n" +
-            "MONITOREXIT\n" +
-            "L4\n" +
             "GOTO L8\n" +
             "FRAME FULL [resources/OnMethodTest java/lang/Object resources/OnMethodTest] [java/lang/Throwable]\n" +
             "ASTORE 4\n" +
@@ -65,17 +56,17 @@ public class BTRACE69Test extends InstrumentorTestBase {
             "ASTORE 5\n" +
             "ALOAD 5\n" +
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$issues$BTRACE69$onSyncExit (Ljava/lang/Object;)V\n" +
-            "L6\n" +
             "ALOAD 4\n" +
             "ATHROW\n" +
             "L8\n" +
             "LINENUMBER 111 L8\n" +
             "FRAME FULL [resources/OnMethodTest T resources/OnMethodTest resources/OnMethodTest T] []\n" +
             "RETURN\n" +
+            "L5\n" +
             "FRAME FULL [resources/OnMethodTest] [java/lang/Throwable]\n" +
-            "ATHROW\n" +
             "FRAME SAME1 java/lang/Throwable\n" +
-            "LOCALVARIABLE this Lresources/OnMethodTest; L0 L1 0\n" +
+            "ATHROW\n" +
+            "LOCALVARIABLE this Lresources/OnMethodTest; L4 L5 0\n" +
             "MAXLOCALS = 6"
         );
     }

--- a/src/test/java/com/sun/btrace/runtime/InstrumentorTest.java
+++ b/src/test/java/com/sun/btrace/runtime/InstrumentorTest.java
@@ -431,6 +431,65 @@ public class InstrumentorTest extends InstrumentorTestBase {
     }
 
     @Test
+    public void methodEntryErrorCaught() throws Exception {
+        loadTargetClass("OnMethodTest");
+        transform("onmethod/ErrorCaught");
+
+        checkTransformation(
+            "TRYCATCHBLOCK L0 L2 L2 java/lang/Throwable\n" +
+            "L3\n" +
+            "LINENUMBER 162 L3\n" +
+            "L4\n" +
+            "LINENUMBER 164 L4\n" +
+            "RETURN\n" +
+            "L2\n" +
+            "FRAME SAME1 java/lang/Throwable\n" +
+            "DUP\n" +
+            "ASTORE 2\n" +
+            "ALOAD 0\n" +
+            "LDC \"caught\"\n" +
+            "ALOAD 2\n" +
+            "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$ErrorCaught$args (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Throwable;)V\n" +
+            "ATHROW\n" +
+            "LOCALVARIABLE e Ljava/lang/RuntimeException; L3 L4 1\n" +
+            "LOCALVARIABLE this Lresources/OnMethodTest; L0 L2 0\n" +
+            "MAXSTACK = 4\n" +
+            "MAXLOCALS = 3"
+        );
+
+        resetClassLoader();
+
+        transform("onmethod/leveled/ErrorCaught");
+
+        checkTransformation(
+            "TRYCATCHBLOCK L0 L2 L2 java/lang/Throwable\n" +
+            "L3\n" +
+            "LINENUMBER 162 L3\n" +
+            "L4\n" +
+            "LINENUMBER 164 L4\n" +
+            "RETURN\n" +
+            "L2\n" +
+            "FRAME SAME1 java/lang/Throwable\n" +
+            "DUP\n" +
+            "ASTORE 2\n" +
+            "GETSTATIC traces/onmethod/leveled/ErrorCaught.$btrace$$level : I\n" +
+            "ICONST_1\n" +
+            "IF_ICMPLT L5\n" +
+            "ALOAD 0\n" +
+            "LDC \"caught\"\n" +
+            "ALOAD 2\n" +
+            "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$leveled$ErrorCaught$args (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Throwable;)V\n" +
+            "L5\n" +
+            "FRAME FULL [resources/OnMethodTest T java/lang/Throwable] [java/lang/Throwable]\n" +
+            "ATHROW\n" +
+            "LOCALVARIABLE e Ljava/lang/RuntimeException; L3 L4 1\n" +
+            "LOCALVARIABLE this Lresources/OnMethodTest; L0 L2 0\n" +
+            "MAXSTACK = 4\n" +
+            "MAXLOCALS = 3"
+        );
+    }
+
+    @Test
     public void methodEntryErrorDuration() throws Exception {
         loadTargetClass("OnMethodTest");
         transform("onmethod/ErrorDuration");
@@ -615,35 +674,26 @@ public class InstrumentorTest extends InstrumentorTestBase {
         transform("onmethod/SyncEntry");
 
         checkTransformation(
-            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
-            "TRYCATCHBLOCK L2 L3 L4 null\n" +
-            "TRYCATCHBLOCK L4 L5 L4 null\n" +
-            "L0\n" +
-            "LINENUMBER 108 L0\n" +
+            "TRYCATCHBLOCK L4 L5 L5 java/lang/Throwable\n" +
             "DUP\n" +
             "ASTORE 2\n" +
             "ALOAD 0\n" +
             "LDC \"sync\"\n" +
             "ALOAD 2\n" +
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$SyncEntry$args (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;)V\n" +
-            "L2\n" +
-            "LINENUMBER 109 L2\n" +
             "L6\n" +
             "LINENUMBER 110 L6\n" +
-            "L3\n" +
             "GOTO L7\n" +
-            "L4\n" +
             "FRAME FULL [resources/OnMethodTest java/lang/Object resources/OnMethodTest] [java/lang/Throwable]\n" +
             "ASTORE 3\n" +
-            "L5\n" +
             "ALOAD 3\n" +
             "L7\n" +
             "LINENUMBER 111 L7\n" +
             "FRAME FULL [resources/OnMethodTest T resources/OnMethodTest T] []\n" +
-            "L1\n" +
+            "L5\n" +
             "FRAME FULL [resources/OnMethodTest] [java/lang/Throwable]\n" +
             "ATHROW\n" +
-            "LOCALVARIABLE this Lresources/OnMethodTest; L0 L1 0\n" +
+            "LOCALVARIABLE this Lresources/OnMethodTest; L4 L5 0\n" +
             "MAXSTACK = 4\n" +
             "MAXLOCALS = 4"
         );
@@ -653,11 +703,7 @@ public class InstrumentorTest extends InstrumentorTestBase {
         transform("onmethod/leveled/SyncEntry");
 
         checkTransformation(
-            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
-            "TRYCATCHBLOCK L2 L3 L4 null\n" +
-            "TRYCATCHBLOCK L4 L5 L4 null\n" +
-            "L0\n" +
-            "LINENUMBER 108 L0\n" +
+            "TRYCATCHBLOCK L4 L5 L5 java/lang/Throwable\n" +
             "GETSTATIC traces/onmethod/leveled/SyncEntry.$btrace$$level : I\n" +
             "ICONST_1\n" +
             "IF_ICMPLT L6\n" +
@@ -669,24 +715,19 @@ public class InstrumentorTest extends InstrumentorTestBase {
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$leveled$SyncEntry$args (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;)V\n" +
             "L6\n" +
             "FRAME FULL [resources/OnMethodTest resources/OnMethodTest T] [resources/OnMethodTest]\n" +
-            "L2\n" +
-            "LINENUMBER 109 L2\n" +
             "L7\n" +
             "LINENUMBER 110 L7\n" +
-            "L3\n" +
             "GOTO L8\n" +
-            "L4\n" +
             "FRAME FULL [resources/OnMethodTest java/lang/Object T] [java/lang/Throwable]\n" +
             "ASTORE 3\n" +
-            "L5\n" +
             "ALOAD 3\n" +
             "L8\n" +
             "LINENUMBER 111 L8\n" +
             "FRAME FULL [resources/OnMethodTest T T T] []\n" +
-            "L1\n" +
+            "L5\n" +
             "FRAME FULL [resources/OnMethodTest] [java/lang/Throwable]\n" +
             "ATHROW\n" +
-            "LOCALVARIABLE this Lresources/OnMethodTest; L0 L1 0\n" +
+            "LOCALVARIABLE this Lresources/OnMethodTest; L4 L5 0\n" +
             "MAXSTACK = 4\n" +
             "MAXLOCALS = 4"
         );
@@ -698,35 +739,26 @@ public class InstrumentorTest extends InstrumentorTestBase {
         transform("onmethod/SyncMEntry");
 
         checkTransformation(
-            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
-            "TRYCATCHBLOCK L2 L3 L4 null\n" +
-            "TRYCATCHBLOCK L4 L5 L4 null\n" +
-            "L0\n" +
-            "LINENUMBER 147 L0\n" +
+            "TRYCATCHBLOCK L4 L5 L5 java/lang/Throwable\n" +
             "DUP\n" +
             "ASTORE 2\n" +
             "ALOAD 0\n" +
             "LDC \"syncM\"\n" +
             "ALOAD 2\n" +
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$SyncMEntry$args (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;)V\n" +
-            "L2\n" +
-            "LINENUMBER 148 L2\n" +
             "L6\n" +
             "LINENUMBER 149 L6\n" +
-            "L3\n" +
             "GOTO L7\n" +
-            "L4\n" +
             "FRAME FULL [resources/OnMethodTest java/lang/Object java/lang/Object] [java/lang/Throwable]\n" +
             "ASTORE 3\n" +
-            "L5\n" +
             "ALOAD 3\n" +
             "L7\n" +
             "LINENUMBER 150 L7\n" +
             "FRAME FULL [resources/OnMethodTest T java/lang/Object T] []\n" +
-            "L1\n" +
+            "L5\n" +
             "FRAME FULL [resources/OnMethodTest] [java/lang/Throwable]\n" +
             "ATHROW\n" +
-            "LOCALVARIABLE this Lresources/OnMethodTest; L0 L1 0\n" +
+            "LOCALVARIABLE this Lresources/OnMethodTest; L4 L5 0\n" +
             "MAXSTACK = 4\n" +
             "MAXLOCALS = 4"
         );
@@ -736,11 +768,7 @@ public class InstrumentorTest extends InstrumentorTestBase {
         transform("onmethod/leveled/SyncMEntry");
 
         checkTransformation(
-            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
-            "TRYCATCHBLOCK L2 L3 L4 null\n" +
-            "TRYCATCHBLOCK L4 L5 L4 null\n" +
-            "L0\n" +
-            "LINENUMBER 147 L0\n" +
+            "TRYCATCHBLOCK L4 L5 L5 java/lang/Throwable\n" +
             "GETSTATIC traces/onmethod/leveled/SyncMEntry.$btrace$$level : I\n" +
             "ICONST_1\n" +
             "IF_ICMPLT L6\n" +
@@ -752,24 +780,19 @@ public class InstrumentorTest extends InstrumentorTestBase {
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$leveled$SyncMEntry$args (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;)V\n" +
             "L6\n" +
             "FRAME FULL [resources/OnMethodTest java/lang/Object T] [java/lang/Object]\n" +
-            "L2\n" +
-            "LINENUMBER 148 L2\n" +
             "L7\n" +
             "LINENUMBER 149 L7\n" +
-            "L3\n" +
             "GOTO L8\n" +
-            "L4\n" +
             "FRAME SAME1 java/lang/Throwable\n" +
             "ASTORE 3\n" +
-            "L5\n" +
             "ALOAD 3\n" +
             "L8\n" +
             "LINENUMBER 150 L8\n" +
             "FRAME FULL [resources/OnMethodTest T T T] []\n" +
-            "L1\n" +
+            "L5\n" +
             "FRAME FULL [resources/OnMethodTest] [java/lang/Throwable]\n" +
             "ATHROW\n" +
-            "LOCALVARIABLE this Lresources/OnMethodTest; L0 L1 0\n" +
+            "LOCALVARIABLE this Lresources/OnMethodTest; L4 L5 0\n" +
             "MAXSTACK = 4\n" +
             "MAXLOCALS = 4"
         );
@@ -781,13 +804,7 @@ public class InstrumentorTest extends InstrumentorTestBase {
         transform("onmethod/SyncExit");
 
         checkTransformation(
-            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
-            "TRYCATCHBLOCK L2 L3 L4 null\n" +
-            "TRYCATCHBLOCK L4 L5 L4 null\n" +
-            "L0\n" +
-            "LINENUMBER 108 L0\n" +
-            "L2\n" +
-            "LINENUMBER 109 L2\n" +
+            "TRYCATCHBLOCK L4 L5 L5 java/lang/Throwable\n" +
             "L6\n" +
             "LINENUMBER 110 L6\n" +
             "DUP\n" +
@@ -796,9 +813,7 @@ public class InstrumentorTest extends InstrumentorTestBase {
             "LDC \"resources.OnMethodTest\"\n" +
             "ALOAD 2\n" +
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$SyncExit$args (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;)V\n" +
-            "L3\n" +
             "GOTO L7\n" +
-            "L4\n" +
             "ASTORE 3\n" +
             "DUP\n" +
             "ASTORE 4\n" +
@@ -806,15 +821,14 @@ public class InstrumentorTest extends InstrumentorTestBase {
             "LDC \"resources.OnMethodTest\"\n" +
             "ALOAD 4\n" +
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$SyncExit$args (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;)V\n" +
-            "L5\n" +
             "ALOAD 3\n" +
             "L7\n" +
             "LINENUMBER 111 L7\n" +
             "FRAME FULL [resources/OnMethodTest T resources/OnMethodTest T] []\n" +
-            "L1\n" +
+            "L5\n" +
             "FRAME FULL [resources/OnMethodTest] [java/lang/Throwable]\n" +
             "ATHROW\n" +
-            "LOCALVARIABLE this Lresources/OnMethodTest; L0 L1 0\n" +
+            "LOCALVARIABLE this Lresources/OnMethodTest; L4 L5 0\n" +
             "MAXSTACK = 4\n" +
             "MAXLOCALS = 5"
         );
@@ -824,13 +838,7 @@ public class InstrumentorTest extends InstrumentorTestBase {
         transform("onmethod/leveled/SyncExit");
 
         checkTransformation(
-            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
-            "TRYCATCHBLOCK L2 L3 L4 null\n" +
-            "TRYCATCHBLOCK L4 L5 L4 null\n" +
-            "L0\n" +
-            "LINENUMBER 108 L0\n" +
-            "L2\n" +
-            "LINENUMBER 109 L2\n" +
+            "TRYCATCHBLOCK L4 L5 L5 java/lang/Throwable\n" +
             "L6\n" +
             "LINENUMBER 110 L6\n" +
             "GETSTATIC traces/onmethod/leveled/SyncExit.$btrace$$level : I\n" +
@@ -844,9 +852,7 @@ public class InstrumentorTest extends InstrumentorTestBase {
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$leveled$SyncExit$args (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;)V\n" +
             "L7\n" +
             "FRAME FULL [resources/OnMethodTest resources/OnMethodTest T] [resources/OnMethodTest]\n" +
-            "L3\n" +
             "GOTO L8\n" +
-            "L4\n" +
             "ASTORE 3\n" +
             "GETSTATIC traces/onmethod/leveled/SyncExit.$btrace$$level : I\n" +
             "ICONST_1\n" +
@@ -859,15 +865,14 @@ public class InstrumentorTest extends InstrumentorTestBase {
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$leveled$SyncExit$args (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;)V\n" +
             "L9\n" +
             "FRAME FULL [resources/OnMethodTest java/lang/Object T java/lang/Throwable T] [java/lang/Object]\n" +
-            "L5\n" +
             "ALOAD 3\n" +
             "L8\n" +
             "LINENUMBER 111 L8\n" +
             "FRAME FULL [resources/OnMethodTest T T T] []\n" +
-            "L1\n" +
+            "L5\n" +
             "FRAME FULL [resources/OnMethodTest] [java/lang/Throwable]\n" +
             "ATHROW\n" +
-            "LOCALVARIABLE this Lresources/OnMethodTest; L0 L1 0\n" +
+            "LOCALVARIABLE this Lresources/OnMethodTest; L4 L5 0\n" +
             "MAXSTACK = 4\n" +
             "MAXLOCALS = 5"
         );
@@ -879,13 +884,7 @@ public class InstrumentorTest extends InstrumentorTestBase {
         transform("onmethod/SyncMExit");
 
         checkTransformation(
-            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
-            "TRYCATCHBLOCK L2 L3 L4 null\n" +
-            "TRYCATCHBLOCK L4 L5 L4 null\n" +
-            "L0\n" +
-            "LINENUMBER 147 L0\n" +
-            "L2\n" +
-            "LINENUMBER 148 L2\n" +
+            "TRYCATCHBLOCK L4 L5 L5 java/lang/Throwable\n" +
             "L6\n" +
             "LINENUMBER 149 L6\n" +
             "DUP\n" +
@@ -894,9 +893,7 @@ public class InstrumentorTest extends InstrumentorTestBase {
             "LDC \"resources.OnMethodTest\"\n" +
             "ALOAD 2\n" +
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$SyncMExit$args (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;)V\n" +
-            "L3\n" +
             "GOTO L7\n" +
-            "L4\n" +
             "ASTORE 3\n" +
             "DUP\n" +
             "ASTORE 4\n" +
@@ -904,15 +901,14 @@ public class InstrumentorTest extends InstrumentorTestBase {
             "LDC \"resources.OnMethodTest\"\n" +
             "ALOAD 4\n" +
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$SyncMExit$args (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;)V\n" +
-            "L5\n" +
             "ALOAD 3\n" +
             "L7\n" +
             "LINENUMBER 150 L7\n" +
             "FRAME FULL [resources/OnMethodTest T java/lang/Object T] []\n" +
-            "L1\n" +
+            "L5\n" +
             "FRAME FULL [resources/OnMethodTest] [java/lang/Throwable]\n" +
             "ATHROW\n" +
-            "LOCALVARIABLE this Lresources/OnMethodTest; L0 L1 0\n" +
+            "LOCALVARIABLE this Lresources/OnMethodTest; L4 L5 0\n" +
             "MAXSTACK = 4\n" +
             "MAXLOCALS = 5"
         );
@@ -922,13 +918,7 @@ public class InstrumentorTest extends InstrumentorTestBase {
         transform("onmethod/leveled/SyncMExit");
 
         checkTransformation(
-            "TRYCATCHBLOCK L0 L1 L1 java/lang/Throwable\n" +
-            "TRYCATCHBLOCK L2 L3 L4 null\n" +
-            "TRYCATCHBLOCK L4 L5 L4 null\n" +
-            "L0\n" +
-            "LINENUMBER 147 L0\n" +
-            "L2\n" +
-            "LINENUMBER 148 L2\n" +
+            "TRYCATCHBLOCK L4 L5 L5 java/lang/Throwable\n" +
             "L6\n" +
             "LINENUMBER 149 L6\n" +
             "GETSTATIC traces/onmethod/leveled/SyncMExit.$btrace$$level : I\n" +
@@ -942,9 +932,7 @@ public class InstrumentorTest extends InstrumentorTestBase {
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$leveled$SyncMExit$args (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;)V\n" +
             "L7\n" +
             "FRAME FULL [resources/OnMethodTest java/lang/Object T] [java/lang/Object]\n" +
-            "L3\n" +
             "GOTO L8\n" +
-            "L4\n" +
             "ASTORE 3\n" +
             "GETSTATIC traces/onmethod/leveled/SyncMExit.$btrace$$level : I\n" +
             "ICONST_1\n" +
@@ -957,15 +945,14 @@ public class InstrumentorTest extends InstrumentorTestBase {
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$leveled$SyncMExit$args (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;)V\n" +
             "L9\n" +
             "FRAME FULL [resources/OnMethodTest java/lang/Object T java/lang/Throwable T] [java/lang/Object]\n" +
-            "L5\n" +
             "ALOAD 3\n" +
             "L8\n" +
             "LINENUMBER 150 L8\n" +
             "FRAME FULL [resources/OnMethodTest T T T] []\n" +
-            "L1\n" +
+            "L5\n" +
             "FRAME FULL [resources/OnMethodTest] [java/lang/Throwable]\n" +
             "ATHROW\n" +
-            "LOCALVARIABLE this Lresources/OnMethodTest; L0 L1 0\n" +
+            "LOCALVARIABLE this Lresources/OnMethodTest; L4 L5 0\n" +
             "MAXSTACK = 4\n" +
             "MAXLOCALS = 5"
         );
@@ -5706,8 +5693,7 @@ public class InstrumentorTest extends InstrumentorTestBase {
             "ALOAD 0\n" +
             "ALOAD 1\n" +
             "INVOKESTATIC resources/OnMethodTest.$btrace$traces$onmethod$ArgsSigMatch$m1 (Ljava/lang/Object;Ljava/util/List;)V\n" +
-            "MAXSTACK = 2\n" +
-            "MAXLOCALS = 2"
+            "MAXSTACK = 2"
         );
 
         resetClassLoader();

--- a/src/test/java/resources/OnMethodTest.java
+++ b/src/test/java/resources/OnMethodTest.java
@@ -154,4 +154,12 @@ import java.util.Map;
     public String argsTypeMatch(java.util.ArrayList<String> l) {
         return "x";
     }
+
+    public void caught() {
+        try {
+            throw new RuntimeException("ho-hey");
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/test/traces/onmethod/ErrorCaught.java
+++ b/src/test/traces/onmethod/ErrorCaught.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Copyright owner designates
+ * this particular file as subject to the "Classpath" exception as provided
+ * by the owner in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package traces.onmethod;
+
+import com.sun.btrace.annotations.BTrace;
+import com.sun.btrace.annotations.Kind;
+import com.sun.btrace.annotations.Location;
+import com.sun.btrace.annotations.OnMethod;
+import com.sun.btrace.annotations.ProbeMethodName;
+import com.sun.btrace.annotations.Self;
+import com.sun.btrace.annotations.TargetInstance;
+import static com.sun.btrace.BTraceUtils.*;
+
+/**
+ *
+ * @author Jaroslav Bachorik
+ */
+@BTrace
+public class ErrorCaught {
+    @OnMethod(clazz="/.*\\.OnMethodTest/", method="caught",
+              location=@Location(value=Kind.ERROR))
+    public static void args(@Self Object self, @ProbeMethodName String pmn, @TargetInstance Throwable cause) {
+        println("args");
+    }
+}

--- a/src/test/traces/onmethod/leveled/ErrorCaught.java
+++ b/src/test/traces/onmethod/leveled/ErrorCaught.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Copyright owner designates
+ * this particular file as subject to the "Classpath" exception as provided
+ * by the owner in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package traces.onmethod.leveled;
+
+import com.sun.btrace.annotations.BTrace;
+import com.sun.btrace.annotations.Kind;
+import com.sun.btrace.annotations.Location;
+import com.sun.btrace.annotations.OnMethod;
+import com.sun.btrace.annotations.ProbeMethodName;
+import com.sun.btrace.annotations.Self;
+import com.sun.btrace.annotations.TargetInstance;
+import static com.sun.btrace.BTraceUtils.*;
+import com.sun.btrace.annotations.*;
+
+/**
+ *
+ * @author Jaroslav Bachorik
+ */
+@BTrace
+public class ErrorCaught {
+    @OnMethod(clazz="/.*\\.OnMethodTest/", method="caught",
+              location=@Location(value=Kind.ERROR), enableAt = @Level(">=1"))
+    public static void args(@Self Object self, @ProbeMethodName String pmn, @TargetInstance Throwable cause) {
+        println("args");
+    }
+}


### PR DESCRIPTION
The fix is based on contribution by @denisbog ( #337 )
Moving the try-catch block visit would throw off the custom stackmap frame generator. This patch addresses that problem and adds test cases covering the problematic bytecode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/338)
<!-- Reviewable:end -->
