### PR TITLE
Set the actual local port number to `btrace.port` system property

### DIFF
--- a/btrace-agent/src/main/java/org/openjdk/btrace/agent/Main.java
+++ b/btrace-agent/src/main/java/org/openjdk/btrace/agent/Main.java
@@ -832,7 +832,6 @@ public final class Main {
       if (isDebug()) {
         debugPrint("starting server at " + port);
       }
-      System.setProperty("btrace.port", String.valueOf(port));
       System.setProperty("btrace.wireio", String.valueOf(WireIO.VERSION));
 
       String scriptOutputFile = settings.getOutputFile();
@@ -840,6 +839,7 @@ public final class Main {
         System.setProperty("btrace.output", scriptOutputFile);
       }
       ss = new ServerSocket(port);
+      System.setProperty("btrace.port", String.valueOf(ss.getLocalPort()));
     } catch (IOException ioexp) {
       ioexp.printStackTrace();
       return;


### PR DESCRIPTION
Motivation:

BTrace agent currently sets the port number given by a user to
`btrace.port` system property as-is. This behavior can be a problem
when:

- The agent actually failed to bind to the given port, because a user
  may still attempt to connect to the port number specified in
  `btrace.port`, where other server may be running already there.
- A user cannot know the actual port where BTrace agent is running when
  the user specified `0` as the port number, because we only know the
  actual port number *after* creating a server socket on it.

Modifications:

- Set the actual local port number after creating a `ServerSocket` so
  that a user can later figure out the actual port number even if the
  user specified `0` as the port number.

Result:

- A user can know the actual local port number, even when the user
  specified `0`.
- A user can know the agent server socket is not open easily by checking
  the existence of `btrace.port` System property.