### PR TITLE
Allow executing commands on BTrace server

### DIFF
--- a/btrace-compiler/src/main/java/org/openjdk/btrace/compiler/Verifier.java
+++ b/btrace-compiler/src/main/java/org/openjdk/btrace/compiler/Verifier.java
@@ -106,7 +106,7 @@ public class Verifier extends AbstractProcessor implements TaskListener {
     for (Tree t : e.getCompilationUnit().getTypeDecls()) {
       TreePath topLevel = new TreePath(e.getCompilationUnit());
       if (t.getKind() == Tree.Kind.CLASS) {
-          if (elem.equals(getTreeUtils().getElement(new TreePath(topLevel, t)))) {
+        if (elem.equals(getTreeUtils().getElement(new TreePath(topLevel, t)))) {
           currentClass = (ClassTree) t;
           break;
         }

--- a/btrace-compiler/src/main/java/org/openjdk/btrace/compiler/VerifierVisitor.java
+++ b/btrace-compiler/src/main/java/org/openjdk/btrace/compiler/VerifierVisitor.java
@@ -36,7 +36,6 @@ import com.sun.source.tree.DoWhileLoopTree;
 import com.sun.source.tree.EnhancedForLoopTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.ForLoopTree;
-import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
@@ -677,7 +676,10 @@ public class VerifierVisitor extends TreeScanner<Void, Void> {
     Element e = verifier.getTreeUtils().getElement(tp);
     if (e == null) {
       if (t.getKind() == Tree.Kind.NEW_CLASS) {
-        e = verifier.getTreeUtils().getElement(new TreePath(tp, ((NewClassTree) t).getIdentifier()));
+        e =
+            verifier
+                .getTreeUtils()
+                .getElement(new TreePath(tp, ((NewClassTree) t).getIdentifier()));
       }
       if (t.getKind() == Tree.Kind.THROW) {
         e = verifier.getTreeUtils().getElement(new TreePath(tp, ((ThrowTree) t).getExpression()));

--- a/btrace-core/src/main/resources/org/openjdk/btrace/core/messages.properties
+++ b/btrace-core/src/main/resources/org/openjdk/btrace/core/messages.properties
@@ -54,6 +54,11 @@ event.invalid.handler=Invalid periodic event handler specified - the handler met
 agent.no.instance.variables=instance variables are not allowed
 agent.unsafe.not.allowed=Trusted mode, requested by the script, not allowed
 jfr.event.invalid.field=Invalid JFR event field name
+remote.commands.help=\
+  BTrace remote commands:\n \
+  - event <name>  : Send an event with an optional name\n \
+  - exit          : Terminate the BTrace probe
+
 # usage messages
 btracec.usage=\
   Usage: btracec <options> <btrace source files>\n\
@@ -77,6 +82,7 @@ btrace.usage=\
     -r <probe id>         Reconnect to an active disconnected probe\n  \
                     \t\t\tExpects PID or app name as the follow-up argument\n  \
                     \t\t\tAll other options are discarded\n  \
+    -r help               Show help on the remote commands\n \
     -o <file>             The path to store the probe output (will disable showing the output in console)\n  \
     -u                    Run in trusted mode\n  \
     -d <path>             Dump the instrumented classes to the specified path\n  \

--- a/btrace-instr/src/test/java/org/openjdk/btrace/RuntimeTest.java
+++ b/btrace-instr/src/test/java/org/openjdk/btrace/RuntimeTest.java
@@ -212,7 +212,7 @@ public abstract class RuntimeTest {
                 String l;
                 while ((l = stdoutReader.readLine()) != null) {
                   if (l.startsWith("ready:")) {
-                    pidStringRef.set(l.split("\\:")[1]);
+                    pidStringRef.set(l.split(":")[1]);
                     testAppLatch.countDown();
                   }
                   if (debugTestApp) {
@@ -274,7 +274,306 @@ public abstract class RuntimeTest {
     v.validate(stdout.toString(), stderr.toString(), ret.get(), jfrFile);
   }
 
-  private File locateTrace(String trace) {
+  public static final class TestApp {
+    private int pid;
+    private final CountDownLatch testAppLatch = new CountDownLatch(1);
+    private final Process process;
+
+    public TestApp(Process process, boolean debug) {
+      this.process = process;
+
+      BufferedReader stdoutReader =
+          new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+      Thread outT =
+          new Thread(
+              () -> {
+                try {
+                  String l;
+                  while ((l = stdoutReader.readLine()) != null) {
+                    if (l.startsWith("ready:")) {
+                      pid = Integer.parseInt(l.split(":")[1]);
+                      testAppLatch.countDown();
+                    }
+                    if (debug) {
+                      System.out.println("[traced app] " + l);
+                    }
+                  }
+
+                } catch (Exception e) {
+                  e.printStackTrace(System.err);
+                }
+              },
+              "STDOUT Reader");
+      outT.setDaemon(true);
+
+      BufferedReader stderrReader =
+          new BufferedReader(new InputStreamReader(process.getErrorStream()));
+
+      Thread errT =
+          new Thread(
+              () -> {
+                try {
+                  String l = null;
+                  while ((l = stderrReader.readLine()) != null) {
+                    if (l.contains("Server VM warning")
+                        || l.contains("XML libraries not available")) {
+                      continue;
+                    }
+                    testAppLatch.countDown();
+                    if (debug) {
+                      System.err.println("[traced app] " + l);
+                    }
+                  }
+                } catch (Exception e) {
+                  e.printStackTrace(System.err);
+                }
+              },
+              "STDERR Reader");
+      errT.setDaemon(true);
+
+      outT.start();
+      errT.start();
+    }
+
+    public void stop() throws InterruptedException {
+      if (process.isAlive()) {
+        PrintWriter pw = new PrintWriter(process.getOutputStream());
+        pw.println("done");
+        pw.flush();
+        process.waitFor();
+      }
+    }
+
+    public int getPid() throws InterruptedException {
+      testAppLatch.await();
+      return pid;
+    }
+  }
+
+  public TestApp launchTestApp(String testApp, String... cmdArgs) throws Exception {
+    if (forceDebug) {
+      // force debug flags
+      debugBTrace = true;
+      debugTestApp = true;
+    }
+    String jfrFile = null;
+    List<String> args = new ArrayList<>(Arrays.asList(javaHome + "/bin/java", "-cp", cp));
+    if (attachDebugger) {
+      args.add("-agentlib:jdwp=transport=dt_socket,server=y,address=8000");
+    }
+    args.add("-XX:+AllowRedefinitionToAddDeleteMethods");
+    args.add("-XX:+IgnoreUnrecognizedVMOptions");
+    // uncomment the following line to get extra JFR logs
+    //    args.add("-Xlog:jfr*=trace");
+    args.addAll(extraJvmArgs);
+    args.addAll(
+        Arrays.asList(
+            "-XX:+AllowRedefinitionToAddDeleteMethods", "-XX:+IgnoreUnrecognizedVMOptions"));
+    if (startJfr) {
+      jfrFile = Files.createTempFile("btrace-", ".jfr").toString();
+      args.add("-XX:StartFlightRecording=settings=default,dumponexit=true,filename=" + jfrFile);
+    }
+    args.add(testApp);
+
+    ProcessBuilder pb = new ProcessBuilder(args);
+    pb.environment().remove("JAVA_TOOL_OPTIONS");
+
+    return new TestApp(pb.start(), debugTestApp);
+  }
+
+  public interface ProcessOutputProcessor {
+    boolean onStdout(int lineno, String line);
+
+    boolean onStderr(int lineno, String line);
+  }
+
+  public void runBTrace(String[] args, ProcessOutputProcessor outputProcessor) throws Exception {
+    List<String> argVals =
+        new ArrayList<>(
+            Arrays.asList(
+                javaHome + "/bin/java",
+                "-cp",
+                cp,
+                "org.openjdk.btrace.client.Main",
+                debugBTrace ? "-v" : "",
+                "-cp",
+                eventsClassPath,
+                "-d",
+                "/tmp/btrace-test"));
+    argVals.addAll(Arrays.asList(args));
+    if (Files.exists(Paths.get(System.getenv("TEST_JAVA_HOME"), "jmods"))) {
+      argVals.addAll(
+          1,
+          Arrays.asList("--add-exports", "jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED"));
+    }
+    ProcessBuilder pb = new ProcessBuilder(argVals);
+
+    pb.environment().remove("JAVA_TOOL_OPTIONS");
+    Process p = pb.start();
+
+    Thread stderrThread =
+        new Thread(
+            () -> {
+              try {
+                BufferedReader br =
+                    new BufferedReader(
+                        new InputStreamReader(p.getErrorStream(), StandardCharsets.UTF_8));
+
+                int lineno = 0;
+                String line = null;
+                while ((line = br.readLine()) != null) {
+                  System.out.println("[btrace err] " + line);
+                  if (line.contains("Server VM warning")
+                      || line.contains("XML libraries not available")
+                      || line.contains("Connection reset")) {
+                    // skip JVM generated warnings
+                    continue;
+                  }
+                  if (line.startsWith("[traced app]") || line.startsWith("[btrace out]")) {
+                    // skip test debug lines
+                    continue;
+                  }
+                  if (!outputProcessor.onStderr(++lineno, line)) {
+                    return;
+                  }
+                  ;
+                }
+              } catch (Exception e) {
+                throw new Error(e);
+              }
+            },
+            "Stderr Reader");
+
+    Thread stdoutThread =
+        new Thread(
+            () -> {
+              try {
+                BufferedReader br =
+                    new BufferedReader(
+                        new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8));
+                int lineno = 0;
+                String line = null;
+                while ((line = br.readLine()) != null) {
+                  if (debugBTrace && line.contains("DEBUG:")) {
+                    continue;
+                  }
+                  if (!outputProcessor.onStdout(++lineno, line)) {
+                    return;
+                  }
+                }
+              } catch (Exception e) {
+                throw new Error(e);
+              }
+            },
+            "Stdout Reader");
+
+    stderrThread.setDaemon(true);
+    stdoutThread.setDaemon(true);
+
+    stderrThread.start();
+    stdoutThread.start();
+
+    stderrThread.join();
+    stdoutThread.join();
+  }
+
+  public Process runBTrace(
+      String[] args, int checkLines, StringBuilder stdout, StringBuilder stderr) throws Exception {
+    List<String> argVals =
+        new ArrayList<>(
+            Arrays.asList(
+                javaHome + "/bin/java",
+                "-cp",
+                cp,
+                "org.openjdk.btrace.client.Main",
+                debugBTrace ? "-v" : "",
+                "-cp",
+                eventsClassPath,
+                "-d",
+                "/tmp/btrace-test"));
+    argVals.addAll(Arrays.asList(args));
+    if (Files.exists(Paths.get(System.getenv("TEST_JAVA_HOME"), "jmods"))) {
+      argVals.addAll(
+          1,
+          Arrays.asList("--add-exports", "jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED"));
+    }
+    ProcessBuilder pb = new ProcessBuilder(argVals);
+
+    pb.environment().remove("JAVA_TOOL_OPTIONS");
+    Process p = pb.start();
+
+    CountDownLatch l = new CountDownLatch(checkLines);
+
+    new Thread(
+            () -> {
+              try {
+                BufferedReader br =
+                    new BufferedReader(
+                        new InputStreamReader(p.getErrorStream(), StandardCharsets.UTF_8));
+
+                String line = null;
+                while ((line = br.readLine()) != null) {
+                  System.out.println("[btrace err] " + line);
+                  if (line.contains("Server VM warning")
+                      || line.contains("XML libraries not available")
+                      || line.contains("Connection reset")) {
+                    // skip JVM generated warnings
+                    continue;
+                  }
+                  if (line.startsWith("[traced app]") || line.startsWith("[btrace out]")) {
+                    // skip test debug lines
+                    continue;
+                  }
+                  stderr.append(line).append('\n');
+                  if (line.contains("Exception") || line.contains("Error")) {
+                    for (int i = 0; i < checkLines; i++) {
+                      l.countDown();
+                    }
+                  }
+                }
+              } catch (Exception e) {
+                for (int i = 0; i < checkLines; i++) {
+                  l.countDown();
+                }
+                throw new Error(e);
+              }
+            },
+            "Stderr Reader")
+        .start();
+
+    new Thread(
+            () -> {
+              try {
+                BufferedReader br =
+                    new BufferedReader(
+                        new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8));
+                String line = null;
+                while ((line = br.readLine()) != null) {
+                  stdout.append(line).append('\n');
+                  System.out.println("[btrace out] " + line);
+                  if (!(debugBTrace && line.contains("DEBUG:"))) {
+                    l.countDown();
+                  }
+                }
+              } catch (Exception e) {
+                for (int i = 0; i < checkLines; i++) {
+                  l.countDown();
+                }
+                throw new Error(e);
+              }
+            },
+            "Stdout Reader")
+        .start();
+
+    l.await(timeout, TimeUnit.MILLISECONDS);
+
+    // Thread.sleep(100_000_000L);
+
+    return p;
+  }
+
+  public File locateTrace(String trace) {
     Path start = projectRoot.resolve("btrace-instr/src");
     AtomicReference<Path> tracePath = new AtomicReference<>();
     try {


### PR DESCRIPTION
This change allows running arbitrary commands on a previously started BTrace session left in unattended mode.
This assumes the BTrace server is not disabled.

Currently, the supported commands are:
- `btrace -r <probe_id> event <pid>` - will send an anonymous event
- `btrace -r <probe_id> event myEvent <pid>` - will send a named event
- `btrace -r <probe_id> exit <pid>` - will initiate the BTrace probe exit

The usage help can be obtained as:
- `btrace -r help`