### PR TITLE
Register Bound Local Port as System Property

### DIFF
--- a/btrace-agent/src/main/java/org/openjdk/btrace/agent/Main.java
+++ b/btrace-agent/src/main/java/org/openjdk/btrace/agent/Main.java
@@ -844,6 +844,12 @@ public final class Main {
         System.setProperty("btrace.output", scriptOutputFile);
       }
       ss = new ServerSocket(port);
+      int localPort = ss.getLocalPort();
+
+      if (isDebug()) {
+        debugPrint("started server at " + localPort);
+      }
+      System.setProperty("btrace.localport", String.valueOf(localPort));
     } catch (IOException ioexp) {
       ioexp.printStackTrace();
       return;


### PR DESCRIPTION
Prior to this pull-request, if BTrace is configured to start the server on port 0 (which instructs the OS to pick a random unbound port to bind to), there was not a way to find which port was actually bound.

This PR queries the bound local-port of the ServerSocket and stores the value in the system property `btrace.localport`.