### PR TITLE
Do not use javac internals

### DIFF
--- a/btrace-dist/src/main/resources/bin/btrace
+++ b/btrace-dist/src/main/resources/bin/btrace
@@ -17,10 +17,6 @@ JAVA_ARGS="-XX:+IgnoreUnrecognizedVMOptions"
 if [ -d "${JAVA_HOME}/jmods" ]; then
   JAVA_ARGS="$JAVA_ARGS -XX:+AllowRedefinitionToAddDeleteMethods"
   JAVA_ARGS="$JAVA_ARGS --add-exports jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
 fi
 
 if [ -f "${BTRACE_HOME}/libs/btrace-client.jar" ]; then

--- a/btrace-dist/src/main/resources/bin/btrace.bat
+++ b/btrace-dist/src/main/resources/bin/btrace.bat
@@ -13,10 +13,6 @@ if "%JAVA_HOME%" == "" goto noJavaHome
   if exist "%JAVA_HOME%/jmods/" (
     set JAVA_ARGS="%JAVA_ARGS% -XX:+AllowRedefinitionToAddDeleteMethods"
     set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED"
-    set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED"
-    set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-    set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
-    set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
   )
   "%JAVA_HOME%/bin/java" "%JAVA_ARGS%" -cp "%BTRACE_HOME%/libs/btrace-client.jar;%JAVA_HOME%/lib/tools.jar" org.openjdk.btrace.client.Main %*
   goto end

--- a/btrace-dist/src/main/resources/bin/btracec
+++ b/btrace-dist/src/main/resources/bin/btracec
@@ -15,10 +15,6 @@ fi
 JAVA_ARGS="-XX:+IgnoreUnrecognizedVMOptions"
 if [ -d "${JAVA_HOME}/jmods" ]; then
   JAVA_ARGS="$JAVA_ARGS --add-exports jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
 fi
 if [ -f "${BTRACE_HOME}/libs/btrace-client.jar" ]; then
   if [ -d "${JAVA_HOME}" ]; then

--- a/btrace-dist/src/main/resources/bin/btracec.bat
+++ b/btrace-dist/src/main/resources/bin/btracec.bat
@@ -12,10 +12,6 @@ if "%JAVA_HOME%" == "" goto noJavaHome
   if exist "%JAVA_HOME%/jmods/" (
     set JAVA_ARGS="%JAVA_ARGS% -XX:+AllowRedefinitionToAddDeleteMethods"
     set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED"
-    set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED"
-    set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-    set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
-    set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
   )
   if "%1" == "--version" (
     %JAVA_HOME%\bin\java "%JAVA_ARGS%" -cp %BTRACE_HOME%/build/btrace-client.jar org.openjdk.btrace.client.Main --version

--- a/btrace-dist/src/main/resources/bin/btracep
+++ b/btrace-dist/src/main/resources/bin/btracep
@@ -17,10 +17,6 @@ JAVA_ARGS="-XX:+IgnoreUnrecognizedVMOptions"
 if [ -d "${JAVA_HOME}/jmods" ]; then
   JAVA_ARGS="$JAVA_ARGS -XX:+AllowRedefinitionToAddDeleteMethods"
   JAVA_ARGS="$JAVA_ARGS --add-exports jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
 fi
 
 if [ -f "${BTRACE_HOME}/libs/btrace-client.jar" ]; then

--- a/btrace-dist/src/main/resources/bin/btracep.bat
+++ b/btrace-dist/src/main/resources/bin/btracep.bat
@@ -12,10 +12,6 @@ if "%JAVA_HOME%" == "" goto noJavaHome
   if exist "%JAVA_HOME%/jmods/" (
     set JAVA_ARGS="%JAVA_ARGS% -XX:+AllowRedefinitionToAddDeleteMethods"
     set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED"
-    set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED"
-    set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-    set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
-    set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
   )
   if "%1" == "--version" (
     %JAVA_HOME%\bin\java "%JAVA_ARGS%" -cp %BTRACE_HOME%/build/btrace-client.jar org.openjdk.btrace.client.Main --version

--- a/btrace-dist/src/main/resources/bin/btracer
+++ b/btrace-dist/src/main/resources/bin/btracer
@@ -40,10 +40,6 @@ JAVA_ARGS="-XX:+IgnoreUnrecognizedVMOptions"
 if [ -d "${JAVA_HOME}/jmods" ]; then
   JAVA_ARGS="$JAVA_ARGS -XX:+AllowRedefinitionToAddDeleteMethods"
   JAVA_ARGS="$JAVA_ARGS --add-exports jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
-  JAVA_ARGS="$JAVA_ARGS --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
 fi
 
 OPTIONS=

--- a/btrace-dist/src/main/resources/bin/btracer.bat
+++ b/btrace-dist/src/main/resources/bin/btracer.bat
@@ -19,10 +19,6 @@ if "%JAVA_HOME%" == "" goto noJavaHome
 if exist "%JAVA_HOME%/jmods/" (
   set JAVA_ARGS="%JAVA_ARGS% -XX:+AllowRedefinitionToAddDeleteMethods"
   set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED"
-  set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED"
-  set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-  set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
-  set JAVA_ARGS="%JAVA_ARGS% --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
 )
 
 if "%1" == "--version" (

--- a/btrace-instr/src/test/java/org/openjdk/btrace/RuntimeTest.java
+++ b/btrace-instr/src/test/java/org/openjdk/btrace/RuntimeTest.java
@@ -348,11 +348,7 @@ public abstract class RuntimeTest {
       argVals.addAll(
           1,
           Arrays.asList(
-              "--add-exports", "jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED",
-              "--add-exports", "jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-              "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-              "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-              "--add-exports", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"));
+              "--add-exports", "jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED"));
     }
     ProcessBuilder pb = new ProcessBuilder(argVals);
 


### PR DESCRIPTION
This should allow to use VisualVM btrace plugin on JDK 11+ without `--add-exports`.