### PR TITLE
Initial support of unattended mode

### DIFF
--- a/benchmarks/runtime-benchmarks/src/jmh/java/org/openjdk/btrace/BTraceBench.java
+++ b/benchmarks/runtime-benchmarks/src/jmh/java/org/openjdk/btrace/BTraceBench.java
@@ -44,7 +44,7 @@ import org.openjdk.btrace.core.ArgsMap;
 import org.openjdk.btrace.core.BTraceRuntime;
 import org.openjdk.btrace.core.comm.CommandListener;
 import org.openjdk.btrace.core.comm.DataCommand;
-import org.openjdk.btrace.core.comm.OkayCommand;
+import org.openjdk.btrace.core.comm.StatusCommand;
 import org.openjdk.btrace.instr.MethodTracker;
 import org.openjdk.btrace.runtime.BTraceRuntimes;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -236,7 +236,7 @@ public class BTraceBench {
   @Measurement(iterations = 5, time = 2000, timeUnit = TimeUnit.MILLISECONDS)
   @Benchmark
   public void testSendCommand() {
-    br.send(new OkayCommand());
+    br.send(new StatusCommand());
   }
 
   @Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
@@ -244,7 +244,7 @@ public class BTraceBench {
   @Threads(2)
   @Benchmark
   public void testSendCommandMulti2() {
-    br.send(new OkayCommand());
+    br.send(new StatusCommand());
   }
 
   @Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
@@ -252,7 +252,7 @@ public class BTraceBench {
   @Threads(4)
   @Benchmark
   public void testSendCommandMulti4() {
-    br.send(new OkayCommand());
+    br.send(new StatusCommand());
   }
 
   @Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
@@ -260,7 +260,7 @@ public class BTraceBench {
   @Threads(8)
   @Benchmark
   public void testSendCommandMulti8() {
-    br.send(new OkayCommand());
+    br.send(new StatusCommand());
   }
 
   @Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
@@ -268,7 +268,7 @@ public class BTraceBench {
   @Threads(16)
   @Benchmark
   public void testSendCommandMulti16() {
-    br.send(new OkayCommand());
+    br.send(new StatusCommand());
   }
 
   long sampleHit10Checks = 0;

--- a/btrace-agent/src/main/java/org/openjdk/btrace/agent/Client.java
+++ b/btrace-agent/src/main/java/org/openjdk/btrace/agent/Client.java
@@ -35,11 +35,15 @@ import java.lang.instrument.UnmodifiableClassException;
 import java.lang.management.ManagementFactory;
 import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.objectweb.asm.ClassReader;
@@ -53,9 +57,9 @@ import org.openjdk.btrace.core.comm.ErrorCommand;
 import org.openjdk.btrace.core.comm.ExitCommand;
 import org.openjdk.btrace.core.comm.InstrumentCommand;
 import org.openjdk.btrace.core.comm.MessageCommand;
-import org.openjdk.btrace.core.comm.OkayCommand;
 import org.openjdk.btrace.core.comm.RenameCommand;
 import org.openjdk.btrace.core.comm.RetransformationStartNotification;
+import org.openjdk.btrace.core.comm.StatusCommand;
 import org.openjdk.btrace.instr.BTraceProbe;
 import org.openjdk.btrace.instr.BTraceProbeFactory;
 import org.openjdk.btrace.instr.BTraceProbePersisted;
@@ -79,6 +83,7 @@ import sun.reflect.annotation.AnnotationType;
  * @author J. Bachorik (j.bachorik@btrace.io)
  */
 abstract class Client implements CommandListener {
+  private static final Map<UUID, Client> CLIENTS = new ConcurrentHashMap<>();
   private static final Map<String, PrintWriter> WRITER_MAP = new HashMap<>();
   private static final Pattern SYSPROP_PTN = Pattern.compile("\\$\\{(.+?)\\}");
 
@@ -96,19 +101,19 @@ abstract class Client implements CommandListener {
     ClassInfo.class.getClassLoader();
   }
 
-  protected final Instrumentation inst;
-  protected final SharedSettings settings;
-  protected final DebugSupport debug;
-  protected final ArgsMap argsMap;
+  private final Instrumentation inst;
+  final SharedSettings settings;
+  final DebugSupport debug;
+  final ArgsMap argsMap;
   private final BTraceTransformer transformer;
-  protected volatile PrintWriter out;
+  volatile PrintWriter out;
   private volatile BTraceRuntime.Impl runtime;
   private volatile String outputName;
-  private byte[] btraceCode;
   private BTraceProbe probe;
   private Timer flusher;
   private volatile boolean initialized = false;
   private volatile boolean shuttingDown = false;
+  final UUID id = UUID.randomUUID();
 
   Client(ClientContext ctx) {
     this(ctx.getInstr(), ctx.getArguments(), ctx.getSettings(), ctx.getTransformer());
@@ -122,6 +127,7 @@ abstract class Client implements CommandListener {
     debug = new DebugSupport(settings);
 
     setupWriter();
+    CLIENTS.put(this.id, this);
   }
 
   private static String pid() {
@@ -141,7 +147,7 @@ abstract class Client implements CommandListener {
   }
 
   @SuppressWarnings("DefaultCharset")
-  protected final void setupWriter() {
+  private final void setupWriter() {
     String outputFile = settings.getOutputFile();
     if (outputFile == null || outputFile.equals("::null") || outputFile.equals("/dev/null")) return;
 
@@ -266,7 +272,17 @@ abstract class Client implements CommandListener {
     return cnt;
   }
 
-  protected synchronized void onExit(int exitCode) {
+  static Collection<String> listProbes() {
+    List<String> probes = new ArrayList<>(CLIENTS.size());
+    for (Client client : CLIENTS.values()) {
+      if (client instanceof RemoteClient) {
+        probes.add(client.id + " [" + client.getClassName() + "]");
+      }
+    }
+    return probes;
+  }
+
+  synchronized void onExit(int exitCode) {
     if (!shuttingDown) {
       shuttingDown = true;
       if (out != null) {
@@ -296,19 +312,20 @@ abstract class Client implements CommandListener {
         }
       } finally {
         runtime.shutdownCmdLine();
+        CLIENTS.remove(this.id);
         HandlerRepository.unregisterProbe(probe);
       }
     }
   }
 
-  protected final Class<?> loadClass(InstrumentCommand instr) throws IOException {
+  final Class<?> loadClass(InstrumentCommand instr) throws IOException {
     return loadClass(instr, true);
   }
 
-  protected final Class<?> loadClass(InstrumentCommand instr, boolean canLoadPack)
+  final Class<?> loadClass(InstrumentCommand instr, boolean canLoadPack)
       throws IOException {
     ArgsMap args = instr.getArguments();
-    btraceCode = instr.getCode();
+    byte[] btraceCode = instr.getCode();
     try {
       probe = load(btraceCode, ArgsMap.merge(argsMap, args), canLoadPack);
       if (probe == null) {
@@ -351,7 +368,7 @@ abstract class Client implements CommandListener {
       debugPrint("sending Okay command");
     }
 
-    onCommand(new OkayCommand());
+    onCommand(new StatusCommand());
 
     boolean entered = false;
     try {
@@ -378,7 +395,7 @@ abstract class Client implements CommandListener {
     WRITER_MAP.remove(outputName);
   }
 
-  protected final void errorExit(Throwable th) throws IOException {
+  private void errorExit(Throwable th) throws IOException {
     debugPrint("sending error command");
     onCommand(new ErrorCommand(th));
     debugPrint("sending exit command");
@@ -386,7 +403,7 @@ abstract class Client implements CommandListener {
     closeAll();
   }
 
-  protected final void cleanupTransformers() {
+  private void cleanupTransformers() {
     if (probe != null) {
       probe.unregister();
     }
@@ -397,7 +414,7 @@ abstract class Client implements CommandListener {
     return initialized;
   }
 
-  final void infoPrint(String msg) {
+  private void infoPrint(String msg) {
     DebugSupport.info(msg);
   }
 
@@ -417,11 +434,11 @@ abstract class Client implements CommandListener {
     return runtime;
   }
 
-  protected final String getClassName() {
+  final String getClassName() {
     return probe != null ? probe.getClassName() : "<unknown>";
   }
 
-  final boolean isCandidate(Class c) {
+  private final boolean isCandidate(Class c) {
     String cname = c.getName().replace('.', '/');
     if (c.isInterface() || c.isPrimitive() || c.isArray()) {
       return false;
@@ -433,7 +450,7 @@ abstract class Client implements CommandListener {
     }
   }
 
-  final void startRetransformClasses(int numClasses) {
+  private final void startRetransformClasses(int numClasses) {
     try {
       onCommand(new RetransformationStartNotification(numClasses));
       if (isDebug()) {
@@ -446,7 +463,7 @@ abstract class Client implements CommandListener {
 
   final void endRetransformClasses() {
     try {
-      onCommand(new OkayCommand());
+      onCommand(new StatusCommand());
       if (isDebug()) debugPrint("finished retransformClasses");
     } catch (IOException e) {
       debugPrint(e);
@@ -472,34 +489,65 @@ abstract class Client implements CommandListener {
     return BTraceProbePersisted.from(cn);
   }
 
-  void retransformLoaded() throws UnmodifiableClassException {
-    if (runtime != null) {
-      if (probe.isTransforming() && settings.isRetransformStartup()) {
-        ArrayList<Class<?>> list = new ArrayList<>();
-        debugPrint("retransforming loaded classes");
-        debugPrint("filtering loaded classes");
-        ClassCache cc = ClassCache.getInstance();
-        for (Class<?> c : inst.getAllLoadedClasses()) {
-          if (c != null) {
-            if (inst.isModifiableClass(c) && isCandidate(c)) {
-              debugPrint("candidate " + c + " added");
-              list.add(c);
-            }
+  boolean retransformLoaded() throws UnmodifiableClassException {
+    if (runtime == null) {
+      return false;
+    }
+    if (probe.isTransforming() && settings.isRetransformStartup()) {
+      ArrayList<Class<?>> list = new ArrayList<>();
+      debugPrint("retransforming loaded classes");
+      debugPrint("filtering loaded classes");
+      ClassCache cc = ClassCache.getInstance();
+      for (Class<?> c : inst.getAllLoadedClasses()) {
+        if (c != null) {
+          if (inst.isModifiableClass(c) && isCandidate(c)) {
+            debugPrint("candidate " + c + " added");
+            list.add(c);
           }
         }
-        list.trimToSize();
-        int size = list.size();
-        if (size > 0) {
-          Class<?>[] classes = new Class[size];
-          list.toArray(classes);
-          startRetransformClasses(size);
-          if (isDebug()) {
+      }
+      list.trimToSize();
+      int size = list.size();
+      if (size > 0) {
+        Class<?>[] classes = new Class[size];
+        list.toArray(classes);
+        startRetransformClasses(size);
+        if (isDebug()) {
+          for (Class<?> c : classes) {
+            try {
+              debugPrint("Attempting to retransform class: " + c.getName());
+              inst.retransformClasses(c);
+            } catch (VerifyError e) {
+              debugPrint(e);
+              try {
+                onCommand(
+                    new MessageCommand(
+                        "[BTRACE WARN] Class verification failed: "
+                            + c.getName()
+                            + " ("
+                            + e.getMessage()
+                            + ")"));
+              } catch (IOException ioException) {
+                if (isDebug()) {
+                  debug.debug(ioException);
+                }
+              }
+            }
+          }
+        } else {
+          try {
+            inst.retransformClasses(classes);
+          } catch (VerifyError e) {
+            /*
+             * If the en-block retransformation fails because of verification retry classes one-by-one.
+             * Otherwise all classes are rolled back to the original state and no instrumentation
+             * is applied.
+             */
             for (Class<?> c : classes) {
               try {
-                debugPrint("Attempting to retransform class: " + c.getName());
                 inst.retransformClasses(c);
-              } catch (VerifyError e) {
-                debugPrint(e);
+              } catch (VerifyError e1) {
+                debugPrint(e1);
                 try {
                   onCommand(
                       new MessageCommand(
@@ -515,40 +563,24 @@ abstract class Client implements CommandListener {
                 }
               }
             }
-          } else {
-            try {
-              inst.retransformClasses(classes);
-            } catch (VerifyError e) {
-              /*
-               * If the en-block retransformation fails because of verification retry classes one-by-one.
-               * Otherwise all classes are rolled back to the original state and no instrumentation
-               * is applied.
-               */
-              for (Class<?> c : classes) {
-                try {
-                  inst.retransformClasses(c);
-                } catch (VerifyError e1) {
-                  debugPrint(e1);
-                  try {
-                    onCommand(
-                        new MessageCommand(
-                            "[BTRACE WARN] Class verification failed: "
-                                + c.getName()
-                                + " ("
-                                + e.getMessage()
-                                + ")"));
-                  } catch (IOException ioException) {
-                    if (isDebug()) {
-                      debug.debug(ioException);
-                    }
-                  }
-                }
-              }
-            }
           }
         }
       }
-      runtime.send(new OkayCommand());
     }
+    return true;
+  }
+
+  static Client findClient(String uuid) {
+    try {
+      UUID id = UUID.fromString(uuid);
+      return CLIENTS.get(id);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "BTrace Client: " + id + "[" + probe.getClassName() + "]";
   }
 }

--- a/btrace-agent/src/main/java/org/openjdk/btrace/agent/Client.java
+++ b/btrace-agent/src/main/java/org/openjdk/btrace/agent/Client.java
@@ -276,7 +276,9 @@ abstract class Client implements CommandListener {
     List<String> probes = new ArrayList<>(CLIENTS.size());
     for (Client client : CLIENTS.values()) {
       if (client instanceof RemoteClient) {
-        probes.add(client.id + " [" + client.getClassName() + "]");
+        if (((RemoteClient) client).isDisconnected()) {
+          probes.add(client.id + " [" + client.getClassName() + "]");
+        }
       }
     }
     return probes;
@@ -322,8 +324,7 @@ abstract class Client implements CommandListener {
     return loadClass(instr, true);
   }
 
-  final Class<?> loadClass(InstrumentCommand instr, boolean canLoadPack)
-      throws IOException {
+  final Class<?> loadClass(InstrumentCommand instr, boolean canLoadPack) throws IOException {
     ArgsMap args = instr.getArguments();
     byte[] btraceCode = instr.getCode();
     try {

--- a/btrace-agent/src/main/java/org/openjdk/btrace/agent/Main.java
+++ b/btrace-agent/src/main/java/org/openjdk/btrace/agent/Main.java
@@ -76,10 +76,14 @@ import java.util.regex.Pattern;
 import java.util.zip.ZipFile;
 import org.openjdk.btrace.core.ArgsMap;
 import org.openjdk.btrace.core.BTraceRuntime;
+import org.openjdk.btrace.core.Function;
 import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.Messages;
 import org.openjdk.btrace.core.SharedSettings;
 import org.openjdk.btrace.core.comm.ErrorCommand;
+import org.openjdk.btrace.core.comm.InstrumentCommand;
+import org.openjdk.btrace.core.comm.MessageCommand;
+import org.openjdk.btrace.core.comm.StatusCommand;
 import org.openjdk.btrace.instr.BTraceTransformer;
 import org.openjdk.btrace.instr.Constants;
 import org.openjdk.btrace.runtime.BTraceRuntimes;
@@ -853,14 +857,20 @@ public final class Main {
           debugPrint("client accepted " + sock);
         }
         ClientContext ctx = new ClientContext(inst, transformer, argMap, settings);
-        Client client = new RemoteClient(ctx, sock);
-        handleNewClient(client).get();
-      } catch (RuntimeException | IOException | ExecutionException re) {
+        Client client =
+            RemoteClient.getClient(
+                ctx,
+                sock,
+                new Function<Client, Future<?>>() {
+                  @Override
+                  public Future<?> apply(Client value) {
+                    return handleNewClient(value);
+                  }
+                });
+      } catch (RuntimeException | IOException re) {
         if (isDebug()) {
           debugPrint(re);
         }
-      } catch (InterruptedException e) {
-        return;
       }
     }
   }
@@ -875,12 +885,25 @@ public final class Main {
               boolean entered = BTraceRuntime.enter();
               try {
                 client.debugPrint("new Client created " + client);
-                client.retransformLoaded();
+                if (client.retransformLoaded()) {
+                  client
+                      .getRuntime()
+                      .send(
+                          new MessageCommand(
+                              "BTrace Probe: [id="
+                                  + client.id
+                                  + ", name="
+                                  + client.getClassName()
+                                  + "]",
+                              true));
+                  client.getRuntime().send(new StatusCommand((byte) 1));
+                }
               } catch (UnmodifiableClassException uce) {
                 if (isDebug()) {
                   debugPrint(uce);
                 }
                 client.getRuntime().send(new ErrorCommand(uce));
+                client.getRuntime().send(new StatusCommand(-1 * InstrumentCommand.STATUS_FLAG));
               } finally {
                 if (entered) {
                   BTraceRuntime.leave();

--- a/btrace-agent/src/main/java/org/openjdk/btrace/agent/Main.java
+++ b/btrace-agent/src/main/java/org/openjdk/btrace/agent/Main.java
@@ -76,13 +76,12 @@ import java.util.regex.Pattern;
 import java.util.zip.ZipFile;
 import org.openjdk.btrace.core.ArgsMap;
 import org.openjdk.btrace.core.BTraceRuntime;
-import org.openjdk.btrace.core.Function;
 import org.openjdk.btrace.core.DebugSupport;
+import org.openjdk.btrace.core.Function;
 import org.openjdk.btrace.core.Messages;
 import org.openjdk.btrace.core.SharedSettings;
 import org.openjdk.btrace.core.comm.ErrorCommand;
 import org.openjdk.btrace.core.comm.InstrumentCommand;
-import org.openjdk.btrace.core.comm.MessageCommand;
 import org.openjdk.btrace.core.comm.StatusCommand;
 import org.openjdk.btrace.instr.BTraceTransformer;
 import org.openjdk.btrace.instr.Constants;
@@ -886,16 +885,6 @@ public final class Main {
               try {
                 client.debugPrint("new Client created " + client);
                 if (client.retransformLoaded()) {
-                  client
-                      .getRuntime()
-                      .send(
-                          new MessageCommand(
-                              "BTrace Probe: [id="
-                                  + client.id
-                                  + ", name="
-                                  + client.getClassName()
-                                  + "]",
-                              true));
                   client.getRuntime().send(new StatusCommand((byte) 1));
                 }
               } catch (UnmodifiableClassException uce) {

--- a/btrace-client/src/main/java/org/openjdk/btrace/client/Client.java
+++ b/btrace-client/src/main/java/org/openjdk/btrace/client/Client.java
@@ -133,7 +133,7 @@ public class Client {
   private volatile ObjectInputStream ois;
   private volatile ObjectOutputStream oos;
 
-  private boolean detached = false;
+  private boolean disconnected = false;
 
   public Client(int port) {
     this(port, null, ".", false, false, false, false, null, null);
@@ -469,7 +469,7 @@ public class Client {
               if (statusReported || cmd.getType() != Command.STATUS) {
                 listener.onCommand(cmd);
               } else {
-                StatusCommand statusCommand = (StatusCommand)cmd;
+                StatusCommand statusCommand = (StatusCommand) cmd;
                 if (statusCommand.getFlag() == ReconnectCommand.STATUS_FLAG) {
                   if (statusCommand.isSuccess()) {
                     DebugSupport.info("Reconnected to an active probe: " + resumeProbe);
@@ -638,13 +638,13 @@ public class Client {
     reset();
   }
 
-  boolean isDetached() {
-    return detached;
+  boolean isDisconnected() {
+    return disconnected;
   }
 
-  void detach() {
-    detached = true;
-    System.exit(0);
+  void disconnect() throws IOException {
+    disconnected = true;
+    sendDisconnect();
   }
 
   void listProbes() throws IOException {

--- a/btrace-client/src/main/java/org/openjdk/btrace/client/Client.java
+++ b/btrace-client/src/main/java/org/openjdk/btrace/client/Client.java
@@ -58,11 +58,15 @@ import org.openjdk.btrace.core.annotations.DTrace;
 import org.openjdk.btrace.core.annotations.DTraceRef;
 import org.openjdk.btrace.core.comm.Command;
 import org.openjdk.btrace.core.comm.CommandListener;
+import org.openjdk.btrace.core.comm.DisconnectCommand;
 import org.openjdk.btrace.core.comm.EventCommand;
 import org.openjdk.btrace.core.comm.ExitCommand;
 import org.openjdk.btrace.core.comm.InstrumentCommand;
+import org.openjdk.btrace.core.comm.ListProbesCommand;
 import org.openjdk.btrace.core.comm.MessageCommand;
+import org.openjdk.btrace.core.comm.ReconnectCommand;
 import org.openjdk.btrace.core.comm.SetSettingsCommand;
+import org.openjdk.btrace.core.comm.StatusCommand;
 import org.openjdk.btrace.core.comm.WireIO;
 
 /**
@@ -128,6 +132,8 @@ public class Client {
   private volatile Socket sock;
   private volatile ObjectInputStream ois;
   private volatile ObjectOutputStream oos;
+
+  private boolean detached = false;
 
   public Client(int port) {
     this(port, null, ".", false, false, false, false, null, null);
@@ -368,6 +374,123 @@ public class Client {
     }
   }
 
+  void connectAndListProbes(String host, final CommandListener listener) throws IOException {
+    if (sock != null) {
+      throw new IllegalStateException();
+    }
+    try {
+      if (debug) {
+        debugPrint("opening socket to " + port);
+      }
+      long timeout = System.nanoTime() + TimeUnit.NANOSECONDS.convert(5, TimeUnit.SECONDS);
+      while (sock == null && System.nanoTime() <= timeout) {
+        try {
+          sock = new Socket(host, port);
+        } catch (ConnectException e) {
+          if (debug) {
+            debugPrint("server not yet available; retrying ...");
+          }
+          Thread.sleep(20);
+        }
+      }
+
+      if (sock == null) {
+        debugPrint("server not available. exiting.");
+        System.exit(1);
+      }
+      oos = new ObjectOutputStream(sock.getOutputStream());
+      WireIO.write(oos, new ListProbesCommand());
+      ois = new ObjectInputStream(sock.getInputStream());
+
+      if (debug) {
+        debugPrint("entering into command loop");
+      }
+      commandLoop(
+          new CommandListener() {
+            @Override
+            public void onCommand(Command cmd) throws IOException {
+              if (cmd.getType() == Command.LIST_PROBES) {
+                listener.onCommand(cmd);
+                System.exit(0);
+              } else {
+                listener.onCommand(cmd);
+              }
+            }
+          });
+    } catch (UnknownHostException uhe) {
+      throw new IOException(uhe);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  void reconnect(String host, final String resumeProbe, final CommandListener listener)
+      throws IOException {
+    if (sock != null) {
+      throw new IllegalStateException();
+    }
+    try {
+      if (debug) {
+        debugPrint("opening socket to " + port);
+      }
+      long timeout = System.nanoTime() + TimeUnit.NANOSECONDS.convert(5, TimeUnit.SECONDS);
+      while (sock == null && System.nanoTime() <= timeout) {
+        try {
+          sock = new Socket(host, port);
+        } catch (ConnectException e) {
+          if (debug) {
+            debugPrint("server not yet available; retrying ...");
+          }
+          Thread.sleep(20);
+        }
+      }
+
+      if (sock == null) {
+        debugPrint("server not available. exiting.");
+        System.exit(1);
+      }
+      oos = new ObjectOutputStream(sock.getOutputStream());
+      if (debug) {
+        debugPrint("reconnecting client");
+      }
+      WireIO.write(oos, new ReconnectCommand(resumeProbe));
+
+      ois = new ObjectInputStream(sock.getInputStream());
+
+      if (debug) {
+        debugPrint("entering into command loop");
+      }
+      commandLoop(
+          new CommandListener() {
+            boolean statusReported = false;
+
+            @Override
+            public void onCommand(Command cmd) throws IOException {
+              if (statusReported || cmd.getType() != Command.STATUS) {
+                listener.onCommand(cmd);
+              } else {
+                StatusCommand statusCommand = (StatusCommand)cmd;
+                if (statusCommand.getFlag() == ReconnectCommand.STATUS_FLAG) {
+                  if (statusCommand.isSuccess()) {
+                    DebugSupport.info("Reconnected to an active probe: " + resumeProbe);
+                  } else {
+                    DebugSupport.warning("Unable to reconnect to an active probe: " + resumeProbe);
+                    System.exit(1);
+                  }
+                } else {
+                  listener.onCommand(cmd);
+                }
+                statusReported = true;
+              }
+            }
+          });
+    } catch (UnknownHostException uhe) {
+      throw new IOException(uhe);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
   /**
    * Submits the compiled BTrace .class to the VM attached and passes given command line arguments.
    * Receives commands from the traced JVM and sends those to the command listener provided.
@@ -382,7 +505,11 @@ public class Client {
    * Receives commands from the traced JVM and sends those to the command listener provided.
    */
   public void submit(
-      String host, String fileName, byte[] code, String[] args, CommandListener listener)
+      String host,
+      final String fileName,
+      byte[] code,
+      String[] args,
+      final CommandListener listener)
       throws IOException {
     if (sock != null) {
       throw new IllegalStateException();
@@ -405,7 +532,7 @@ public class Client {
       }
 
       if (sock == null) {
-        debugPrint("server not available. exitting.");
+        debugPrint("server not available. exiting.");
         System.exit(1);
       }
       oos = new ObjectOutputStream(sock.getOutputStream());
@@ -422,17 +549,42 @@ public class Client {
 
       WireIO.write(oos, new SetSettingsCommand(settings));
 
+      ois = new ObjectInputStream(sock.getInputStream());
+
       if (debug) {
         debugPrint("sending instrument command: " + Arrays.deepToString(args));
       }
       SharedSettings sSettings = new SharedSettings();
       sSettings.from(settings);
       WireIO.write(oos, new InstrumentCommand(code, args, new DebugSupport(sSettings)));
-      ois = new ObjectInputStream(sock.getInputStream());
+
       if (debug) {
         debugPrint("entering into command loop");
       }
-      commandLoop(listener);
+      commandLoop(
+          new CommandListener() {
+            boolean statusReported = false;
+
+            @Override
+            public void onCommand(Command cmd) throws IOException {
+              if (statusReported || cmd.getType() != Command.STATUS) {
+                listener.onCommand(cmd);
+              } else {
+                StatusCommand statusCommand = (StatusCommand) cmd;
+                if (statusCommand.getFlag() == InstrumentCommand.STATUS_FLAG) {
+                  if (statusCommand.isSuccess()) {
+                    DebugSupport.info("Successfully started BTrace probe: " + fileName);
+                  } else {
+                    DebugSupport.warning("Failed to start BTrace probe: " + fileName);
+                    System.exit(1);
+                  }
+                  statusReported = true;
+                } else {
+                  listener.onCommand(cmd);
+                }
+              }
+            }
+          });
     } catch (UnknownHostException uhe) {
       throw new IOException(uhe);
     } catch (InterruptedException e) {
@@ -458,6 +610,10 @@ public class Client {
     send(new ExitCommand(code));
   }
 
+  public void sendDisconnect() throws IOException {
+    send(new DisconnectCommand());
+  }
+
   /** Sends an EventCommand to the traced JVM. */
   public void sendEvent() throws IOException {
     sendEvent("");
@@ -480,6 +636,19 @@ public class Client {
       sock.close();
     }
     reset();
+  }
+
+  boolean isDetached() {
+    return detached;
+  }
+
+  void detach() {
+    detached = true;
+    System.exit(0);
+  }
+
+  void listProbes() throws IOException {
+    send(new ListProbesCommand());
   }
 
   /** reset the internal status of the client */

--- a/btrace-client/src/main/java/org/openjdk/btrace/client/Main.java
+++ b/btrace-client/src/main/java/org/openjdk/btrace/client/Main.java
@@ -29,11 +29,15 @@ import java.io.Console;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+
+import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.Messages;
 import org.openjdk.btrace.core.comm.Command;
 import org.openjdk.btrace.core.comm.CommandListener;
 import org.openjdk.btrace.core.comm.ExitCommand;
+import org.openjdk.btrace.core.comm.InstrumentCommand;
 import org.openjdk.btrace.core.comm.PrintableCommand;
+import org.openjdk.btrace.core.comm.StatusCommand;
 import sun.misc.Signal;
 import sun.misc.SignalHandler;
 
@@ -93,6 +97,9 @@ public final class Main {
     boolean classpathDefined = false;
     boolean includePathDefined = false;
     String statsdDef = "";
+    String resumeProbe = null;
+    boolean listProbes = false;
+    boolean unattended = false;
 
     OUTER:
     for (String arg : args) {
@@ -157,6 +164,15 @@ public final class Main {
         } else if (args[count].equals("-host") && !hostDefined) {
           host = args[++count];
           hostDefined = true;
+        } else if (args[count].equals("-r")) {
+          if (isDebug()) debugPrint("reconnecting to an already active probe " + resumeProbe);
+          resumeProbe = args[++count];
+        } else if (args[count].equals("-lp")) {
+          if (isDebug()) debugPrint("listing active probes");
+          listProbes = true;
+        } else if (args[count].equals("-x")) {
+          if (isDebug()) debugPrint("submitting probe in unattended mode");
+          unattended = true;
         } else {
           usage();
         }
@@ -186,16 +202,11 @@ public final class Main {
     if (pid == null) {
       errorExit("Unable to find JVM with either PID or name: " + pidArg, 1);
     } else {
-      System.out.println("Attaching BTrace to PID: " + pid);
-    }
-    String fileName = args[count + 1];
-    String[] btraceArgs = new String[args.length - count - 2];
-    if (btraceArgs.length > 0) {
-      System.arraycopy(args, count + 2, btraceArgs, 0, btraceArgs.length);
+      DebugSupport.info("Attaching BTrace to PID: " + pid);
     }
 
     try {
-      Client client =
+      final Client client =
           new Client(
               port,
               OUTPUT_FILE,
@@ -206,23 +217,54 @@ public final class Main {
               DUMP_CLASSES,
               DUMP_DIR,
               statsdDef);
-      if (!new File(fileName).exists()) {
-        errorExit("File not found: " + fileName, 1);
+      if (resumeProbe != null) {
+        registerExitHook(client);
+        if (con != null) {
+          registerSignalHandler(client);
+        }
+        client.reconnect(host, resumeProbe, createCommandListener(client));
+      } else if (listProbes) {
+        registerExitHook(client);
+        client.attach(pid.toString(), null, classPath);
+        client.connectAndListProbes(host, createCommandListener(client));
+        System.exit(0);
+      } else {
+        String fileName = args[count + 1];
+        String[] btraceArgs = new String[args.length - count - 2];
+        if (btraceArgs.length > 0) {
+          System.arraycopy(args, count + 2, btraceArgs, 0, btraceArgs.length);
+        }
+        if (!new File(fileName).exists()) {
+          errorExit("File not found: " + fileName, 1);
+        }
+        byte[] code = client.compile(fileName, classPath, includePath);
+        if (code == null) {
+          errorExit("BTrace compilation failed", 1);
+        }
+        if (isDebug()) {
+          debugPrint("Boot classpath: " + classPath);
+        }
+        if (!hostDefined) client.attach(pid.toString(), null, classPath);
+        registerExitHook(client);
+        if (con != null) {
+          registerSignalHandler(client);
+        }
+        if (isDebug()) debugPrint("submitting the BTrace program");
+        final CommandListener listener = createCommandListener(client);
+
+        final boolean isUnattended = unattended;
+        client.submit(host, fileName, code, btraceArgs, new CommandListener() {
+          @Override
+          public void onCommand(Command cmd) throws IOException {
+            if (isUnattended && cmd.getType() == Command.STATUS && ((StatusCommand)cmd).getFlag() == InstrumentCommand.STATUS_FLAG) {
+              client.sendDisconnect();
+              System.exit(0);
+            } else {
+              listener.onCommand(cmd);
+            }
+          }
+        });
       }
-      byte[] code = client.compile(fileName, classPath, includePath);
-      if (code == null) {
-        errorExit("BTrace compilation failed", 1);
-      }
-      if (isDebug()) {
-        debugPrint("Boot classpath: " + classPath);
-      }
-      if (!hostDefined) client.attach(pid.toString(), null, classPath);
-      registerExitHook(client);
-      if (con != null) {
-        registerSignalHandler(client);
-      }
-      if (isDebug()) debugPrint("submitting the BTrace program");
-      client.submit(host, fileName, code, btraceArgs, createCommandListener(client));
     } catch (IOException exp) {
       errorExit(exp.getMessage(), 1);
     }
@@ -256,8 +298,13 @@ public final class Main {
                   public void run() {
                     if (!exiting) {
                       try {
-                        if (isDebug()) debugPrint("sending exit command");
-                        client.sendExit(0);
+                        if (!client.isDetached()) {
+                          if (isDebug()) debugPrint("sending exit command");
+                          client.sendExit(0);
+                        } else {
+                          if (isDebug()) debugPrint("sending disconnect command");
+                          client.sendDisconnect();
+                        }
                       } catch (IOException ioexp) {
                         if (isDebug()) debugPrint(ioexp.toString());
                       }
@@ -276,7 +323,7 @@ public final class Main {
             try {
               con.printf("Please enter your option:\n");
               con.printf(
-                  "\t1. exit\n\t2. send an event\n\t3. send a named event\n\t4. flush console output\n");
+                  "\t1. exit\n\t2. send an event\n\t3. send a named event\n\t4. flush console output\n\t5. list probes\n\t6. detach client\n");
               con.flush();
               String option = con.readLine();
               if (option == null) {
@@ -300,6 +347,12 @@ public final class Main {
                   break;
                 case "4":
                   out.flush();
+                  break;
+                case "5":
+                  client.listProbes();
+                  break;
+                case "6":
+                  client.detach();
                   break;
                 default:
                   con.printf("invalid option!\n");

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/CircularBuffer.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/CircularBuffer.java
@@ -1,0 +1,57 @@
+package org.openjdk.btrace.core;
+
+public final class CircularBuffer<T> {
+    private final T[] elements;
+    private final int size;
+    private long readIndex = 0;
+    private long writeIndex = -1;
+    private int length = 0;
+
+    @SuppressWarnings("unchecked")
+    public CircularBuffer(int size) {
+        this.size = size;
+        elements = (T[])new Object[size];
+    }
+
+    public void add(T element) {
+        int newIndex = (int)(++writeIndex) % size;
+        elements[newIndex] = element;
+        int nextIndex = (newIndex + 1) % size;
+        if (elements[nextIndex] != null) {
+            readIndex = nextIndex;
+        }
+        if (++length > size) {
+            length = size;
+        }
+    }
+
+    public boolean forEach(Function<T, Boolean> functor) {
+        int cntr = 0;
+        while (cntr < size && writeIndex >= readIndex) {
+            if (functor.apply(elements[(int)readIndex % size])) {
+                readIndex++;
+                if (--length <0) {
+                    length = 0;
+                }
+            } else {
+                return false;
+            }
+            cntr++;
+        }
+        return true;
+    }
+
+    public boolean doNext(Function<T, Boolean> nextWork) {
+        if (writeIndex >= readIndex) {
+            if (nextWork.apply(elements[(int)readIndex % size])) {
+                readIndex++;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public int getLength() {
+        return length;
+    }
+}

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/CircularBuffer.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/CircularBuffer.java
@@ -1,57 +1,57 @@
 package org.openjdk.btrace.core;
 
 public final class CircularBuffer<T> {
-    private final T[] elements;
-    private final int size;
-    private long readIndex = 0;
-    private long writeIndex = -1;
-    private int length = 0;
+  private final T[] elements;
+  private final int size;
+  private long readIndex = 0;
+  private long writeIndex = -1;
+  private int length = 0;
 
-    @SuppressWarnings("unchecked")
-    public CircularBuffer(int size) {
-        this.size = size;
-        elements = (T[])new Object[size];
+  @SuppressWarnings("unchecked")
+  public CircularBuffer(int size) {
+    this.size = size;
+    elements = (T[]) new Object[size];
+  }
+
+  public void add(T element) {
+    int newIndex = (int) (++writeIndex) % size;
+    elements[newIndex] = element;
+    int nextIndex = (newIndex + 1) % size;
+    if (elements[nextIndex] != null) {
+      readIndex = nextIndex;
     }
-
-    public void add(T element) {
-        int newIndex = (int)(++writeIndex) % size;
-        elements[newIndex] = element;
-        int nextIndex = (newIndex + 1) % size;
-        if (elements[nextIndex] != null) {
-            readIndex = nextIndex;
-        }
-        if (++length > size) {
-            length = size;
-        }
+    if (++length > size) {
+      length = size;
     }
+  }
 
-    public boolean forEach(Function<T, Boolean> functor) {
-        int cntr = 0;
-        while (cntr < size && writeIndex >= readIndex) {
-            if (functor.apply(elements[(int)readIndex % size])) {
-                readIndex++;
-                if (--length <0) {
-                    length = 0;
-                }
-            } else {
-                return false;
-            }
-            cntr++;
+  public boolean forEach(Function<T, Boolean> functor) {
+    int cntr = 0;
+    while (cntr < size && writeIndex >= readIndex) {
+      if (functor.apply(elements[(int) readIndex % size])) {
+        readIndex++;
+        if (--length < 0) {
+          length = 0;
         }
-        return true;
-    }
-
-    public boolean doNext(Function<T, Boolean> nextWork) {
-        if (writeIndex >= readIndex) {
-            if (nextWork.apply(elements[(int)readIndex % size])) {
-                readIndex++;
-                return true;
-            }
-        }
+      } else {
         return false;
+      }
+      cntr++;
     }
+    return true;
+  }
 
-    public int getLength() {
-        return length;
+  public boolean doNext(Function<T, Boolean> nextWork) {
+    if (writeIndex >= readIndex) {
+      if (nextWork.apply(elements[(int) readIndex % size])) {
+        readIndex++;
+        return true;
+      }
     }
+    return false;
+  }
+
+  public int getLength() {
+    return length;
+  }
 }

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/Function.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/Function.java
@@ -1,0 +1,5 @@
+package org.openjdk.btrace.core;
+
+public interface Function<T, R> {
+  R apply(T value);
+}

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/Command.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/Command.java
@@ -52,13 +52,14 @@ public abstract class Command implements Serializable {
   public static final byte FIRST_COMMAND = ERROR;
   public static final byte LAST_COMMAND = RECONNECT;
 
-  public static Command NULL = new Command() {
-    @Override
-    protected void write(ObjectOutput out) throws IOException {}
+  public static Command NULL =
+      new Command() {
+        @Override
+        protected void write(ObjectOutput out) throws IOException {}
 
-    @Override
-    protected void read(ObjectInput in) throws IOException, ClassNotFoundException {}
-  };
+        @Override
+        protected void read(ObjectInput in) throws IOException, ClassNotFoundException {}
+      };
 
   protected byte type;
   private boolean urgent;

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/Command.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/Command.java
@@ -37,7 +37,7 @@ public abstract class Command implements Serializable {
   public static final byte INSTRUMENT = 3;
   public static final byte MESSAGE = 4;
   public static final byte RENAME = 5;
-  public static final byte SUCCESS = 6;
+  public static final byte STATUS = 6;
   public static final byte NUMBER_MAP = 7;
   public static final byte STRING_MAP = 8;
   public static final byte NUMBER = 9;
@@ -45,41 +45,54 @@ public abstract class Command implements Serializable {
   public static final byte RETRANSFORMATION_START = 11;
   public static final byte RETRANSFORM_CLASS = 12;
   public static final byte SET_PARAMS = 13;
+  public static final byte LIST_PROBES = 14;
+  public static final byte DISCONNECT = 15;
+  public static final byte RECONNECT = 16;
 
   public static final byte FIRST_COMMAND = ERROR;
-  public static final byte LAST_COMMAND = SET_PARAMS;
+  public static final byte LAST_COMMAND = RECONNECT;
+
+  public static Command NULL = new Command() {
+    @Override
+    protected void write(ObjectOutput out) throws IOException {}
+
+    @Override
+    protected void read(ObjectInput in) throws IOException, ClassNotFoundException {}
+  };
 
   protected byte type;
+  private boolean urgent;
 
   protected Command(byte type) {
+    this(type, true);
+  }
+
+  protected Command(byte type, boolean urgent) {
     if (type < FIRST_COMMAND || type > LAST_COMMAND) {
       throw new IllegalArgumentException();
     }
     this.type = type;
+    this.urgent = urgent;
+  }
+
+  private Command() {
+    this.type = -1;
+    this.urgent = true;
   }
 
   protected abstract void write(ObjectOutput out) throws IOException;
 
   protected abstract void read(ObjectInput in) throws IOException, ClassNotFoundException;
 
-  public byte getType() {
+  public final byte getType() {
     return type;
   }
 
-  final boolean isUrgent() {
-    switch (type) {
-      case MESSAGE:
-      case NUMBER_MAP:
-      case STRING_MAP:
-      case NUMBER:
-      case GRID_DATA:
-        {
-          return false;
-        }
-      default:
-        {
-          return true;
-        }
-    }
+  public final boolean isUrgent() {
+    return urgent;
+  }
+
+  final void setUrgent() {
+    urgent = true;
   }
 }

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/DataCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/DataCommand.java
@@ -33,8 +33,8 @@ package org.openjdk.btrace.core.comm;
 public abstract class DataCommand extends Command implements PrintableCommand {
   protected String name;
 
-  public DataCommand(byte type, String name) {
-    super(type);
+  public DataCommand(byte type, String name, boolean urgent) {
+    super(type, urgent);
     this.name = name;
   }
 

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/DisconnectCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/DisconnectCommand.java
@@ -3,15 +3,36 @@ package org.openjdk.btrace.core.comm;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.io.PrintWriter;
 
-public final class DisconnectCommand extends Command {
+public final class DisconnectCommand extends Command implements PrintableCommand {
+  private String probeId = "";
+
   public DisconnectCommand() {
-    super(Command.DISCONNECT);
+    super(Command.DISCONNECT, true);
+  }
+
+  public DisconnectCommand(String probeId) {
+    super(Command.DISCONNECT, true);
+    this.probeId = probeId;
   }
 
   @Override
-  protected void write(ObjectOutput out) throws IOException {}
+  protected void write(ObjectOutput out) throws IOException {
+    out.writeUTF(probeId);
+  }
 
   @Override
-  protected void read(ObjectInput in) throws IOException, ClassNotFoundException {}
+  protected void read(ObjectInput in) throws IOException, ClassNotFoundException {
+    probeId = in.readUTF();
+  }
+
+  public void setProbeId(String probeId) {
+    this.probeId = probeId;
+  }
+
+  @Override
+  public void print(PrintWriter out) {
+    out.println("BTrace Probe: " + probeId);
+  }
 }

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/DisconnectCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/DisconnectCommand.java
@@ -1,0 +1,17 @@
+package org.openjdk.btrace.core.comm;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public final class DisconnectCommand extends Command {
+  public DisconnectCommand() {
+    super(Command.DISCONNECT);
+  }
+
+  @Override
+  protected void write(ObjectOutput out) throws IOException {}
+
+  @Override
+  protected void read(ObjectInput in) throws IOException, ClassNotFoundException {}
+}

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/ErrorCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/ErrorCommand.java
@@ -34,7 +34,7 @@ public class ErrorCommand extends Command implements PrintableCommand {
   private Throwable cause;
 
   public ErrorCommand(Throwable cause) {
-    super(ERROR);
+    super(ERROR, true);
     this.cause = cause;
   }
 

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/EventCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/EventCommand.java
@@ -33,7 +33,7 @@ public class EventCommand extends Command {
   private String event;
 
   public EventCommand(String event) {
-    super(EVENT);
+    super(EVENT, true);
     this.event = event;
   }
 

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/ExitCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/ExitCommand.java
@@ -33,7 +33,7 @@ public class ExitCommand extends Command {
   private int exitCode;
 
   public ExitCommand(int exitCode) {
-    super(EXIT);
+    super(EXIT, true);
     this.exitCode = exitCode;
   }
 

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/GridDataCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/GridDataCommand.java
@@ -96,7 +96,7 @@ public class GridDataCommand extends DataCommand {
    * @see String#format(java.lang.String, java.lang.Object[])
    */
   public GridDataCommand(String name, List<Object[]> data, String format) {
-    super(GRID_DATA, name);
+    super(GRID_DATA, name, false);
     this.data = data;
     this.format = format;
   }

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/InstrumentCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/InstrumentCommand.java
@@ -34,12 +34,14 @@ import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.SharedSettings;
 
 public class InstrumentCommand extends Command {
+  public static final int STATUS_FLAG = 1;
+
   private final DebugSupport debug;
   private byte[] code;
   private ArgsMap args;
 
   public InstrumentCommand(byte[] code, ArgsMap args, DebugSupport debug) {
-    super(INSTRUMENT);
+    super(INSTRUMENT, true);
     this.code = code;
     this.args = args;
     this.debug = debug;

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/ListProbesCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/ListProbesCommand.java
@@ -1,0 +1,46 @@
+package org.openjdk.btrace.core.comm;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class ListProbesCommand extends Command implements PrintableCommand {
+  private final List<String> probes = new ArrayList<>();
+
+  public ListProbesCommand() {
+    super(Command.LIST_PROBES, true);
+  }
+
+  public void setProbes(Collection<String> probes) {
+    this.probes.clear();
+    this.probes.addAll(probes);
+  }
+
+  @Override
+  protected void write(ObjectOutput out) throws IOException {
+    out.writeInt(probes.size());
+    for (String probe : probes) {
+      out.writeUTF(probe);
+    }
+  }
+
+  @Override
+  protected void read(ObjectInput in) throws IOException, ClassNotFoundException {
+    int numProbes = in.readInt();
+    for (int i = 0; i < numProbes; i++) {
+      probes.add(in.readUTF());
+    }
+  }
+
+  @Override
+  public void print(PrintWriter out) {
+    int cntr = 1;
+    for (String probe : probes) {
+      out.println(cntr++ + ": " + probe);
+    }
+  }
+}

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/MessageCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/MessageCommand.java
@@ -46,13 +46,21 @@ public class MessageCommand extends DataCommand {
   private String msg;
 
   public MessageCommand(long time, String msg) {
-    super(MESSAGE, null);
+    this(time, msg, false);
+  }
+
+  public MessageCommand(long time, String msg, boolean urgent) {
+    super(MESSAGE, null, urgent);
     this.time = time;
     this.msg = msg;
   }
 
   public MessageCommand(String msg) {
-    this(0L, msg);
+    this(msg, false);
+  }
+
+  public MessageCommand(String msg, boolean urgent) {
+    this(0L, msg, urgent);
   }
 
   protected MessageCommand() {
@@ -61,6 +69,7 @@ public class MessageCommand extends DataCommand {
 
   @Override
   protected void write(ObjectOutput out) throws IOException {
+    out.writeBoolean(isUrgent());
     out.writeLong(time);
     byte[] bytes = msg != null ? msg.getBytes(StandardCharsets.UTF_8) : new byte[0];
     out.writeInt(bytes.length);
@@ -71,6 +80,9 @@ public class MessageCommand extends DataCommand {
 
   @Override
   protected void read(ObjectInput in) throws ClassNotFoundException, IOException {
+    if (in.readBoolean()) {
+      setUrgent();
+    }
     time = in.readLong();
     int len = in.readInt();
     byte[] bytes = new byte[len];
@@ -98,7 +110,10 @@ public class MessageCommand extends DataCommand {
       out.print(" : ");
     }
     if (msg != null) {
-      out.print(msg);
+      out.println(msg);
+    }
+    if (isUrgent()) {
+      out.flush();
     }
   }
 }

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/NumberDataCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/NumberDataCommand.java
@@ -43,7 +43,7 @@ public class NumberDataCommand extends DataCommand {
   }
 
   public NumberDataCommand(String name, Number value) {
-    super(NUMBER, name);
+    super(NUMBER, name, false);
     this.value = value;
   }
 

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/NumberMapDataCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/NumberMapDataCommand.java
@@ -45,7 +45,7 @@ public class NumberMapDataCommand extends DataCommand {
   }
 
   public NumberMapDataCommand(String name, Map<String, ? extends Number> data) {
-    super(NUMBER_MAP, name);
+    super(NUMBER_MAP, name, false);
     this.data = (data != null) ? new HashMap<String, Number>(data) : null;
   }
 

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/ReconnectCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/ReconnectCommand.java
@@ -1,0 +1,34 @@
+package org.openjdk.btrace.core.comm;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class ReconnectCommand extends Command {
+  public static final int STATUS_FLAG = 8;
+
+  private String probeId;
+
+  public ReconnectCommand() {
+    super(Command.RECONNECT);
+  }
+
+  public ReconnectCommand(String probeId) {
+    super(Command.RECONNECT);
+    this.probeId = probeId;
+  }
+
+  @Override
+  protected void write(ObjectOutput out) throws IOException {
+    out.writeUTF(probeId);
+  }
+
+  @Override
+  protected void read(ObjectInput in) throws IOException, ClassNotFoundException {
+    probeId = in.readUTF();
+  }
+
+  public String getProbeId() {
+    return probeId;
+  }
+}

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/RenameCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/RenameCommand.java
@@ -33,7 +33,7 @@ public class RenameCommand extends Command {
   private String newName;
 
   public RenameCommand(String newName) {
-    super(RENAME);
+    super(RENAME, true);
     this.newName = newName;
   }
 

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/RetransformClassNotification.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/RetransformClassNotification.java
@@ -39,7 +39,7 @@ public class RetransformClassNotification extends Command implements PrintableCo
   private String className;
 
   public RetransformClassNotification(String className) {
-    super(RETRANSFORM_CLASS);
+    super(RETRANSFORM_CLASS, true);
     this.className = className;
   }
 

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/RetransformationStartNotification.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/RetransformationStartNotification.java
@@ -32,7 +32,7 @@ import java.lang.instrument.Instrumentation;
 
 /**
  * This command is sent out when the BTrace engine calls {@linkplain
- * Instrumentation#retransformClasses(Class[])} method. It is followed by {@linkplain OkayCommand}
+ * Instrumentation#retransformClasses(Class[])} method. It is followed by {@linkplain StatusCommand}
  * command when the retransformation ends.
  *
  * @author Jaroslav Bachorik jaroslav.bachorik@sun.com
@@ -45,7 +45,7 @@ public class RetransformationStartNotification extends Command {
   }
 
   public RetransformationStartNotification(int numClasses) {
-    super(RETRANSFORMATION_START);
+    super(RETRANSFORMATION_START, true);
     this.numClasses = numClasses;
   }
 

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/SetSettingsCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/SetSettingsCommand.java
@@ -40,9 +40,8 @@ public class SetSettingsCommand extends Command {
   private final Map<String, Object> params;
 
   public SetSettingsCommand(Map<String, ?> params) {
-    super(SET_PARAMS);
-    this.params =
-        params != null ? new HashMap<String, Object>(params) : new HashMap<String, Object>();
+    super(SET_PARAMS, true);
+    this.params = params != null ? new HashMap<>(params) : new HashMap<String, Object>();
   }
 
   protected SetSettingsCommand() {

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/StatusCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/StatusCommand.java
@@ -29,14 +29,34 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
-public class OkayCommand extends Command {
-  public OkayCommand() {
-    super(SUCCESS);
+public class StatusCommand extends Command {
+  // custom flag
+  private int flag;
+
+  public StatusCommand(int flag) {
+    super(STATUS, true);
+    this.flag = flag;
+  }
+
+  public StatusCommand() {
+    this((byte) 0);
   }
 
   @Override
-  protected void write(ObjectOutput out) throws IOException {}
+  protected void write(ObjectOutput out) throws IOException {
+    out.writeInt(flag);
+  }
 
   @Override
-  protected void read(ObjectInput in) throws IOException, ClassNotFoundException {}
+  protected void read(ObjectInput in) throws IOException, ClassNotFoundException {
+    flag = in.readInt();
+  }
+
+  public int getFlag() {
+    return Math.abs(flag);
+  }
+
+  public boolean isSuccess() {
+    return flag >= 0;
+  }
 }

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/StringMapDataCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/StringMapDataCommand.java
@@ -46,7 +46,7 @@ public class StringMapDataCommand extends DataCommand {
   }
 
   public StringMapDataCommand(String name, Map<String, String> data) {
-    super(STRING_MAP, name);
+    super(STRING_MAP, name, false);
     if (data != null) {
       this.data = new HashMap<>(data);
     } else {

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/WireIO.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/WireIO.java
@@ -54,8 +54,8 @@ public class WireIO {
       case Command.RENAME:
         cmd = new RenameCommand();
         break;
-      case Command.SUCCESS:
-        cmd = new OkayCommand();
+      case Command.STATUS:
+        cmd = new StatusCommand();
         break;
       case Command.NUMBER_MAP:
         cmd = new NumberMapDataCommand();
@@ -77,6 +77,15 @@ public class WireIO {
         break;
       case Command.SET_PARAMS:
         cmd = new SetSettingsCommand();
+        break;
+      case Command.LIST_PROBES:
+        cmd = new ListProbesCommand();
+        break;
+      case Command.DISCONNECT:
+        cmd = new DisconnectCommand();
+        break;
+      case Command.RECONNECT:
+        cmd = new ReconnectCommand();
         break;
       default:
         throw new RuntimeException("invalid command: " + type);

--- a/btrace-core/src/main/resources/org/openjdk/btrace/core/messages.properties
+++ b/btrace-core/src/main/resources/org/openjdk/btrace/core/messages.properties
@@ -71,6 +71,12 @@ btrace.usage=\
     --version             Show the version\n  \
     -v                    Run in verbose mode\n  \
     -l                    List all locally attachable JVMs\n  \
+    -lp                   List active probes in the given JVM\n  \
+                    \t\t\tExpects PID or app name as the follow-up argument\n  \
+                    \t\t\tAll other options are discarded\n  \
+    -r <probe id>         Reconnect to an active disconnected probe\n  \
+                    \t\t\tExpects PID or app name as the follow-up argument\n  \
+                    \t\t\tAll other options are discarded\n  \
     -o <file>             The path to store the probe output (will disable showing the output in console)\n  \
     -u                    Run in trusted mode\n  \
     -d <path>             Dump the instrumented classes to the specified path\n  \
@@ -79,7 +85,9 @@ btrace.usage=\
     -cp <path>            Specify where to find user class files and annotation processors\n  \
     -I <path>             Specify where to find include files\n  \
     -p <port>             Specify port to which the btrace agent listens for clients\n  \
-    -statsd <host[:port]> Specify the statsd server, if any
+    -statsd <host[:port]> Specify the statsd server, if any\n  \
+    -x                    Run unattended\n  \
+                    \t\t\tDeploy the given probe and disconnect
 btrace.agent.usage=\
   Usage: java -javaagent:java-agent.jar=<arguments> <main class> <application arguments>\n\
   where arguments is comma separated name=value pairs. Argument names include:\n  \

--- a/btrace-core/src/test/java/org/openjdk/btrace/core/CircularBufferTest.java
+++ b/btrace-core/src/test/java/org/openjdk/btrace/core/CircularBufferTest.java
@@ -1,0 +1,112 @@
+package org.openjdk.btrace.core;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class CircularBufferTest {
+
+    @Test
+    public void testAddOverflow() {
+        CircularBuffer<Integer> cb = new CircularBuffer<>(3);
+        cb.add(1);
+        cb.add(2);
+        cb.add(3);
+        cb.add(4);
+
+        assertEquals(3, cb.getLength());
+        final List<Integer> elements = new ArrayList<>();
+        cb.forEach(new Function<Integer, Boolean>() {
+            @Override
+            public Boolean apply(Integer value) {
+                elements.add(value);
+                return true;
+            }
+        });
+
+        assertEquals(0, cb.getLength());
+        assertEquals(Arrays.asList(2, 3, 4), elements);
+    }
+
+    @Test
+    public void testAddOverflowSeveral() {
+        CircularBuffer<Integer> cb = new CircularBuffer<>(2);
+        cb.add(1);
+        cb.add(2);
+        cb.add(3);
+        cb.add(4);
+        cb.add(5);
+        cb.add(6);
+        cb.add(7);
+
+        assertEquals(2, cb.getLength());
+        final List<Integer> elements = new ArrayList<>();
+        cb.forEach(new Function<Integer, Boolean>() {
+            @Override
+            public Boolean apply(Integer value) {
+                elements.add(value);
+                return true;
+            }
+        });
+        assertEquals(0, cb.getLength());
+
+        assertEquals(Arrays.asList(6, 7), elements);
+    }
+
+
+    @Test
+    public void testAdd() {
+        CircularBuffer<Integer> cb = new CircularBuffer<>(2);
+
+        cb.add(1);
+        assertEquals(1, cb.getLength());
+        final List<Integer> elements = new ArrayList<>();
+        cb.forEach(new Function<Integer, Boolean>() {
+            @Override
+            public Boolean apply(Integer value) {
+                elements.add(value);
+                return true;
+            }
+        });
+        assertEquals(0, cb.getLength());
+        assertEquals(Arrays.asList(1), elements);
+    }
+
+    @Test
+    public void testAddFull() {
+        CircularBuffer<Integer> cb = new CircularBuffer<>(2);
+
+        cb.add(1);
+        cb.add(2);
+        assertEquals(2, cb.getLength());
+        final List<Integer> elements = new ArrayList<>();
+        cb.forEach(new Function<Integer, Boolean>() {
+            @Override
+            public Boolean apply(Integer value) {
+                elements.add(value);
+                return true;
+            }
+        });
+        assertEquals(0, cb.getLength());
+        assertEquals(Arrays.asList(1, 2), elements);
+    }
+
+    @Test
+    public void testEmpty() {
+        CircularBuffer<Integer> cb = new CircularBuffer<>(2);
+
+        final List<Integer> elements = new ArrayList<>();
+        cb.forEach(new Function<Integer, Boolean>() {
+            @Override
+            public Boolean apply(Integer value) {
+                elements.add(value);
+                return true;
+            }
+        });
+        assertTrue(elements.isEmpty());
+    }
+}

--- a/btrace-core/src/test/java/org/openjdk/btrace/core/CircularBufferTest.java
+++ b/btrace-core/src/test/java/org/openjdk/btrace/core/CircularBufferTest.java
@@ -1,112 +1,115 @@
 package org.openjdk.btrace.core;
 
-import org.junit.Test;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 public class CircularBufferTest {
 
-    @Test
-    public void testAddOverflow() {
-        CircularBuffer<Integer> cb = new CircularBuffer<>(3);
-        cb.add(1);
-        cb.add(2);
-        cb.add(3);
-        cb.add(4);
+  @Test
+  public void testAddOverflow() {
+    CircularBuffer<Integer> cb = new CircularBuffer<>(3);
+    cb.add(1);
+    cb.add(2);
+    cb.add(3);
+    cb.add(4);
 
-        assertEquals(3, cb.getLength());
-        final List<Integer> elements = new ArrayList<>();
-        cb.forEach(new Function<Integer, Boolean>() {
-            @Override
-            public Boolean apply(Integer value) {
-                elements.add(value);
-                return true;
-            }
+    assertEquals(3, cb.getLength());
+    final List<Integer> elements = new ArrayList<>();
+    cb.forEach(
+        new Function<Integer, Boolean>() {
+          @Override
+          public Boolean apply(Integer value) {
+            elements.add(value);
+            return true;
+          }
         });
 
-        assertEquals(0, cb.getLength());
-        assertEquals(Arrays.asList(2, 3, 4), elements);
-    }
+    assertEquals(0, cb.getLength());
+    assertEquals(Arrays.asList(2, 3, 4), elements);
+  }
 
-    @Test
-    public void testAddOverflowSeveral() {
-        CircularBuffer<Integer> cb = new CircularBuffer<>(2);
-        cb.add(1);
-        cb.add(2);
-        cb.add(3);
-        cb.add(4);
-        cb.add(5);
-        cb.add(6);
-        cb.add(7);
+  @Test
+  public void testAddOverflowSeveral() {
+    CircularBuffer<Integer> cb = new CircularBuffer<>(2);
+    cb.add(1);
+    cb.add(2);
+    cb.add(3);
+    cb.add(4);
+    cb.add(5);
+    cb.add(6);
+    cb.add(7);
 
-        assertEquals(2, cb.getLength());
-        final List<Integer> elements = new ArrayList<>();
-        cb.forEach(new Function<Integer, Boolean>() {
-            @Override
-            public Boolean apply(Integer value) {
-                elements.add(value);
-                return true;
-            }
+    assertEquals(2, cb.getLength());
+    final List<Integer> elements = new ArrayList<>();
+    cb.forEach(
+        new Function<Integer, Boolean>() {
+          @Override
+          public Boolean apply(Integer value) {
+            elements.add(value);
+            return true;
+          }
         });
-        assertEquals(0, cb.getLength());
+    assertEquals(0, cb.getLength());
 
-        assertEquals(Arrays.asList(6, 7), elements);
-    }
+    assertEquals(Arrays.asList(6, 7), elements);
+  }
 
+  @Test
+  public void testAdd() {
+    CircularBuffer<Integer> cb = new CircularBuffer<>(2);
 
-    @Test
-    public void testAdd() {
-        CircularBuffer<Integer> cb = new CircularBuffer<>(2);
-
-        cb.add(1);
-        assertEquals(1, cb.getLength());
-        final List<Integer> elements = new ArrayList<>();
-        cb.forEach(new Function<Integer, Boolean>() {
-            @Override
-            public Boolean apply(Integer value) {
-                elements.add(value);
-                return true;
-            }
+    cb.add(1);
+    assertEquals(1, cb.getLength());
+    final List<Integer> elements = new ArrayList<>();
+    cb.forEach(
+        new Function<Integer, Boolean>() {
+          @Override
+          public Boolean apply(Integer value) {
+            elements.add(value);
+            return true;
+          }
         });
-        assertEquals(0, cb.getLength());
-        assertEquals(Arrays.asList(1), elements);
-    }
+    assertEquals(0, cb.getLength());
+    assertEquals(Arrays.asList(1), elements);
+  }
 
-    @Test
-    public void testAddFull() {
-        CircularBuffer<Integer> cb = new CircularBuffer<>(2);
+  @Test
+  public void testAddFull() {
+    CircularBuffer<Integer> cb = new CircularBuffer<>(2);
 
-        cb.add(1);
-        cb.add(2);
-        assertEquals(2, cb.getLength());
-        final List<Integer> elements = new ArrayList<>();
-        cb.forEach(new Function<Integer, Boolean>() {
-            @Override
-            public Boolean apply(Integer value) {
-                elements.add(value);
-                return true;
-            }
+    cb.add(1);
+    cb.add(2);
+    assertEquals(2, cb.getLength());
+    final List<Integer> elements = new ArrayList<>();
+    cb.forEach(
+        new Function<Integer, Boolean>() {
+          @Override
+          public Boolean apply(Integer value) {
+            elements.add(value);
+            return true;
+          }
         });
-        assertEquals(0, cb.getLength());
-        assertEquals(Arrays.asList(1, 2), elements);
-    }
+    assertEquals(0, cb.getLength());
+    assertEquals(Arrays.asList(1, 2), elements);
+  }
 
-    @Test
-    public void testEmpty() {
-        CircularBuffer<Integer> cb = new CircularBuffer<>(2);
+  @Test
+  public void testEmpty() {
+    CircularBuffer<Integer> cb = new CircularBuffer<>(2);
 
-        final List<Integer> elements = new ArrayList<>();
-        cb.forEach(new Function<Integer, Boolean>() {
-            @Override
-            public Boolean apply(Integer value) {
-                elements.add(value);
-                return true;
-            }
+    final List<Integer> elements = new ArrayList<>();
+    cb.forEach(
+        new Function<Integer, Boolean>() {
+          @Override
+          public Boolean apply(Integer value) {
+            elements.add(value);
+            return true;
+          }
         });
-        assertTrue(elements.isEmpty());
-    }
+    assertTrue(elements.isEmpty());
+  }
 }

--- a/btrace-dtrace/src/main/java/org/openjdk/btrace/dtrace/DTraceDataCommand.java
+++ b/btrace-dtrace/src/main/java/org/openjdk/btrace/dtrace/DTraceDataCommand.java
@@ -43,7 +43,7 @@ public class DTraceDataCommand extends MessageCommand implements DTraceCommand {
   private DataEvent de;
 
   public DTraceDataCommand(DataEvent de) {
-    super(asString(de));
+    super(asString(de), true);
     this.de = de;
   }
 

--- a/btrace-dtrace/src/main/java/org/openjdk/btrace/dtrace/DTraceDropCommand.java
+++ b/btrace-dtrace/src/main/java/org/openjdk/btrace/dtrace/DTraceDropCommand.java
@@ -40,7 +40,7 @@ public class DTraceDropCommand extends MessageCommand implements DTraceCommand {
   private DropEvent de;
 
   public DTraceDropCommand(DropEvent de) {
-    super(asString(de));
+    super(asString(de), true);
     this.de = de;
   }
 

--- a/btrace-instr/src/main/java/org/openjdk/btrace/instr/InstrumentingMethodVisitor.java
+++ b/btrace-instr/src/main/java/org/openjdk/btrace/instr/InstrumentingMethodVisitor.java
@@ -33,7 +33,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
@@ -1182,7 +1181,11 @@ public final class InstrumentingMethodVisitor extends MethodVisitor
   }
 
   // package accessible for targeted tests
-  static Object[] computeFrameLocals(int argsSize, List<Object> locals, Set<LocalVarSlot> newLocals, VariableMapper variableMapper) {
+  static Object[] computeFrameLocals(
+      int argsSize,
+      List<Object> locals,
+      Set<LocalVarSlot> newLocals,
+      VariableMapper variableMapper) {
     newLocals = newLocals != null ? newLocals : Collections.<LocalVarSlot>emptySet();
     Object[] localsArr;
     int nextMappedVar = variableMapper.getNextMappedVar();

--- a/btrace-instr/src/test/java/org/openjdk/btrace/BTraceFunctionalTests.java
+++ b/btrace-instr/src/test/java/org/openjdk/btrace/BTraceFunctionalTests.java
@@ -102,7 +102,7 @@ public class BTraceFunctionalTests extends RuntimeTest {
     test(
         "resources.Main",
         "btrace/OnTimerTest.java",
-        5,
+        10,
         new ResultValidator() {
           @Override
           public void validate(String stdout, String stderr, int retcode, String jfrFile) {
@@ -121,7 +121,7 @@ public class BTraceFunctionalTests extends RuntimeTest {
         "resources.Main",
         "btrace/OnTimerArgTest.java",
         new String[] {"timer=500"},
-        5,
+        10,
         new ResultValidator() {
           @Override
           public void validate(String stdout, String stderr, int retcode, String jfrFile) {
@@ -304,7 +304,7 @@ public class BTraceFunctionalTests extends RuntimeTest {
     testWithJfr(
         "resources.Main",
         "btrace/JfrTest.java",
-        5,
+        10,
         new ResultValidator() {
           @Override
           public void validate(String stdout, String stderr, int retcode, String jfrFile) {

--- a/btrace-instr/src/test/java/org/openjdk/btrace/RuntimeTest.java
+++ b/btrace-instr/src/test/java/org/openjdk/btrace/RuntimeTest.java
@@ -179,7 +179,7 @@ public abstract class RuntimeTest {
     args.add("-XX:+AllowRedefinitionToAddDeleteMethods");
     args.add("-XX:+IgnoreUnrecognizedVMOptions");
     // uncomment the following line to get extra JFR logs
-//    args.add("-Xlog:jfr*=trace");
+    //    args.add("-Xlog:jfr*=trace");
     args.addAll(extraJvmArgs);
     args.addAll(
         Arrays.asList(

--- a/btrace-instr/src/test/java/org/openjdk/btrace/instr/InstrumentingMethodVisitorTest.java
+++ b/btrace-instr/src/test/java/org/openjdk/btrace/instr/InstrumentingMethodVisitorTest.java
@@ -1,22 +1,102 @@
 package org.openjdk.btrace.instr;
 
-import org.junit.Test;
-
-import java.util.Arrays;
-
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
+import org.junit.Test;
+
 public class InstrumentingMethodVisitorTest {
-    @Test
-    public void testComplexSparkContextInit() {
-        Object[] expected = {"org/apache/spark/SparkContext", "org/apache/spark/SparkConf", "java/util/concurrent/ConcurrentMap", "scala/Option", "java/lang/String", 0, 0, 1, "scala/Option", "scala/Tuple2", "org/apache/spark/scheduler/SchedulerBackend", "org/apache/spark/scheduler/TaskScheduler", "scala/Tuple2", "scala/Tuple2", "org/apache/spark/scheduler/SchedulerBackend", "org/apache/spark/scheduler/TaskScheduler", "scala/Option", 0, 1, "org/apache/spark/scheduler/SchedulerBackend", "scala/Option"};
-        VariableMapper mapper = new VariableMapper(2, 21, new int[]{0, 0, 1073741844, 1073741836, 1073741826, 1073741827, 1073741828, 1073741829, 1073741830, 1073741831, 1073741832, 1073741837, 1073741833, 1073741834, 1073741835, 1073741838, 1073741839, 1073741840, 1073741841, 1073741842, 1073741843, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+  @Test
+  public void testComplexSparkContextInit() {
+    Object[] expected = {
+      "org/apache/spark/SparkContext",
+      "org/apache/spark/SparkConf",
+      "java/util/concurrent/ConcurrentMap",
+      "scala/Option",
+      "java/lang/String",
+      0,
+      0,
+      1,
+      "scala/Option",
+      "scala/Tuple2",
+      "org/apache/spark/scheduler/SchedulerBackend",
+      "org/apache/spark/scheduler/TaskScheduler",
+      "scala/Tuple2",
+      "scala/Tuple2",
+      "org/apache/spark/scheduler/SchedulerBackend",
+      "org/apache/spark/scheduler/TaskScheduler",
+      "scala/Option",
+      0,
+      1,
+      "org/apache/spark/scheduler/SchedulerBackend",
+      "scala/Option"
+    };
+    VariableMapper mapper =
+        new VariableMapper(
+            2,
+            21,
+            new int[] {
+              0,
+              0,
+              1073741844,
+              1073741836,
+              1073741826,
+              1073741827,
+              1073741828,
+              1073741829,
+              1073741830,
+              1073741831,
+              1073741832,
+              1073741837,
+              1073741833,
+              1073741834,
+              1073741835,
+              1073741838,
+              1073741839,
+              1073741840,
+              1073741841,
+              1073741842,
+              1073741843,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0
+            });
 
-        Object[] fromFrame = {"org/apache/spark/SparkContext", "org/apache/spark/SparkConf", 0, 0, "scala/Option", "scala/Tuple2", "java/util/concurrent/ConcurrentMap", "scala/Option", "java/lang/String", 0, 0, 1, "scala/Option", "scala/Tuple2", "scala/Tuple2", "org/apache/spark/scheduler/SchedulerBackend", "org/apache/spark/scheduler/TaskScheduler", "org/apache/spark/scheduler/SchedulerBackend", "org/apache/spark/scheduler/TaskScheduler", "scala/Option", 0, 1, "org/apache/spark/scheduler/SchedulerBackend"};
-        Object[] locals = InstrumentingMethodVisitor.computeFrameLocals(
-                2, Arrays.asList(fromFrame), null, mapper
-        );
-        assertArrayEquals(expected, locals);
-
-    }
+    Object[] fromFrame = {
+      "org/apache/spark/SparkContext",
+      "org/apache/spark/SparkConf",
+      0,
+      0,
+      "scala/Option",
+      "scala/Tuple2",
+      "java/util/concurrent/ConcurrentMap",
+      "scala/Option",
+      "java/lang/String",
+      0,
+      0,
+      1,
+      "scala/Option",
+      "scala/Tuple2",
+      "scala/Tuple2",
+      "org/apache/spark/scheduler/SchedulerBackend",
+      "org/apache/spark/scheduler/TaskScheduler",
+      "org/apache/spark/scheduler/SchedulerBackend",
+      "org/apache/spark/scheduler/TaskScheduler",
+      "scala/Option",
+      0,
+      1,
+      "org/apache/spark/scheduler/SchedulerBackend"
+    };
+    Object[] locals =
+        InstrumentingMethodVisitor.computeFrameLocals(2, Arrays.asList(fromFrame), null, mapper);
+    assertArrayEquals(expected, locals);
+  }
 }

--- a/btrace-instr/src/test/java/org/openjdk/btrace/instr/TezSplitterTest.java
+++ b/btrace-instr/src/test/java/org/openjdk/btrace/instr/TezSplitterTest.java
@@ -8,447 +8,447 @@ public class TezSplitterTest extends InstrumentorTestBase {
     originalBC = loadTargetClass("classdata/TezSplitter");
     transform("issues/TezSplitter");
     checkTransformation(
-    "ICONST_4\n" +
-            "ANEWARRAY java/lang/Object\n" +
-            "DUP\n" +
-            "ICONST_0\n" +
-            "ALOAD 1\n" +
-            "AASTORE\n" +
-            "DUP\n" +
-            "ICONST_1\n" +
-            "ALOAD 2\n" +
-            "AASTORE\n" +
-            "DUP\n" +
-            "ICONST_2\n" +
-            "ILOAD 3\n" +
-            "INVOKESTATIC java/lang/Integer.valueOf (I)Ljava/lang/Integer;\n" +
-            "AASTORE\n" +
-            "DUP\n" +
-            "ICONST_3\n" +
-            "ALOAD 4\n" +
-            "AASTORE\n" +
-            "INVOKESTATIC org/apache/hadoop/mapred/split/TezMapredSplitsGrouper.$btrace$org$openjdk$btrace$runtime$aux$TezSplitter$getGroupedSplitsHook ([Ljava/lang/Object;)V\n" +
-            "ICONST_5\n" +
-            "ANEWARRAY java/lang/Object\n" +
-            "DUP\n" +
-            "ICONST_0\n" +
-            "ALOAD 1\n" +
-            "AASTORE\n" +
-            "DUP\n" +
-            "ICONST_1\n" +
-            "ALOAD 2\n" +
-            "AASTORE\n" +
-            "DUP\n" +
-            "ICONST_2\n" +
-            "ILOAD 3\n" +
-            "INVOKESTATIC java/lang/Integer.valueOf (I)Ljava/lang/Integer;\n" +
-            "AASTORE\n" +
-            "DUP\n" +
-            "ICONST_3\n" +
-            "ALOAD 4\n" +
-            "AASTORE\n" +
-            "DUP\n" +
-            "ICONST_4\n" +
-            "ALOAD 5\n" +
-            "AASTORE\n" +
-            "INVOKESTATIC org/apache/hadoop/mapred/split/TezMapredSplitsGrouper.$btrace$org$openjdk$btrace$runtime$aux$TezSplitter$getGroupedSplitsHook ([Ljava/lang/Object;)V\n" +
-            "LSTORE 23\n" +
-            "LSTORE 25\n" +
-            "LSTORE 27\n" +
-            "LLOAD 25\n" +
-            "LLOAD 27\n" +
-            "LLOAD 27\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map I T T T T T T T T J J J] []\n" +
-            "LLOAD 25\n" +
-            "LLOAD 27\n" +
-            "LLOAD 23\n" +
-            "LLOAD 25\n" +
-            "LLOAD 25\n" +
-            "LLOAD 23\n" +
-            "LLOAD 25\n" +
-            "LLOAD 23\n" +
-            "LLOAD 27\n" +
-            "LLOAD 27\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map I T T T T T T I T J J J] []\n" +
-            "LLOAD 23\n" +
-            "LLOAD 27\n" +
-            "ISTORE 23\n" +
-            "ASTORE 24\n" +
-            "ALOAD 24\n" +
-            "ISTORE 25\n" +
-            "ISTORE 26\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map [Lorg/apache/hadoop/mapred/InputSplit; T T T T T T T T I [Lorg/apache/hadoop/mapred/InputSplit; I I] []\n" +
-            "ILOAD 26\n" +
-            "ILOAD 25\n" +
-            "ALOAD 24\n" +
-            "ILOAD 26\n" +
-            "ASTORE 27\n" +
-            "ALOAD 27\n" +
-            "ASTORE 28\n" +
-            "ALOAD 28\n" +
-            "ALOAD 27\n" +
-            "ILOAD 23\n" +
-            "IINC 23 1\n" +
-            "ALOAD 28\n" +
-            "IINC 26 1\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map] []\n" +
-            "LSTORE 23\n" +
-            "ISTORE 25\n" +
-            "ILOAD 25\n" +
-            "ISTORE 26\n" +
-            "ISTORE 27\n" +
-            "ASTORE 28\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T T T J I I I java/util/Iterator] []\n" +
-            "ALOAD 28\n" +
-            "ALOAD 28\n" +
-            "ILOAD 26\n" +
-            "ASTORE 28\n" +
-            "ISTORE 29\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T [Lorg/apache/hadoop/mapred/InputSplit; I J I I I java/util/Set I] []\n" +
-            "ILOAD 29\n" +
-            "ILOAD 29\n" +
-            "ASTORE 30\n" +
-            "ALOAD 28\n" +
-            "ALOAD 30\n" +
-            "ASTORE 31\n" +
-            "ALOAD 30\n" +
-            "ASTORE 32\n" +
-            "ALOAD 32\n" +
-            "ALOAD 32\n" +
-            "ASTORE 32\n" +
-            "ALOAD 32\n" +
-            "ASTORE 33\n" +
-            "ALOAD 33\n" +
-            "ISTORE 34\n" +
-            "ISTORE 35\n" +
-            "ILOAD 35\n" +
-            "ILOAD 34\n" +
-            "ALOAD 33\n" +
-            "ILOAD 35\n" +
-            "ASTORE 36\n" +
-            "ALOAD 36\n" +
-            "ASTORE 36\n" +
-            "ALOAD 28\n" +
-            "ALOAD 36\n" +
-            "IINC 35 1\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T [Lorg/apache/hadoop/mapred/InputSplit; I J I I I java/util/Set I org/apache/hadoop/mapred/InputSplit org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder [Ljava/lang/String;] []\n" +
-            "ALOAD 28\n" +
-            "ASTORE 33\n" +
-            "ALOAD 33\n" +
-            "ALOAD 33\n" +
-            "ASTORE 34\n" +
-            "ALOAD 34\n" +
-            "ASTORE 35\n" +
-            "ALOAD 35\n" +
-            "ALOAD 31\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T [Lorg/apache/hadoop/mapred/InputSplit; I J I I I java/util/Set I] []\n" +
-            "IINC 29 1\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T T T J I I I java/util/Set] []\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set] []\n" +
-            "LLOAD 23\n" +
-            "ILOAD 25\n" +
-            "ILOAD 26\n" +
-            "ILOAD 27\n" +
-            "ISTORE 29\n" +
-            "ILOAD 27\n" +
-            "ASTORE 30\n" +
-            "ASTORE 31\n" +
-            "ISTORE 32\n" +
-            "ISTORE 33\n" +
-            "ISTORE 34\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I] []\n" +
-            "ILOAD 29\n" +
-            "IINC 34 1\n" +
-            "ISTORE 35\n" +
-            "ASTORE 36\n" +
-            "ALOAD 36\n" +
-            "ALOAD 36\n" +
-            "ASTORE 37\n" +
-            "ALOAD 30\n" +
-            "ALOAD 31\n" +
-            "ALOAD 37\n" +
-            "ASTORE 38\n" +
-            "ALOAD 37\n" +
-            "ASTORE 39\n" +
-            "ALOAD 39\n" +
-            "ASTORE 40\n" +
-            "ALOAD 40\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I java/util/Iterator java/util/Map$Entry java/lang/String org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder] []\n" +
-            "ALOAD 39\n" +
-            "ISTORE 41\n" +
-            "LSTORE 42\n" +
-            "ISTORE 44\n" +
-            "ALOAD 30\n" +
-            "ALOAD 40\n" +
-            "LLOAD 42\n" +
-            "ALOAD 40\n" +
-            "LSTORE 42\n" +
-            "IINC 44 1\n" +
-            "ALOAD 39\n" +
-            "ALOAD 39\n" +
-            "ASTORE 40\n" +
-            "ALOAD 40\n" +
-            "LLOAD 42\n" +
-            "ALOAD 40\n" +
-            "LLOAD 23\n" +
-            "ILOAD 44\n" +
-            "ILOAD 27\n" +
-            "ALOAD 39\n" +
-            "ILOAD 32\n" +
-            "LLOAD 42\n" +
-            "LLOAD 23\n" +
-            "ILOAD 44\n" +
-            "ILOAD 27\n" +
-            "ALOAD 39\n" +
-            "ILOAD 41\n" +
-            "IINC 35 1\n" +
-            "ALOAD 38\n" +
-            "ASTORE 45\n" +
-            "ALOAD 38\n" +
-            "ASTORE 45\n" +
-            "ILOAD 33\n" +
-            "ALOAD 30\n" +
-            "ASTORE 46\n" +
-            "ALOAD 46\n" +
-            "ALOAD 46\n" +
-            "ASTORE 47\n" +
-            "ALOAD 47\n" +
-            "ASTORE 48\n" +
-            "ALOAD 48\n" +
-            "ALOAD 48\n" +
-            "ASTORE 49\n" +
-            "ALOAD 49\n" +
-            "ISTORE 50\n" +
-            "ISTORE 51\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I java/util/Iterator java/util/Map$Entry java/lang/String org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder I J I [Ljava/lang/String; java/util/Iterator org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder [Ljava/lang/String; [Ljava/lang/String; I I] []\n" +
-            "ILOAD 51\n" +
-            "ILOAD 50\n" +
-            "ALOAD 49\n" +
-            "ILOAD 51\n" +
-            "ASTORE 52\n" +
-            "ALOAD 52\n" +
-            "ALOAD 31\n" +
-            "ALOAD 52\n" +
-            "IINC 51 1\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I java/util/Iterator java/util/Map$Entry java/lang/String org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder I J I [Ljava/lang/String; java/util/Iterator] []\n" +
-            "ALOAD 31\n" +
-            "ALOAD 45\n" +
-            "ASTORE 45\n" +
-            "ALOAD 30\n" +
-            "ALOAD 45\n" +
-            "ILOAD 33\n" +
-            "ALOAD 38\n" +
-            "ALOAD 38\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I java/util/Iterator java/util/Map$Entry java/lang/String org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder I J I [Ljava/lang/String;] [L144 L144 I java/lang/String [Ljava/lang/String;]\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I java/util/Iterator java/util/Map$Entry java/lang/String org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder I J I [Ljava/lang/String;] [L144 L144 I java/lang/String [Ljava/lang/String; java/lang/String]\n" +
-            "ASTORE 46\n" +
-            "ALOAD 30\n" +
-            "ASTORE 47\n" +
-            "ALOAD 47\n" +
-            "ALOAD 47\n" +
-            "ASTORE 48\n" +
-            "ALOAD 46\n" +
-            "ALOAD 48\n" +
-            "ALOAD 48\n" +
-            "ALOAD 38\n" +
-            "ALOAD 48\n" +
-            "IINC 29 1\n" +
-            "ALOAD 30\n" +
-            "ALOAD 46\n" +
-            "ALOAD 38\n" +
-            "ALOAD 46\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I] []\n" +
-            "ILOAD 33\n" +
-            "ILOAD 35\n" +
-            "ISTORE 33\n" +
-            "ILOAD 29\n" +
-            "ISTORE 36\n" +
-            "ILOAD 36\n" +
-            "ASTORE 37\n" +
-            "ASTORE 38\n" +
-            "ALOAD 38\n" +
-            "ALOAD 38\n" +
-            "ASTORE 39\n" +
-            "ALOAD 39\n" +
-            "ASTORE 40\n" +
-            "ALOAD 40\n" +
-            "ALOAD 40\n" +
-            "ASTORE 41\n" +
-            "ALOAD 41\n" +
-            "ALOAD 37\n" +
-            "ALOAD 41\n" +
-            "ALOAD 40\n" +
-            "ALOAD 37\n" +
-            "ILOAD 36\n" +
-            "ILOAD 36\n" +
-            "ALOAD 37\n" +
-            "ASTORE 38\n" +
-            "ASTORE 39\n" +
-            "ASTORE 40\n" +
-            "ALOAD 40\n" +
-            "ALOAD 40\n" +
-            "ASTORE 41\n" +
-            "ASTORE 42\n" +
-            "ALOAD 41\n" +
-            "ALOAD 41\n" +
-            "ASTORE 42\n" +
-            "ALOAD 38\n" +
-            "ALOAD 41\n" +
-            "ALOAD 42\n" +
-            "ALOAD 39\n" +
-            "ALOAD 42\n" +
-            "ALOAD 39\n" +
-            "ALOAD 42\n" +
-            "ILOAD 36\n" +
-            "ALOAD 39\n" +
-            "ASTORE 40\n" +
-            "ALOAD 37\n" +
-            "ISTORE 41\n" +
-            "ASTORE 42\n" +
-            "ALOAD 42\n" +
-            "ISTORE 43\n" +
-            "ISTORE 44\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I I java/util/Set java/util/Map java/util/Map java/util/HashSet I [Lorg/apache/hadoop/mapred/InputSplit; I I] []\n" +
-            "ILOAD 44\n" +
-            "ILOAD 43\n" +
-            "ALOAD 42\n" +
-            "ILOAD 44\n" +
-            "ASTORE 45\n" +
-            "ILOAD 41\n" +
-            "ALOAD 37\n" +
-            "ALOAD 45\n" +
-            "IINC 41 -1\n" +
-            "ALOAD 40\n" +
-            "ALOAD 45\n" +
-            "ASTORE 46\n" +
-            "ALOAD 45\n" +
-            "ASTORE 47\n" +
-            "ALOAD 47\n" +
-            "ALOAD 47\n" +
-            "ASTORE 47\n" +
-            "ALOAD 47\n" +
-            "ASTORE 48\n" +
-            "ALOAD 48\n" +
-            "ISTORE 49\n" +
-            "ISTORE 50\n" +
-            "ILOAD 50\n" +
-            "ILOAD 49\n" +
-            "ALOAD 48\n" +
-            "ILOAD 50\n" +
-            "ASTORE 51\n" +
-            "ALOAD 51\n" +
-            "ASTORE 51\n" +
-            "ALOAD 40\n" +
-            "ALOAD 38\n" +
-            "ALOAD 51\n" +
-            "IINC 50 1\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I I java/util/Set java/util/Map java/util/Map java/util/HashSet I [Lorg/apache/hadoop/mapred/InputSplit; I I org/apache/hadoop/mapred/InputSplit org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder [Ljava/lang/String;] []\n" +
-            "ALOAD 40\n" +
-            "ASTORE 48\n" +
-            "ALOAD 48\n" +
-            "ALOAD 48\n" +
-            "ASTORE 49\n" +
-            "ALOAD 39\n" +
-            "ALOAD 49\n" +
-            "ALOAD 46\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I I java/util/Set java/util/Map java/util/Map java/util/HashSet I [Lorg/apache/hadoop/mapred/InputSplit; I I] []\n" +
-            "IINC 44 1\n" +
-            "ALOAD 37\n" +
-            "ALOAD 39\n" +
-            "FSTORE 42\n" +
-            "FLOAD 42\n" +
-            "LLOAD 23\n" +
-            "FLOAD 42\n" +
-            "LSTORE 43\n" +
-            "ILOAD 27\n" +
-            "FLOAD 42\n" +
-            "ISTORE 45\n" +
-            "LLOAD 43\n" +
-            "LLOAD 43\n" +
-            "LSTORE 23\n" +
-            "ILOAD 45\n" +
-            "ILOAD 45\n" +
-            "ISTORE 27\n" +
-            "ILOAD 34\n" +
-            "ILOAD 29\n" +
-            "ILOAD 35\n" +
-            "LLOAD 23\n" +
-            "ILOAD 27\n" +
-            "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I] []\n" +
-            "ILOAD 32\n" +
-            "ILOAD 35\n" +
-            "ILOAD 25\n" +
-            "ISTORE 32\n" +
-            "ILOAD 34\n" +
-            "ILOAD 29\n" +
-            "ILOAD 35\n" +
-            "ILOAD 34\n" +
-            "ILOAD 29\n" +
-            "ILOAD 35\n" +
-            "ASTORE 35\n" +
-            "ALOAD 35\n" +
-            "ILOAD 29\n" +
-            "ALOAD 35\n" +
-            "LOCALVARIABLE locations [Ljava/lang/String; L21 L26 26\n" +
-            "LOCALVARIABLE split Lorg/apache/hadoop/mapred/InputSplit; L17 L26 25\n" +
-            "LOCALVARIABLE lengthPerGroup J L42 L34 23\n" +
-            "LOCALVARIABLE maxLengthPerGroup J L43 L34 25\n" +
-            "LOCALVARIABLE minLengthPerGroup J L44 L34 27\n" +
-            "LOCALVARIABLE newSplit Lorg/apache/hadoop/mapred/split/TezGroupedSplit; L68 L70 28\n" +
-            "LOCALVARIABLE split Lorg/apache/hadoop/mapred/InputSplit; L66 L70 27\n" +
-            "LOCALVARIABLE i I L63 L60 23\n" +
-            "LOCALVARIABLE location Ljava/lang/String; L91 L94 36\n" +
-            "LOCALVARIABLE holder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder; L98 L99 35\n" +
-            "LOCALVARIABLE location Ljava/lang/String; L97 L99 34\n" +
-            "LOCALVARIABLE splitHolder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder; L85 L96 31\n" +
-            "LOCALVARIABLE locations [Ljava/lang/String; L86 L96 32\n" +
-            "LOCALVARIABLE split Lorg/apache/hadoop/mapred/InputSplit; L83 L96 30\n" +
-            "LOCALVARIABLE loc Ljava/lang/String; L153 L154 52\n" +
-            "LOCALVARIABLE locations [Ljava/lang/String; L149 L150 48\n" +
-            "LOCALVARIABLE splitH Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder; L148 L150 47\n" +
-            "LOCALVARIABLE groupedSplitHolder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder; L162 L168 48\n" +
-            "LOCALVARIABLE location Ljava/lang/String; L120 L173 38\n" +
-            "LOCALVARIABLE holder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder; L121 L173 39\n" +
-            "LOCALVARIABLE splitHolder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder; L122 L173 40\n" +
-            "LOCALVARIABLE oldHeadIndex I L125 L173 41\n" +
-            "LOCALVARIABLE groupLength J L126 L173 42\n" +
-            "LOCALVARIABLE groupNumSplits I L127 L173 44\n" +
-            "LOCALVARIABLE groupLocation [Ljava/lang/String; L141 L173 45\n" +
-            "LOCALVARIABLE groupedSplit Lorg/apache/hadoop/mapred/split/TezGroupedSplit; L159 L173 46\n" +
-            "LOCALVARIABLE entry Ljava/util/Map$Entry; L117 L173 37\n" +
-            "LOCALVARIABLE splitHolder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder; L185 L186 41\n" +
-            "LOCALVARIABLE locHolder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder; L182 L183 40\n" +
-            "LOCALVARIABLE entry Ljava/util/Map$Entry; L181 L183 39\n" +
-            "LOCALVARIABLE rack Ljava/lang/String; L198 L202 42\n" +
-            "LOCALVARIABLE location Ljava/lang/String; L197 L202 41\n" +
-            "LOCALVARIABLE location Ljava/lang/String; L223 L226 51\n" +
-            "LOCALVARIABLE rack Ljava/lang/String; L228 L229 49\n" +
-            "LOCALVARIABLE splitHolder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder; L217 L214 46\n" +
-            "LOCALVARIABLE locations [Ljava/lang/String; L218 L214 47\n" +
-            "LOCALVARIABLE split Lorg/apache/hadoop/mapred/InputSplit; L209 L214 45\n" +
-            "LOCALVARIABLE newLengthPerGroup J L235 L233 43\n" +
-            "LOCALVARIABLE newNumSplitsInGroup I L236 L233 45\n" +
-            "LOCALVARIABLE numRemainingSplits I L177 L174 36\n" +
-            "LOCALVARIABLE remainingSplits Ljava/util/Set; L178 L174 37\n" +
-            "LOCALVARIABLE locToRackMap Ljava/util/Map; L193 L174 38\n" +
-            "LOCALVARIABLE rackLocations Ljava/util/Map; L194 L174 39\n" +
-            "LOCALVARIABLE rackSet Ljava/util/HashSet; L205 L174 40\n" +
-            "LOCALVARIABLE numRackSplitsToGroup I L206 L174 41\n" +
-            "LOCALVARIABLE rackSplitReduction F L232 L174 42\n" +
-            "LOCALVARIABLE numFullGroupsCreated I L114 L248 35\n" +
-            "LOCALVARIABLE lengthPerGroup J L72 L257 23\n" +
-            "LOCALVARIABLE numNodeLocations I L73 L257 25\n" +
-            "LOCALVARIABLE numSplitsPerLocation I L74 L257 26\n" +
-            "LOCALVARIABLE numSplitsInGroup I L75 L257 27\n" +
-            "LOCALVARIABLE locSet Ljava/util/Set; L80 L257 28\n" +
-            "LOCALVARIABLE splitsProcessed I L105 L257 29\n" +
-            "LOCALVARIABLE group Ljava/util/List; L106 L257 30\n" +
-            "LOCALVARIABLE groupLocationSet Ljava/util/Set; L107 L257 31\n" +
-            "LOCALVARIABLE allowSmallGroups Z L108 L257 32\n" +
-            "LOCALVARIABLE doingRackLocal Z L109 L257 33\n" +
-            "LOCALVARIABLE iterations I L110 L257 34\n" +
-            "LOCALVARIABLE groupedSplits [Lorg/apache/hadoop/mapred/InputSplit; L252 L257 35\n" +
-            "MAXLOCALS = 53",
+        "ICONST_4\n"
+            + "ANEWARRAY java/lang/Object\n"
+            + "DUP\n"
+            + "ICONST_0\n"
+            + "ALOAD 1\n"
+            + "AASTORE\n"
+            + "DUP\n"
+            + "ICONST_1\n"
+            + "ALOAD 2\n"
+            + "AASTORE\n"
+            + "DUP\n"
+            + "ICONST_2\n"
+            + "ILOAD 3\n"
+            + "INVOKESTATIC java/lang/Integer.valueOf (I)Ljava/lang/Integer;\n"
+            + "AASTORE\n"
+            + "DUP\n"
+            + "ICONST_3\n"
+            + "ALOAD 4\n"
+            + "AASTORE\n"
+            + "INVOKESTATIC org/apache/hadoop/mapred/split/TezMapredSplitsGrouper.$btrace$org$openjdk$btrace$runtime$aux$TezSplitter$getGroupedSplitsHook ([Ljava/lang/Object;)V\n"
+            + "ICONST_5\n"
+            + "ANEWARRAY java/lang/Object\n"
+            + "DUP\n"
+            + "ICONST_0\n"
+            + "ALOAD 1\n"
+            + "AASTORE\n"
+            + "DUP\n"
+            + "ICONST_1\n"
+            + "ALOAD 2\n"
+            + "AASTORE\n"
+            + "DUP\n"
+            + "ICONST_2\n"
+            + "ILOAD 3\n"
+            + "INVOKESTATIC java/lang/Integer.valueOf (I)Ljava/lang/Integer;\n"
+            + "AASTORE\n"
+            + "DUP\n"
+            + "ICONST_3\n"
+            + "ALOAD 4\n"
+            + "AASTORE\n"
+            + "DUP\n"
+            + "ICONST_4\n"
+            + "ALOAD 5\n"
+            + "AASTORE\n"
+            + "INVOKESTATIC org/apache/hadoop/mapred/split/TezMapredSplitsGrouper.$btrace$org$openjdk$btrace$runtime$aux$TezSplitter$getGroupedSplitsHook ([Ljava/lang/Object;)V\n"
+            + "LSTORE 23\n"
+            + "LSTORE 25\n"
+            + "LSTORE 27\n"
+            + "LLOAD 25\n"
+            + "LLOAD 27\n"
+            + "LLOAD 27\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map I T T T T T T T T J J J] []\n"
+            + "LLOAD 25\n"
+            + "LLOAD 27\n"
+            + "LLOAD 23\n"
+            + "LLOAD 25\n"
+            + "LLOAD 25\n"
+            + "LLOAD 23\n"
+            + "LLOAD 25\n"
+            + "LLOAD 23\n"
+            + "LLOAD 27\n"
+            + "LLOAD 27\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map I T T T T T T I T J J J] []\n"
+            + "LLOAD 23\n"
+            + "LLOAD 27\n"
+            + "ISTORE 23\n"
+            + "ASTORE 24\n"
+            + "ALOAD 24\n"
+            + "ISTORE 25\n"
+            + "ISTORE 26\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map [Lorg/apache/hadoop/mapred/InputSplit; T T T T T T T T I [Lorg/apache/hadoop/mapred/InputSplit; I I] []\n"
+            + "ILOAD 26\n"
+            + "ILOAD 25\n"
+            + "ALOAD 24\n"
+            + "ILOAD 26\n"
+            + "ASTORE 27\n"
+            + "ALOAD 27\n"
+            + "ASTORE 28\n"
+            + "ALOAD 28\n"
+            + "ALOAD 27\n"
+            + "ILOAD 23\n"
+            + "IINC 23 1\n"
+            + "ALOAD 28\n"
+            + "IINC 26 1\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map] []\n"
+            + "LSTORE 23\n"
+            + "ISTORE 25\n"
+            + "ILOAD 25\n"
+            + "ISTORE 26\n"
+            + "ISTORE 27\n"
+            + "ASTORE 28\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T T T J I I I java/util/Iterator] []\n"
+            + "ALOAD 28\n"
+            + "ALOAD 28\n"
+            + "ILOAD 26\n"
+            + "ASTORE 28\n"
+            + "ISTORE 29\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T [Lorg/apache/hadoop/mapred/InputSplit; I J I I I java/util/Set I] []\n"
+            + "ILOAD 29\n"
+            + "ILOAD 29\n"
+            + "ASTORE 30\n"
+            + "ALOAD 28\n"
+            + "ALOAD 30\n"
+            + "ASTORE 31\n"
+            + "ALOAD 30\n"
+            + "ASTORE 32\n"
+            + "ALOAD 32\n"
+            + "ALOAD 32\n"
+            + "ASTORE 32\n"
+            + "ALOAD 32\n"
+            + "ASTORE 33\n"
+            + "ALOAD 33\n"
+            + "ISTORE 34\n"
+            + "ISTORE 35\n"
+            + "ILOAD 35\n"
+            + "ILOAD 34\n"
+            + "ALOAD 33\n"
+            + "ILOAD 35\n"
+            + "ASTORE 36\n"
+            + "ALOAD 36\n"
+            + "ASTORE 36\n"
+            + "ALOAD 28\n"
+            + "ALOAD 36\n"
+            + "IINC 35 1\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T [Lorg/apache/hadoop/mapred/InputSplit; I J I I I java/util/Set I org/apache/hadoop/mapred/InputSplit org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder [Ljava/lang/String;] []\n"
+            + "ALOAD 28\n"
+            + "ASTORE 33\n"
+            + "ALOAD 33\n"
+            + "ALOAD 33\n"
+            + "ASTORE 34\n"
+            + "ALOAD 34\n"
+            + "ASTORE 35\n"
+            + "ALOAD 35\n"
+            + "ALOAD 31\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T [Lorg/apache/hadoop/mapred/InputSplit; I J I I I java/util/Set I] []\n"
+            + "IINC 29 1\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T T T J I I I java/util/Set] []\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set] []\n"
+            + "LLOAD 23\n"
+            + "ILOAD 25\n"
+            + "ILOAD 26\n"
+            + "ILOAD 27\n"
+            + "ISTORE 29\n"
+            + "ILOAD 27\n"
+            + "ASTORE 30\n"
+            + "ASTORE 31\n"
+            + "ISTORE 32\n"
+            + "ISTORE 33\n"
+            + "ISTORE 34\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I] []\n"
+            + "ILOAD 29\n"
+            + "IINC 34 1\n"
+            + "ISTORE 35\n"
+            + "ASTORE 36\n"
+            + "ALOAD 36\n"
+            + "ALOAD 36\n"
+            + "ASTORE 37\n"
+            + "ALOAD 30\n"
+            + "ALOAD 31\n"
+            + "ALOAD 37\n"
+            + "ASTORE 38\n"
+            + "ALOAD 37\n"
+            + "ASTORE 39\n"
+            + "ALOAD 39\n"
+            + "ASTORE 40\n"
+            + "ALOAD 40\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I java/util/Iterator java/util/Map$Entry java/lang/String org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder] []\n"
+            + "ALOAD 39\n"
+            + "ISTORE 41\n"
+            + "LSTORE 42\n"
+            + "ISTORE 44\n"
+            + "ALOAD 30\n"
+            + "ALOAD 40\n"
+            + "LLOAD 42\n"
+            + "ALOAD 40\n"
+            + "LSTORE 42\n"
+            + "IINC 44 1\n"
+            + "ALOAD 39\n"
+            + "ALOAD 39\n"
+            + "ASTORE 40\n"
+            + "ALOAD 40\n"
+            + "LLOAD 42\n"
+            + "ALOAD 40\n"
+            + "LLOAD 23\n"
+            + "ILOAD 44\n"
+            + "ILOAD 27\n"
+            + "ALOAD 39\n"
+            + "ILOAD 32\n"
+            + "LLOAD 42\n"
+            + "LLOAD 23\n"
+            + "ILOAD 44\n"
+            + "ILOAD 27\n"
+            + "ALOAD 39\n"
+            + "ILOAD 41\n"
+            + "IINC 35 1\n"
+            + "ALOAD 38\n"
+            + "ASTORE 45\n"
+            + "ALOAD 38\n"
+            + "ASTORE 45\n"
+            + "ILOAD 33\n"
+            + "ALOAD 30\n"
+            + "ASTORE 46\n"
+            + "ALOAD 46\n"
+            + "ALOAD 46\n"
+            + "ASTORE 47\n"
+            + "ALOAD 47\n"
+            + "ASTORE 48\n"
+            + "ALOAD 48\n"
+            + "ALOAD 48\n"
+            + "ASTORE 49\n"
+            + "ALOAD 49\n"
+            + "ISTORE 50\n"
+            + "ISTORE 51\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I java/util/Iterator java/util/Map$Entry java/lang/String org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder I J I [Ljava/lang/String; java/util/Iterator org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder [Ljava/lang/String; [Ljava/lang/String; I I] []\n"
+            + "ILOAD 51\n"
+            + "ILOAD 50\n"
+            + "ALOAD 49\n"
+            + "ILOAD 51\n"
+            + "ASTORE 52\n"
+            + "ALOAD 52\n"
+            + "ALOAD 31\n"
+            + "ALOAD 52\n"
+            + "IINC 51 1\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I java/util/Iterator java/util/Map$Entry java/lang/String org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder I J I [Ljava/lang/String; java/util/Iterator] []\n"
+            + "ALOAD 31\n"
+            + "ALOAD 45\n"
+            + "ASTORE 45\n"
+            + "ALOAD 30\n"
+            + "ALOAD 45\n"
+            + "ILOAD 33\n"
+            + "ALOAD 38\n"
+            + "ALOAD 38\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I java/util/Iterator java/util/Map$Entry java/lang/String org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder I J I [Ljava/lang/String;] [L144 L144 I java/lang/String [Ljava/lang/String;]\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I java/util/Iterator java/util/Map$Entry java/lang/String org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder I J I [Ljava/lang/String;] [L144 L144 I java/lang/String [Ljava/lang/String; java/lang/String]\n"
+            + "ASTORE 46\n"
+            + "ALOAD 30\n"
+            + "ASTORE 47\n"
+            + "ALOAD 47\n"
+            + "ALOAD 47\n"
+            + "ASTORE 48\n"
+            + "ALOAD 46\n"
+            + "ALOAD 48\n"
+            + "ALOAD 48\n"
+            + "ALOAD 38\n"
+            + "ALOAD 48\n"
+            + "IINC 29 1\n"
+            + "ALOAD 30\n"
+            + "ALOAD 46\n"
+            + "ALOAD 38\n"
+            + "ALOAD 46\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I] []\n"
+            + "ILOAD 33\n"
+            + "ILOAD 35\n"
+            + "ISTORE 33\n"
+            + "ILOAD 29\n"
+            + "ISTORE 36\n"
+            + "ILOAD 36\n"
+            + "ASTORE 37\n"
+            + "ASTORE 38\n"
+            + "ALOAD 38\n"
+            + "ALOAD 38\n"
+            + "ASTORE 39\n"
+            + "ALOAD 39\n"
+            + "ASTORE 40\n"
+            + "ALOAD 40\n"
+            + "ALOAD 40\n"
+            + "ASTORE 41\n"
+            + "ALOAD 41\n"
+            + "ALOAD 37\n"
+            + "ALOAD 41\n"
+            + "ALOAD 40\n"
+            + "ALOAD 37\n"
+            + "ILOAD 36\n"
+            + "ILOAD 36\n"
+            + "ALOAD 37\n"
+            + "ASTORE 38\n"
+            + "ASTORE 39\n"
+            + "ASTORE 40\n"
+            + "ALOAD 40\n"
+            + "ALOAD 40\n"
+            + "ASTORE 41\n"
+            + "ASTORE 42\n"
+            + "ALOAD 41\n"
+            + "ALOAD 41\n"
+            + "ASTORE 42\n"
+            + "ALOAD 38\n"
+            + "ALOAD 41\n"
+            + "ALOAD 42\n"
+            + "ALOAD 39\n"
+            + "ALOAD 42\n"
+            + "ALOAD 39\n"
+            + "ALOAD 42\n"
+            + "ILOAD 36\n"
+            + "ALOAD 39\n"
+            + "ASTORE 40\n"
+            + "ALOAD 37\n"
+            + "ISTORE 41\n"
+            + "ASTORE 42\n"
+            + "ALOAD 42\n"
+            + "ISTORE 43\n"
+            + "ISTORE 44\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I I java/util/Set java/util/Map java/util/Map java/util/HashSet I [Lorg/apache/hadoop/mapred/InputSplit; I I] []\n"
+            + "ILOAD 44\n"
+            + "ILOAD 43\n"
+            + "ALOAD 42\n"
+            + "ILOAD 44\n"
+            + "ASTORE 45\n"
+            + "ILOAD 41\n"
+            + "ALOAD 37\n"
+            + "ALOAD 45\n"
+            + "IINC 41 -1\n"
+            + "ALOAD 40\n"
+            + "ALOAD 45\n"
+            + "ASTORE 46\n"
+            + "ALOAD 45\n"
+            + "ASTORE 47\n"
+            + "ALOAD 47\n"
+            + "ALOAD 47\n"
+            + "ASTORE 47\n"
+            + "ALOAD 47\n"
+            + "ASTORE 48\n"
+            + "ALOAD 48\n"
+            + "ISTORE 49\n"
+            + "ISTORE 50\n"
+            + "ILOAD 50\n"
+            + "ILOAD 49\n"
+            + "ALOAD 48\n"
+            + "ILOAD 50\n"
+            + "ASTORE 51\n"
+            + "ALOAD 51\n"
+            + "ASTORE 51\n"
+            + "ALOAD 40\n"
+            + "ALOAD 38\n"
+            + "ALOAD 51\n"
+            + "IINC 50 1\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I I java/util/Set java/util/Map java/util/Map java/util/HashSet I [Lorg/apache/hadoop/mapred/InputSplit; I I org/apache/hadoop/mapred/InputSplit org/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder [Ljava/lang/String;] []\n"
+            + "ALOAD 40\n"
+            + "ASTORE 48\n"
+            + "ALOAD 48\n"
+            + "ALOAD 48\n"
+            + "ASTORE 49\n"
+            + "ALOAD 39\n"
+            + "ALOAD 49\n"
+            + "ALOAD 46\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I I java/util/Set java/util/Map java/util/Map java/util/HashSet I [Lorg/apache/hadoop/mapred/InputSplit; I I] []\n"
+            + "IINC 44 1\n"
+            + "ALOAD 37\n"
+            + "ALOAD 39\n"
+            + "FSTORE 42\n"
+            + "FLOAD 42\n"
+            + "LLOAD 23\n"
+            + "FLOAD 42\n"
+            + "LSTORE 43\n"
+            + "ILOAD 27\n"
+            + "FLOAD 42\n"
+            + "ISTORE 45\n"
+            + "LLOAD 43\n"
+            + "LLOAD 43\n"
+            + "LSTORE 23\n"
+            + "ILOAD 45\n"
+            + "ILOAD 45\n"
+            + "ISTORE 27\n"
+            + "ILOAD 34\n"
+            + "ILOAD 29\n"
+            + "ILOAD 35\n"
+            + "LLOAD 23\n"
+            + "ILOAD 27\n"
+            + "FRAME FULL [org/apache/hadoop/mapred/split/TezMapredSplitsGrouper org/apache/hadoop/conf/Configuration [Lorg/apache/hadoop/mapred/InputSplit; I java/lang/String org/apache/hadoop/mapred/split/SplitSizeEstimator I java/lang/String java/lang/String [Ljava/lang/String; I J java/util/Map java/util/List T T T T T T I I J I I I java/util/Set I java/util/List java/util/Set I I I I] []\n"
+            + "ILOAD 32\n"
+            + "ILOAD 35\n"
+            + "ILOAD 25\n"
+            + "ISTORE 32\n"
+            + "ILOAD 34\n"
+            + "ILOAD 29\n"
+            + "ILOAD 35\n"
+            + "ILOAD 34\n"
+            + "ILOAD 29\n"
+            + "ILOAD 35\n"
+            + "ASTORE 35\n"
+            + "ALOAD 35\n"
+            + "ILOAD 29\n"
+            + "ALOAD 35\n"
+            + "LOCALVARIABLE locations [Ljava/lang/String; L21 L26 26\n"
+            + "LOCALVARIABLE split Lorg/apache/hadoop/mapred/InputSplit; L17 L26 25\n"
+            + "LOCALVARIABLE lengthPerGroup J L42 L34 23\n"
+            + "LOCALVARIABLE maxLengthPerGroup J L43 L34 25\n"
+            + "LOCALVARIABLE minLengthPerGroup J L44 L34 27\n"
+            + "LOCALVARIABLE newSplit Lorg/apache/hadoop/mapred/split/TezGroupedSplit; L68 L70 28\n"
+            + "LOCALVARIABLE split Lorg/apache/hadoop/mapred/InputSplit; L66 L70 27\n"
+            + "LOCALVARIABLE i I L63 L60 23\n"
+            + "LOCALVARIABLE location Ljava/lang/String; L91 L94 36\n"
+            + "LOCALVARIABLE holder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder; L98 L99 35\n"
+            + "LOCALVARIABLE location Ljava/lang/String; L97 L99 34\n"
+            + "LOCALVARIABLE splitHolder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder; L85 L96 31\n"
+            + "LOCALVARIABLE locations [Ljava/lang/String; L86 L96 32\n"
+            + "LOCALVARIABLE split Lorg/apache/hadoop/mapred/InputSplit; L83 L96 30\n"
+            + "LOCALVARIABLE loc Ljava/lang/String; L153 L154 52\n"
+            + "LOCALVARIABLE locations [Ljava/lang/String; L149 L150 48\n"
+            + "LOCALVARIABLE splitH Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder; L148 L150 47\n"
+            + "LOCALVARIABLE groupedSplitHolder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder; L162 L168 48\n"
+            + "LOCALVARIABLE location Ljava/lang/String; L120 L173 38\n"
+            + "LOCALVARIABLE holder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder; L121 L173 39\n"
+            + "LOCALVARIABLE splitHolder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder; L122 L173 40\n"
+            + "LOCALVARIABLE oldHeadIndex I L125 L173 41\n"
+            + "LOCALVARIABLE groupLength J L126 L173 42\n"
+            + "LOCALVARIABLE groupNumSplits I L127 L173 44\n"
+            + "LOCALVARIABLE groupLocation [Ljava/lang/String; L141 L173 45\n"
+            + "LOCALVARIABLE groupedSplit Lorg/apache/hadoop/mapred/split/TezGroupedSplit; L159 L173 46\n"
+            + "LOCALVARIABLE entry Ljava/util/Map$Entry; L117 L173 37\n"
+            + "LOCALVARIABLE splitHolder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder; L185 L186 41\n"
+            + "LOCALVARIABLE locHolder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$LocationHolder; L182 L183 40\n"
+            + "LOCALVARIABLE entry Ljava/util/Map$Entry; L181 L183 39\n"
+            + "LOCALVARIABLE rack Ljava/lang/String; L198 L202 42\n"
+            + "LOCALVARIABLE location Ljava/lang/String; L197 L202 41\n"
+            + "LOCALVARIABLE location Ljava/lang/String; L223 L226 51\n"
+            + "LOCALVARIABLE rack Ljava/lang/String; L228 L229 49\n"
+            + "LOCALVARIABLE splitHolder Lorg/apache/hadoop/mapred/split/TezMapredSplitsGrouper$SplitHolder; L217 L214 46\n"
+            + "LOCALVARIABLE locations [Ljava/lang/String; L218 L214 47\n"
+            + "LOCALVARIABLE split Lorg/apache/hadoop/mapred/InputSplit; L209 L214 45\n"
+            + "LOCALVARIABLE newLengthPerGroup J L235 L233 43\n"
+            + "LOCALVARIABLE newNumSplitsInGroup I L236 L233 45\n"
+            + "LOCALVARIABLE numRemainingSplits I L177 L174 36\n"
+            + "LOCALVARIABLE remainingSplits Ljava/util/Set; L178 L174 37\n"
+            + "LOCALVARIABLE locToRackMap Ljava/util/Map; L193 L174 38\n"
+            + "LOCALVARIABLE rackLocations Ljava/util/Map; L194 L174 39\n"
+            + "LOCALVARIABLE rackSet Ljava/util/HashSet; L205 L174 40\n"
+            + "LOCALVARIABLE numRackSplitsToGroup I L206 L174 41\n"
+            + "LOCALVARIABLE rackSplitReduction F L232 L174 42\n"
+            + "LOCALVARIABLE numFullGroupsCreated I L114 L248 35\n"
+            + "LOCALVARIABLE lengthPerGroup J L72 L257 23\n"
+            + "LOCALVARIABLE numNodeLocations I L73 L257 25\n"
+            + "LOCALVARIABLE numSplitsPerLocation I L74 L257 26\n"
+            + "LOCALVARIABLE numSplitsInGroup I L75 L257 27\n"
+            + "LOCALVARIABLE locSet Ljava/util/Set; L80 L257 28\n"
+            + "LOCALVARIABLE splitsProcessed I L105 L257 29\n"
+            + "LOCALVARIABLE group Ljava/util/List; L106 L257 30\n"
+            + "LOCALVARIABLE groupLocationSet Ljava/util/Set; L107 L257 31\n"
+            + "LOCALVARIABLE allowSmallGroups Z L108 L257 32\n"
+            + "LOCALVARIABLE doingRackLocal Z L109 L257 33\n"
+            + "LOCALVARIABLE iterations I L110 L257 34\n"
+            + "LOCALVARIABLE groupedSplits [Lorg/apache/hadoop/mapred/InputSplit; L252 L257 35\n"
+            + "MAXLOCALS = 53",
         false);
   }
 }

--- a/btrace-instr/src/test/java/org/openjdk/btrace/instr/VariableMapperTest.java
+++ b/btrace-instr/src/test/java/org/openjdk/btrace/instr/VariableMapperTest.java
@@ -1,88 +1,98 @@
 package org.openjdk.btrace.instr;
 
+import static org.junit.Assert.*;
+
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
 public class VariableMapperTest {
-    private VariableMapper instance;
+  private VariableMapper instance;
 
-    @Before
-    public void setup() {
-        instance = new VariableMapper(0);
-    }
-    @Test
-    public void remapMethodArguments() {
-        int numArgs = 4;
-        VariableMapper mapper = new VariableMapper(numArgs);
+  @Before
+  public void setup() {
+    instance = new VariableMapper(0);
+  }
 
-        assertEquals(0, mapper.remap(0, 1));
-        assertEquals(1, mapper.remap(1, 2));
-        assertEquals(3, mapper.remap(3, 1));
-    }
+  @Test
+  public void remapMethodArguments() {
+    int numArgs = 4;
+    VariableMapper mapper = new VariableMapper(numArgs);
 
-    @Test
-    public void remapOutOfOrder() {
-        assertEquals(0, instance.remap(2, 1));
-        assertEquals(1, instance.remap(0, 2));
-        assertEquals(3, instance.remap(3, 1));
-    }
+    assertEquals(0, mapper.remap(0, 1));
+    assertEquals(1, mapper.remap(1, 2));
+    assertEquals(3, mapper.remap(3, 1));
+  }
 
-    @Test
-    public void remapSame() {
-        int var = instance.remap(2, 1);
-        assertEquals(var, instance.remap(2, 1));
-    }
+  @Test
+  public void remapOutOfOrder() {
+    assertEquals(0, instance.remap(2, 1));
+    assertEquals(1, instance.remap(0, 2));
+    assertEquals(3, instance.remap(3, 1));
+  }
 
-    @Test
-    public void remapWithNewVar() {
-        int xVar = instance.newVarIdx(2);
-        int yVar = instance.newVarIdx(1);
+  @Test
+  public void remapSame() {
+    int var = instance.remap(2, 1);
+    assertEquals(var, instance.remap(2, 1));
+  }
 
-        assertEquals(VariableMapper.unmask(xVar), instance.remap(xVar, 2));
-        assertEquals(VariableMapper.unmask(yVar), instance.remap(yVar, 1));
-        assertEquals(3, instance.remap(0, 1));
-        assertEquals(4, instance.remap(1, 2));
-    }
+  @Test
+  public void remapWithNewVar() {
+    int xVar = instance.newVarIdx(2);
+    int yVar = instance.newVarIdx(1);
 
-    @Test
-    public void remapOverflow() {
-        assertEquals(0, instance.remap(16, 1)); // default mapping array size is 8 so going for double should trigger overflow handling
-    }
+    assertEquals(VariableMapper.unmask(xVar), instance.remap(xVar, 2));
+    assertEquals(VariableMapper.unmask(yVar), instance.remap(yVar, 1));
+    assertEquals(3, instance.remap(0, 1));
+    assertEquals(4, instance.remap(1, 2));
+  }
 
-    @Test
-    public void testMapEmpty() {
-        assertTrue(VariableMapper.isInvalidMapping(instance.map(0)));
-    }
+  @Test
+  public void remapOverflow() {
+    assertEquals(
+        0,
+        instance.remap(
+            16,
+            1)); // default mapping array size is 8 so going for double should trigger overflow
+                 // handling
+  }
 
-    @Test
-    public void testMapMethodArgs() {
-        int numArgs = 4;
-        VariableMapper mapper = new VariableMapper(numArgs);
+  @Test
+  public void testMapEmpty() {
+    assertTrue(VariableMapper.isInvalidMapping(instance.map(0)));
+  }
 
-        assertEquals(0, mapper.map(0));
-        assertEquals(1, mapper.map(1));
-        assertEquals(3, mapper.map(3));
-    }
+  @Test
+  public void testMapMethodArgs() {
+    int numArgs = 4;
+    VariableMapper mapper = new VariableMapper(numArgs);
 
-    @Test
-    public void testMappings() {
-        instance.setMapping(0, 2, 1);
-        instance.setMapping(1, 0, 2);
+    assertEquals(0, mapper.map(0));
+    assertEquals(1, mapper.map(1));
+    assertEquals(3, mapper.map(3));
+  }
 
-        assertEquals(2, instance.map(0));
-        assertEquals(0, instance.map(1));
-    }
+  @Test
+  public void testMappings() {
+    instance.setMapping(0, 2, 1);
+    instance.setMapping(1, 0, 2);
 
-    @Test
-    public void testMapRemapped() {
-        int varX  = instance.newVarIdx(1);
-        assertEquals(VariableMapper.unmask(varX), instance.map(varX));
-    }
+    assertEquals(2, instance.map(0));
+    assertEquals(0, instance.map(1));
+  }
 
-    @Test
-    public void mapOverflow() {
-        assertTrue(VariableMapper.isInvalidMapping(instance.map(16))); // default mapping array size is 8 so going for double should trigger overflow handling
-    }
+  @Test
+  public void testMapRemapped() {
+    int varX = instance.newVarIdx(1);
+    assertEquals(VariableMapper.unmask(varX), instance.map(varX));
+  }
+
+  @Test
+  public void mapOverflow() {
+    assertTrue(
+        VariableMapper.isInvalidMapping(
+            instance.map(
+                16))); // default mapping array size is 8 so going for double should trigger
+                       // overflow handling
+  }
 }

--- a/btrace-instr/src/test/java/org/openjdk/btrace/instr/VariableMapperTest.java
+++ b/btrace-instr/src/test/java/org/openjdk/btrace/instr/VariableMapperTest.java
@@ -52,9 +52,8 @@ public class VariableMapperTest {
     assertEquals(
         0,
         instance.remap(
-            16,
-            1)); // default mapping array size is 8 so going for double should trigger overflow
-                 // handling
+            16, 1)); // default mapping array size is 8 so going for double should trigger overflow
+    // handling
   }
 
   @Test
@@ -93,6 +92,6 @@ public class VariableMapperTest {
         VariableMapper.isInvalidMapping(
             instance.map(
                 16))); // default mapping array size is 8 so going for double should trigger
-                       // overflow handling
+    // overflow handling
   }
 }

--- a/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimes.java
+++ b/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimes.java
@@ -10,9 +10,10 @@ public final class BTraceRuntimes {
   private static BTraceRuntimeImplFactory<?> FACTORY = null;
 
   static {
-    boolean loaded = loadFactory("org.openjdk.btrace.runtime.BTraceRuntimeImpl_11$Factory") ||
-                     loadFactory("org.openjdk.btrace.runtime.BTraceRuntimeImpl_9$Factory") ||
-                     loadFactory("org.openjdk.btrace.runtime.BTraceRuntimeImpl_7$Factory");
+    boolean loaded =
+        loadFactory("org.openjdk.btrace.runtime.BTraceRuntimeImpl_11$Factory")
+            || loadFactory("org.openjdk.btrace.runtime.BTraceRuntimeImpl_9$Factory")
+            || loadFactory("org.openjdk.btrace.runtime.BTraceRuntimeImpl_7$Factory");
     DebugSupport.SHARED.debug("BTraceRuntime loaded: " + loaded);
     BTraceRuntimeAccess.registerRuntimeAccessor();
   }


### PR DESCRIPTION
This change allows running BTrace probes in unattended mode when they are not connected to the initiating client.

Having the possibility of running probes in unattended mode comes very handy especially with the recent addition of JFR event support where one can setup a probe to emit custom JFR events and disconnect and leave the application running with the probe applied.

In order to support the unattended execution this PR is adding:
- the ability to detach from the command line client
- the ability to deploy the probe in unattended mode (`btrace -x <options> <pid> <probe>`)
- the ability to list all active probes which can be attached to (`btrace -lp <pid>`)
- the ability to reconnect to a previously disconnected probes (`btrace -r <probe id> <pid>`) where probe id is assigned (and displayed) when the probe is first time deployed

For disconnected probes there is small message buffers which can hold up to 5000 most recent messages so when reconnecting one can get the most recent history replayed.