### PR TITLE
Use SLF4J SimpleLogger

### DIFF
--- a/benchmarks/runtime-benchmarks/src/jmh/java/org/openjdk/btrace/bench/OnMethodTemplateBenchmark.java
+++ b/benchmarks/runtime-benchmarks/src/jmh/java/org/openjdk/btrace/bench/OnMethodTemplateBenchmark.java
@@ -23,8 +23,6 @@ package org.openjdk.btrace.bench;
 
 import java.util.concurrent.TimeUnit;
 import org.openjdk.btrace.core.ArgsMap;
-import org.openjdk.btrace.core.DebugSupport;
-import org.openjdk.btrace.core.SharedSettings;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
@@ -40,7 +38,7 @@ public class OnMethodTemplateBenchmark {
 
   @Setup
   public void setup() {
-    argsMap = new ArgsMap(new String[] {"arg1=val1"}, new DebugSupport(SharedSettings.GLOBAL));
+    argsMap = new ArgsMap(new String[] {"arg1=val1"});
   }
 
   @Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)

--- a/btrace-agent/build.gradle
+++ b/btrace-agent/build.gradle
@@ -1,4 +1,7 @@
 dependencies {
+    // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
+
     implementation(group: 'org.ow2.asm', name: 'asm', version: "${rootProject.asmVersion}")
 
     implementation files("${JAVA_8_HOME}/lib/tools.jar")

--- a/btrace-agent/src/main/java/org/openjdk/btrace/agent/Client.java
+++ b/btrace-agent/src/main/java/org/openjdk/btrace/agent/Client.java
@@ -51,6 +51,7 @@ import org.objectweb.asm.ClassWriter;
 import org.openjdk.btrace.core.ArgsMap;
 import org.openjdk.btrace.core.BTraceRuntime;
 import org.openjdk.btrace.core.SharedSettings;
+import org.openjdk.btrace.core.comm.Command;
 import org.openjdk.btrace.core.comm.CommandListener;
 import org.openjdk.btrace.core.comm.ErrorCommand;
 import org.openjdk.btrace.core.comm.ExitCommand;

--- a/btrace-agent/src/main/java/org/openjdk/btrace/agent/Client.java
+++ b/btrace-agent/src/main/java/org/openjdk/btrace/agent/Client.java
@@ -50,9 +50,15 @@ import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.openjdk.btrace.core.ArgsMap;
 import org.openjdk.btrace.core.BTraceRuntime;
-import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.SharedSettings;
-import org.openjdk.btrace.core.comm.*;
+import org.openjdk.btrace.core.comm.CommandListener;
+import org.openjdk.btrace.core.comm.ErrorCommand;
+import org.openjdk.btrace.core.comm.ExitCommand;
+import org.openjdk.btrace.core.comm.InstrumentCommand;
+import org.openjdk.btrace.core.comm.MessageCommand;
+import org.openjdk.btrace.core.comm.RenameCommand;
+import org.openjdk.btrace.core.comm.RetransformationStartNotification;
+import org.openjdk.btrace.core.comm.StatusCommand;
 import org.openjdk.btrace.instr.BTraceProbe;
 import org.openjdk.btrace.instr.BTraceProbeFactory;
 import org.openjdk.btrace.instr.BTraceProbePersisted;
@@ -66,6 +72,8 @@ import org.openjdk.btrace.instr.Instrumentor;
 import org.openjdk.btrace.instr.templates.impl.MethodTrackingExpander;
 import org.openjdk.btrace.runtime.BTraceRuntimeAccess;
 import org.openjdk.btrace.runtime.BTraceRuntimes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abstract class that represents a BTrace client at the BTrace agent.
@@ -74,6 +82,8 @@ import org.openjdk.btrace.runtime.BTraceRuntimes;
  * @author J. Bachorik (j.bachorik@btrace.io)
  */
 abstract class Client implements CommandListener {
+  private static final Logger log = LoggerFactory.getLogger(Client.class);
+
   private static final Map<UUID, Client> CLIENTS = new ConcurrentHashMap<>();
   private static final Map<String, PrintWriter> WRITER_MAP = new HashMap<>();
   private static final Pattern SYSPROP_PTN = Pattern.compile("\\$\\{(.+?)}");
@@ -92,7 +102,6 @@ abstract class Client implements CommandListener {
 
   private final Instrumentation inst;
   final SharedSettings settings;
-  final DebugSupport debug;
   final ArgsMap argsMap;
   private final BTraceTransformer transformer;
   volatile PrintWriter out;
@@ -113,7 +122,6 @@ abstract class Client implements CommandListener {
     this.argsMap = argsMap;
     settings = s != null ? s : SharedSettings.GLOBAL;
     transformer = t;
-    debug = new DebugSupport(settings);
 
     setupWriter();
     CLIENTS.put(id, this);
@@ -144,7 +152,7 @@ abstract class Client implements CommandListener {
       String outputDir = settings.getOutputDir();
       String output = (outputDir != null ? outputDir + File.separator : "") + outputFile;
       outputFile = templateOutputFileName(output);
-      infoPrint("Redirecting output to " + outputFile);
+      log.info("Redirecting output to {}", outputFile);
     }
     out = WRITER_MAP.get(outputFile);
     if (out == null) {
@@ -159,7 +167,7 @@ abstract class Client implements CommandListener {
         } else {
           out =
               new PrintWriter(
-                  new BufferedWriter(TraceOutputWriter.fileWriter(new File(outputFile), settings)));
+                  new BufferedWriter(TraceOutputWriter.fileWriter(new File(outputFile))));
         }
       }
       WRITER_MAP.put(outputFile, out);
@@ -227,8 +235,8 @@ abstract class Client implements CommandListener {
               .replace("[default]", "");
 
       fName = replaceSysProps(fName);
-      if (dflt && settings.isDebug()) {
-        debugPrint("scriptOutputFile not specified. defaulting to " + fName);
+      if (dflt && log.isDebugEnabled()) {
+        log.debug("scriptOutputFile not specified. defaulting to {}", fName);
       }
     }
     return fName;
@@ -282,23 +290,23 @@ abstract class Client implements CommandListener {
 
       BTraceRuntime.leave();
       try {
-        debugPrint("onExit:");
-        debugPrint("cleaning up transformers");
+        log.debug("onExit:");
+        log.debug("cleaning up transformers");
         cleanupTransformers();
-        debugPrint("removing instrumentation");
+        log.debug("removing instrumentation");
         retransformLoaded();
-        debugPrint("closing all I/O");
+        log.debug("closing all I/O");
         Thread.sleep(300);
         try {
           closeAll();
         } catch (IOException e) {
           // ignore IOException when closing
         }
-        debugPrint("done");
+        log.debug("done");
       } catch (Throwable th) {
         // ExitException is expected here
         if (!th.getClass().getName().equals("ExitException")) {
-          debugPrint(th);
+          log.debug("Failed to gracefully exit BTrace probe", th);
           BTraceRuntime.handleException(th);
         }
       } finally {
@@ -319,7 +327,7 @@ abstract class Client implements CommandListener {
     try {
       probe = load(btraceCode, ArgsMap.merge(argsMap, args), canLoadPack);
       if (probe == null) {
-        debugPrint("Failed to load BTrace probe code");
+        log.debug("Failed to load BTrace probe code");
         return null;
       }
 
@@ -327,14 +335,14 @@ abstract class Client implements CommandListener {
         probe.checkVerified();
       }
     } catch (Throwable th) {
-      debugPrint(th);
+      log.debug("Filed to load BTrace probe code", th);
       errorExit(th);
       return null;
     }
-    if (isDebug()) {
-      debugPrint("creating BTraceRuntime instance for " + probe.getClassName());
+    if (log.isDebugEnabled()) {
+      log.debug("creating BTraceRuntime instance for {}", probe.getClassName());
     }
-    runtime = BTraceRuntimes.getRuntime(probe.getClassName(), args, this, debug, inst);
+    runtime = BTraceRuntimes.getRuntime(probe.getClassName(), args, this, inst);
     Runtime.getRuntime()
         .addShutdownHook(
             new Thread(
@@ -344,14 +352,14 @@ abstract class Client implements CommandListener {
                   }
                 }));
     if (probe.isClassRenamed()) {
-      if (isDebug()) {
-        debugPrint("class renamed to " + probe.getClassName());
+      if (log.isDebugEnabled()) {
+        log.debug("class renamed to {}", probe.getClassName());
       }
       sendCommand(new RenameCommand(probe.getClassName()));
     }
-    if (isDebug()) {
-      debugPrint("created BTraceRuntime instance for " + probe.getClassName());
-      debugPrint("sending Okay command");
+    if (log.isDebugEnabled()) {
+      log.debug("created BTraceRuntime instance for {}", probe.getClassName());
+      log.debug("sending Okay command");
     }
 
     sendCommand(new StatusCommand());
@@ -361,7 +369,7 @@ abstract class Client implements CommandListener {
       entered = BTraceRuntimeAccess.enter(runtime);
       return probe.register(runtime, transformer);
     } catch (Throwable th) {
-      debugPrint(th);
+      log.debug("Failed to load BTrace probe", th);
       errorExit(th);
       return null;
     } finally {
@@ -382,9 +390,9 @@ abstract class Client implements CommandListener {
   }
 
   private void errorExit(Throwable th) throws IOException {
-    debugPrint("sending error command");
+    log.debug("sending error command");
     sendCommand(new ErrorCommand(th));
-    debugPrint("sending exit command");
+    log.debug("sending exit command");
     sendCommand(new ExitCommand(1));
     closeAll();
   }
@@ -398,22 +406,6 @@ abstract class Client implements CommandListener {
   // package privates below this point
   final boolean isInitialized() {
     return initialized;
-  }
-
-  private void infoPrint(String msg) {
-    DebugSupport.info(msg);
-  }
-
-  final boolean isDebug() {
-    return settings.isDebug();
-  }
-
-  final void debugPrint(String msg) {
-    debug.debug(msg);
-  }
-
-  final void debugPrint(Throwable th) {
-    debug.debug(th);
   }
 
   final BTraceRuntime.Impl getRuntime() {
@@ -438,30 +430,32 @@ abstract class Client implements CommandListener {
 
   private final void startRetransformClasses(int numClasses) {
     sendCommand(new RetransformationStartNotification(numClasses));
-    if (isDebug()) {
-      debugPrint("calling retransformClasses (" + numClasses + " classes to be retransformed)");
+    if (log.isDebugEnabled()) {
+      log.debug("calling retransformClasses ({} classes to be retransformed)", numClasses);
     }
   }
 
   final void endRetransformClasses() {
     sendCommand(new StatusCommand());
-    if (isDebug()) debugPrint("finished retransformClasses");
+    log.debug("finished retransformClasses");
   }
 
   // Internals only below this point
   private BTraceProbe load(byte[] buf, ArgsMap args, boolean canLoadPack) {
     BTraceProbeFactory f = new BTraceProbeFactory(settings, canLoadPack);
-    debugPrint("loading BTrace class");
+    log.debug("loading BTrace class");
     BTraceProbe cn = f.createProbe(buf, args);
 
     if (cn != null) {
-      if (isDebug()) {
-        if (cn.isVerified()) {
-          debugPrint("loaded '" + cn.getClassName() + "' successfully");
-        } else {
-          debugPrint(cn.getClassName() + " failed verification");
-          return null;
+      if (cn.isVerified()) {
+        if (log.isDebugEnabled()) {
+          log.debug("loaded '{}' successfully", cn.getClassName());
         }
+      } else {
+        if (log.isDebugEnabled()) {
+          log.debug("{} failed verification", cn.getClassName());
+        }
+        return null;
       }
     }
     return BTraceProbePersisted.from(cn);
@@ -473,13 +467,15 @@ abstract class Client implements CommandListener {
     }
     if (probe.isTransforming() && settings.isRetransformStartup()) {
       ArrayList<Class<?>> list = new ArrayList<>();
-      debugPrint("retransforming loaded classes");
-      debugPrint("filtering loaded classes");
+      log.debug("retransforming loaded classes");
+      log.debug("filtering loaded classes");
       ClassCache cc = ClassCache.getInstance();
       for (Class<?> c : inst.getAllLoadedClasses()) {
         if (c != null) {
           if (inst.isModifiableClass(c) && isCandidate(c)) {
-            debugPrint("candidate " + c + " added");
+            if (log.isDebugEnabled()) {
+              log.debug("candidate {} added", c);
+            }
             list.add(c);
           }
         }
@@ -490,14 +486,13 @@ abstract class Client implements CommandListener {
         Class<?>[] classes = new Class[size];
         list.toArray(classes);
         startRetransformClasses(size);
-        if (isDebug()) {
+        if (log.isDebugEnabled()) {
           for (Class<?> c : classes) {
             try {
-              debugPrint("Attempting to retransform class: " + c.getName());
+              log.debug("Attempting to retransform class: {}", c.getName());
               inst.retransformClasses(c);
             } catch (ClassFormatError | VerifyError e) {
-              debugPrint("Class '" + c.getName() + "' verification failed");
-              debugPrint(e);
+              log.debug("Class '{}' verification failed", c.getName(), e);
               sendCommand(
                   new MessageCommand(
                       "[BTRACE WARN] Class verification failed: "
@@ -520,8 +515,7 @@ abstract class Client implements CommandListener {
               try {
                 inst.retransformClasses(c);
               } catch (ClassFormatError | VerifyError e1) {
-                debugPrint("Class '" + c.getName() + "' verification failed");
-                debugPrint(e1);
+                log.debug("Class '{}' verification failed", c.getName(), e);
                 sendCommand(
                     new MessageCommand(
                         "[BTRACE WARN] Class verification failed: "

--- a/btrace-agent/src/main/java/org/openjdk/btrace/agent/Main.java
+++ b/btrace-agent/src/main/java/org/openjdk/btrace/agent/Main.java
@@ -80,7 +80,6 @@ import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.Messages;
 import org.openjdk.btrace.core.SharedSettings;
 import org.openjdk.btrace.core.comm.ErrorCommand;
-import org.openjdk.btrace.core.comm.InstrumentCommand;
 import org.openjdk.btrace.core.comm.StatusCommand;
 import org.openjdk.btrace.core.comm.WireIO;
 import org.openjdk.btrace.instr.BTraceTransformer;
@@ -866,7 +865,7 @@ public final class Main {
             } catch (UnmodifiableClassException uce) {
               log.debug("BTrace class retransformation failed", uce);
               client.getRuntime().send(new ErrorCommand(uce));
-              client.getRuntime().send(new StatusCommand(-1 * InstrumentCommand.STATUS_FLAG));
+              client.getRuntime().send(new StatusCommand(-1 * StatusCommand.STATUS_FLAG));
             } finally {
               if (entered) {
                 BTraceRuntime.leave();

--- a/btrace-agent/src/main/java/org/openjdk/btrace/agent/RemoteClient.java
+++ b/btrace-agent/src/main/java/org/openjdk/btrace/agent/RemoteClient.java
@@ -104,10 +104,10 @@ class RemoteClient extends Client {
             try {
               Client client = new RemoteClient(ctx, ois, oos, sock, (InstrumentCommand) cmd);
               initCallback.apply(client).get();
-              client.sendCommand(new StatusCommand(InstrumentCommand.STATUS_FLAG));
+              client.sendCommand(new StatusCommand(StatusCommand.STATUS_FLAG));
               return client;
             } catch (ExecutionException | InterruptedException e) {
-              WireIO.write(oos, new StatusCommand(-1 * InstrumentCommand.STATUS_FLAG));
+              WireIO.write(oos, new StatusCommand(-1 * StatusCommand.STATUS_FLAG));
               throw new IOException(e);
             }
           }

--- a/btrace-agent/src/main/java/org/openjdk/btrace/agent/RemoteClient.java
+++ b/btrace-agent/src/main/java/org/openjdk/btrace/agent/RemoteClient.java
@@ -46,6 +46,8 @@ import org.openjdk.btrace.core.comm.ReconnectCommand;
 import org.openjdk.btrace.core.comm.SetSettingsCommand;
 import org.openjdk.btrace.core.comm.StatusCommand;
 import org.openjdk.btrace.core.comm.WireIO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents a remote client communicated by socket.
@@ -54,6 +56,8 @@ import org.openjdk.btrace.core.comm.WireIO;
  */
 @SuppressWarnings("SynchronizeOnNonFinalField")
 class RemoteClient extends Client {
+  private static final Logger log = LoggerFactory.getLogger(RemoteClient.class);
+
   private final class DelayedCommandExecutor implements Function<Command, Boolean> {
     private final boolean isConnected;
 
@@ -85,7 +89,6 @@ class RemoteClient extends Client {
     SharedSettings settings = ctx.getSettings();
     ObjectInputStream ois = new ObjectInputStream(sock.getInputStream());
     ObjectOutputStream oos = new ObjectOutputStream(sock.getOutputStream());
-    DebugSupport debug = new DebugSupport(settings);
 
     while (true) {
       Command cmd = WireIO.read(ois);
@@ -97,7 +100,7 @@ class RemoteClient extends Client {
           }
         case Command.INSTRUMENT:
           {
-            debug.debug("got instrument command");
+            log.debug("got instrument command");
             try {
               Client client = new RemoteClient(ctx, ois, oos, sock, (InstrumentCommand) cmd);
               initCallback.apply(client).get();
@@ -177,14 +180,14 @@ class RemoteClient extends Client {
                     switch (cmd.getType()) {
                       case Command.EXIT:
                         {
-                          debugPrint("received exit command");
+                          log.debug("received exit command");
                           onCommand(cmd);
 
                           return;
                         }
                       case Command.DISCONNECT:
                         {
-                          debugPrint("received disconnect command");
+                          log.debug("received disconnect command");
                           onCommand(cmd);
                           break;
                         }
@@ -199,13 +202,13 @@ class RemoteClient extends Client {
                           break;
                         }
                       default:
-                        if (isDebug()) {
-                          debugPrint("received " + cmd);
+                        if (log.isDebugEnabled()) {
+                          log.debug("received {}", cmd);
                         }
                         // ignore any other command
                     }
                   } catch (Exception exp) {
-                    debugPrint(exp);
+                    log.debug("Error while processing BTrace command", exp);
                     break;
                   }
                 }
@@ -214,7 +217,7 @@ class RemoteClient extends Client {
               }
             });
     cmdHandler.setDaemon(true);
-    debugPrint("starting client command handler thread");
+    log.debug("starting client command handler thread");
     cmdHandler.start();
   }
 
@@ -228,8 +231,8 @@ class RemoteClient extends Client {
       }
       return;
     }
-    if (isDebug()) {
-      debugPrint("client " + getClassName() + ": got " + cmd);
+    if (log.isDebugEnabled()) {
+      log.debug("client {}: got {}", getClassName(), cmd);
     }
     try {
       boolean isConnected = true;

--- a/btrace-client/build.gradle
+++ b/btrace-client/build.gradle
@@ -3,6 +3,9 @@ plugins {
 }
 
 dependencies {
+    // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
+
     implementation(group: 'org.ow2.asm', name: 'asm', version: "${rootProject.asmVersion}")
     implementation(group: 'org.ow2.asm', name: 'asm-tree', version: "${rootProject.asmVersion}")
     implementation(group: 'org.ow2.asm', name: 'asm-util', version: "${rootProject.asmVersion}")

--- a/btrace-client/src/main/java/org/openjdk/btrace/client/Client.java
+++ b/btrace-client/src/main/java/org/openjdk/btrace/client/Client.java
@@ -52,7 +52,6 @@ import org.objectweb.asm.Type;
 import org.openjdk.btrace.compiler.Compiler;
 import org.openjdk.btrace.core.Args;
 import org.openjdk.btrace.core.BTraceRuntime;
-import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.SharedSettings;
 import org.openjdk.btrace.core.annotations.DTrace;
 import org.openjdk.btrace.core.annotations.DTraceRef;
@@ -68,6 +67,8 @@ import org.openjdk.btrace.core.comm.ReconnectCommand;
 import org.openjdk.btrace.core.comm.SetSettingsCommand;
 import org.openjdk.btrace.core.comm.StatusCommand;
 import org.openjdk.btrace.core.comm.WireIO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class represents a BTrace client. This can be used to create command line as well as a GUI
@@ -77,6 +78,7 @@ import org.openjdk.btrace.core.comm.WireIO;
  * @author A. Sundararajan
  */
 public class Client {
+  private static final Logger log = LoggerFactory.getLogger(Client.class);
 
   private static final String DTRACE_DESC;
   private static final String DTRACE_REF_DESC;
@@ -207,31 +209,31 @@ public class Client {
     if (fileName.endsWith(".java")) {
       Compiler compiler = new Compiler(includePath);
       classPath += File.pathSeparator + System.getProperty("java.class.path");
-      if (debug) {
-        debugPrint("compiling " + fileName);
+      if (log.isDebugEnabled()) {
+        log.debug("compiling {}", fileName);
       }
       Map<String, byte[]> classes = compiler.compile(file, err, ".", classPath);
       if (classes == null) {
-        err.println("btrace compilation failed!");
+        log.error("btrace compilation for script {} failed!", fileName);
         return null;
       }
 
       int size = classes.size();
       if (size != 1) {
-        err.println("no classes or more than one class");
+        log.error("no classes or more than one class in script {}", fileName);
         return null;
       }
       String name = classes.keySet().iterator().next();
       code = classes.get(name);
-      if (debug) {
-        debugPrint("compiled " + fileName);
+      if (log.isDebugEnabled()) {
+        log.debug("compiled {}", fileName);
       }
     } else if (fileName.endsWith(".class")) {
       int codeLen = (int) file.length();
       code = new byte[codeLen];
       try {
-        if (debug) {
-          debugPrint("reading " + fileName);
+        if (log.isDebugEnabled()) {
+          log.debug("reading {}", fileName);
         }
         try (FileInputStream fis = new FileInputStream(file)) {
           int off = 0;
@@ -243,8 +245,8 @@ public class Client {
             }
           } while (off < codeLen && len != -1);
         }
-        if (debug) {
-          debugPrint("read " + fileName);
+        if (log.isDebugEnabled()) {
+          log.debug("read {}", fileName);
         }
       } catch (IOException exp) {
         err.println(exp.getMessage());
@@ -274,7 +276,7 @@ public class Client {
         agentPath = new File(new URI(agentPath)).getAbsolutePath();
         attach(pid, agentPath, sysCp, bootCp);
       } else {
-        warn("Unable to prepare BTrace agent");
+        log.warn("Unable to prepare BTrace agent");
       }
     } catch (RuntimeException | IOException e) {
       throw e;
@@ -291,12 +293,12 @@ public class Client {
   public void attach(String pid, String agentPath, String sysCp, String bootCp) throws IOException {
     try {
       VirtualMachine vm = null;
-      if (debug) {
-        debugPrint("attaching to " + pid);
+      if (log.isDebugEnabled()) {
+        log.debug("attaching to {}", pid);
       }
       vm = VirtualMachine.attach(pid);
-      if (debug) {
-        debugPrint("checking port availability: " + port);
+      if (log.isDebugEnabled()) {
+        log.debug("checking port availability: {}", port);
       }
       Properties serverVmProps = vm.getSystemProperties();
       int serverPort = Integer.parseInt(serverVmProps.getProperty("btrace.port", "-1"));
@@ -317,12 +319,9 @@ public class Client {
         }
       }
 
-      if (debug) {
-        debugPrint("attached to " + pid);
-      }
-
-      if (debug) {
-        debugPrint("loading " + agentPath);
+      if (log.isDebugEnabled()) {
+        log.debug("attached to {}", pid);
+        log.debug("loading {}", agentPath);
       }
       String agentArgs = Args.PORT + "=" + port;
       if (statsdDef != null) {
@@ -358,12 +357,12 @@ public class Client {
         agentArgs += ",=" + Args.CMD_QUEUE_LIMIT + cmdQueueLimit;
       }
       agentArgs += "," + Args.PROBE_DESC_PATH + "=" + probeDescPath;
-      if (debug) {
-        debugPrint("agent args: " + agentArgs);
+      if (log.isDebugEnabled()) {
+        log.debug("agent args: {}", agentArgs);
       }
       vm.loadAgent(agentPath, agentArgs);
-      if (debug) {
-        debugPrint("loaded " + agentPath);
+      if (log.isDebugEnabled()) {
+        log.debug("loaded {}", agentPath);
       }
     } catch (RuntimeException | IOException re) {
       throw re;
@@ -377,32 +376,28 @@ public class Client {
       throw new IllegalStateException();
     }
     try {
-      if (debug) {
-        debugPrint("opening socket to " + port);
+      if (log.isDebugEnabled()) {
+        log.debug("opening socket to {}", port);
       }
       long timeout = System.nanoTime() + TimeUnit.NANOSECONDS.convert(5, TimeUnit.SECONDS);
       while (sock == null && System.nanoTime() <= timeout) {
         try {
           sock = new Socket(host, port);
         } catch (ConnectException e) {
-          if (debug) {
-            debugPrint("server not yet available; retrying ...");
-          }
+          log.debug("server not yet available; retrying ...");
           Thread.sleep(20);
         }
       }
 
       if (sock == null) {
-        debugPrint("server not available. exiting.");
+        log.debug("server not available. exiting.");
         System.exit(1);
       }
       oos = new ObjectOutputStream(sock.getOutputStream());
       WireIO.write(oos, new ListProbesCommand());
       ois = new ObjectInputStream(sock.getInputStream());
 
-      if (debug) {
-        debugPrint("entering into command loop");
-      }
+      log.debug("entering into command loop");
       commandLoop(
           cmd -> {
             if (cmd.getType() == Command.LIST_PROBES) {
@@ -425,36 +420,30 @@ public class Client {
       throw new IllegalStateException();
     }
     try {
-      if (debug) {
-        debugPrint("opening socket to " + port);
+      if (log.isDebugEnabled()) {
+        log.debug("opening socket to {}", port);
       }
       long timeout = System.nanoTime() + TimeUnit.NANOSECONDS.convert(5, TimeUnit.SECONDS);
       while (sock == null && System.nanoTime() <= timeout) {
         try {
           sock = new Socket(host, port);
         } catch (ConnectException e) {
-          if (debug) {
-            debugPrint("server not yet available; retrying ...");
-          }
+          log.debug("server not yet available; retrying ...");
           Thread.sleep(20);
         }
       }
 
       if (sock == null) {
-        debugPrint("server not available. exiting.");
+        log.debug("server not available. exiting.");
         System.exit(1);
       }
       oos = new ObjectOutputStream(sock.getOutputStream());
-      if (debug) {
-        debugPrint("reconnecting client");
-      }
+      log.debug("reconnecting client");
       WireIO.write(oos, new ReconnectCommand(resumeProbe));
 
       ois = new ObjectInputStream(sock.getInputStream());
 
-      if (debug) {
-        debugPrint("entering into command loop");
-      }
+      log.debug("entering into command loop");
       commandLoop(
           new CommandListener() {
             boolean statusReported = false;
@@ -467,15 +456,13 @@ public class Client {
                 StatusCommand statusCommand = (StatusCommand) cmd;
                 if (statusCommand.getFlag() == ReconnectCommand.STATUS_FLAG) {
                   if (statusCommand.isSuccess()) {
-                    DebugSupport.info("Reconnected to an active probe: " + resumeProbe);
+                    log.info("Reconnected to an active probe: {}", resumeProbe);
                     String probeCommand = command[0];
                     String probeCommandArg = command[1];
                     if (probeCommand != null) {
-                      debugPrint(
-                          "Executing remote command '"
-                              + probeCommand
-                              + "'"
-                              + (probeCommandArg != null ? "(" + probeCommandArg + ")" : ""));
+                      if (log.isDebugEnabled()) {
+                        log.debug("Executing remote command '{}'{}", probeCommand, (probeCommandArg != null ? "(" + probeCommandArg + ")" : ""));
+                      }
                       switch (probeCommand) {
                         case "exit":
                           {
@@ -499,7 +486,7 @@ public class Client {
                       }
                     }
                   } else {
-                    DebugSupport.warning("Unable to reconnect to an active probe: " + resumeProbe);
+                    log.warn("Unable to reconnect to an active probe: {}", resumeProbe);
                     System.exit(1);
                   }
                 } else {
@@ -537,29 +524,25 @@ public class Client {
     }
     submitDTrace(fileName, code, args, listener);
     try {
-      if (debug) {
-        debugPrint("opening socket to " + port);
+      if (log.isDebugEnabled()) {
+        log.debug("opening socket to {}", port);
       }
       long timeout = System.nanoTime() + TimeUnit.NANOSECONDS.convert(5, TimeUnit.SECONDS);
       while (sock == null && System.nanoTime() <= timeout) {
         try {
           sock = new Socket(host, port);
         } catch (ConnectException e) {
-          if (debug) {
-            debugPrint("server not yet available; retrying ...");
-          }
+          log.debug("server not yet available; retrying ...");
           Thread.sleep(20);
         }
       }
 
       if (sock == null) {
-        debugPrint("server not available. exiting.");
+        log.debug("server not available. exiting.");
         System.exit(1);
       }
       oos = new ObjectOutputStream(sock.getOutputStream());
-      if (debug) {
-        debugPrint("setting up client settings");
-      }
+      log.debug("setting up client settings");
       Map<String, Object> settings = new HashMap<>();
       settings.put(SharedSettings.DEBUG_KEY, debug);
       settings.put(SharedSettings.DUMP_DIR_KEY, dumpClasses ? dumpDir : "");
@@ -572,16 +555,14 @@ public class Client {
 
       ois = new ObjectInputStream(sock.getInputStream());
 
-      if (debug) {
-        debugPrint("sending instrument command: " + Arrays.deepToString(args));
+      if (log.isDebugEnabled()) {
+        log.debug("sending instrument command: {}", Arrays.deepToString(args));
       }
       SharedSettings sSettings = new SharedSettings();
       sSettings.from(settings);
-      WireIO.write(oos, new InstrumentCommand(code, args, new DebugSupport(sSettings)));
+      WireIO.write(oos, new InstrumentCommand(code, args));
 
-      if (debug) {
-        debugPrint("entering into command loop");
-      }
+      log.debug("entering into command loop");
       commandLoop(
           new CommandListener() {
             boolean statusReported = false;
@@ -594,9 +575,9 @@ public class Client {
                 StatusCommand statusCommand = (StatusCommand) cmd;
                 if (statusCommand.getFlag() == InstrumentCommand.STATUS_FLAG) {
                   if (statusCommand.isSuccess()) {
-                    DebugSupport.info("Successfully started BTrace probe: " + fileName);
+                    log.info("Successfully started BTrace probe: {}", fileName);
                   } else {
-                    DebugSupport.warning("Failed to start BTrace probe: " + fileName);
+                    log.warn("Failed to start BTrace probe: {}", fileName);
                     System.exit(1);
                   }
                   statusReported = true;
@@ -718,12 +699,12 @@ public class Client {
     while (true) {
       try {
         Command cmd = WireIO.read(ois);
-        if (debug) {
-          debugPrint("received " + cmd);
+        if (log.isDebugEnabled()) {
+          log.debug("received command {}", cmd);
         }
         listener.onCommand(cmd);
         if (cmd.getType() == Command.EXIT) {
-          debugPrint("received EXIT cmd");
+          log.debug("received EXIT cmd");
           return;
         }
       } catch (IOException e) {
@@ -736,21 +717,13 @@ public class Client {
     }
   }
 
-  public void debugPrint(String msg) {
-    System.out.println("DEBUG: " + msg);
-  }
-
-  private void warn(String msg) {
-    System.out.println("WARNING: " + msg);
-  }
-
   private void warn(CommandListener listener, String msg) {
     try {
       msg = "WARNING: " + msg + "\n";
       listener.onCommand(new MessageCommand(msg));
     } catch (IOException exp) {
-      if (debug) {
-        exp.printStackTrace();
+      if (log.isDebugEnabled()) {
+        log.debug("Failed to send warning messge", exp);
       }
     }
   }

--- a/btrace-client/src/main/java/org/openjdk/btrace/client/Client.java
+++ b/btrace-client/src/main/java/org/openjdk/btrace/client/Client.java
@@ -461,7 +461,10 @@ public class Client {
                     String probeCommandArg = command[1];
                     if (probeCommand != null) {
                       if (log.isDebugEnabled()) {
-                        log.debug("Executing remote command '{}'{}", probeCommand, (probeCommandArg != null ? "(" + probeCommandArg + ")" : ""));
+                        log.debug(
+                            "Executing remote command '{}'{}",
+                            probeCommand,
+                            (probeCommandArg != null ? "(" + probeCommandArg + ")" : ""));
                       }
                       switch (probeCommand) {
                         case "exit":
@@ -481,7 +484,7 @@ public class Client {
                           }
                         default:
                           {
-                            DebugSupport.warning("Unrecognized BTrace command " + probeCommand);
+                            log.warn("Unrecognized BTrace command {}", probeCommand);
                           }
                       }
                     }
@@ -573,7 +576,7 @@ public class Client {
                 listener.onCommand(cmd);
               } else {
                 StatusCommand statusCommand = (StatusCommand) cmd;
-                if (statusCommand.getFlag() == InstrumentCommand.STATUS_FLAG) {
+                if (statusCommand.getFlag() == StatusCommand.STATUS_FLAG) {
                   if (statusCommand.isSuccess()) {
                     log.info("Successfully started BTrace probe: {}", fileName);
                   } else {

--- a/btrace-client/src/main/java/org/openjdk/btrace/client/JpsUtils.java
+++ b/btrace-client/src/main/java/org/openjdk/btrace/client/JpsUtils.java
@@ -4,13 +4,16 @@ import com.sun.tools.attach.VirtualMachine;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import org.openjdk.btrace.core.DebugSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import sun.jvmstat.monitor.MonitoredHost;
 import sun.jvmstat.monitor.MonitoredVm;
 import sun.jvmstat.monitor.MonitoredVmUtil;
 import sun.jvmstat.monitor.VmIdentifier;
 
 final class JpsUtils {
+  private static final Logger log = LoggerFactory.getLogger(JpsUtils.class);
+
   static Integer findVmByName(String name) {
     try {
       return Integer.parseInt(name);
@@ -28,7 +31,7 @@ final class JpsUtils {
           }
         }
       } catch (Exception e) {
-        DebugSupport.warning(e);
+        log.warn("Unexpected exception", e);
       }
       return pid;
     }
@@ -57,7 +60,7 @@ final class JpsUtils {
         }
       }
     } catch (Exception e) {
-      DebugSupport.warning(e);
+      log.warn("Unexpected exception", e);
     }
     return vms;
   }

--- a/btrace-core/build.gradle
+++ b/btrace-core/build.gradle
@@ -5,6 +5,12 @@ plugins {
 }
 
 dependencies {
+    // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
+
+    // https://mvnrepository.com/artifact/org.slf4j/slf4j-simple
+    implementation(group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.36')
+
     // https://mvnrepository.com/artifact/org.jctools/jctools-core
     implementation(group: 'org.jctools', name: 'jctools-core', version: '3.3.0')
 

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/ArgsMap.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/ArgsMap.java
@@ -30,14 +30,12 @@ import java.util.regex.Pattern;
 /** A simple argument map wrapper allowing indexed access */
 public final class ArgsMap implements Iterable<Map.Entry<String, String>> {
   private final LinkedHashMap<String, String> map;
-  private final DebugSupport debug;
 
-  public ArgsMap(Map<String, String> args, DebugSupport debug) {
+  public ArgsMap(Map<String, String> args) {
     map = args != null ? new LinkedHashMap<>(args) : new LinkedHashMap<>();
-    this.debug = debug;
   }
 
-  public ArgsMap(String[] argLine, DebugSupport debug) {
+  public ArgsMap(String[] argLine) {
     map = new LinkedHashMap<>();
     if (argLine != null) {
       for (String arg : argLine) {
@@ -49,28 +47,22 @@ public final class ArgsMap implements Iterable<Map.Entry<String, String>> {
         }
       }
     }
-    this.debug = debug;
   }
 
   public ArgsMap() {
-    this((Map<String, String>) null, DebugSupport.SHARED);
+    this((Map<String, String>) null);
   }
 
-  public ArgsMap(int initialCapacity, DebugSupport debug) {
+  public ArgsMap(int initialCapacity) {
     map = new LinkedHashMap<>(initialCapacity);
-    this.debug = debug;
   }
 
   public static ArgsMap merge(ArgsMap... maps) {
-    DebugSupport debug = null;
     Map<String, String> propMap = new LinkedHashMap<>();
     for (ArgsMap map : maps) {
-      if (debug == null) {
-        debug = map.debug;
-      }
       propMap.putAll(map.map);
     }
-    return new ArgsMap(propMap, debug);
+    return new ArgsMap(propMap);
   }
 
   public String get(String key) {
@@ -127,7 +119,7 @@ public final class ArgsMap implements Iterable<Map.Entry<String, String>> {
 
   @Override
   public String toString() {
-    return "ArgsMap{" + "map=" + map + ", debug=" + debug + '}';
+    return "ArgsMap{" + "map=" + map + '}';
   }
 
   public String template(String value) {

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/BTraceRuntime.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/BTraceRuntime.java
@@ -68,11 +68,15 @@ import org.openjdk.btrace.core.types.AnyType;
 import org.openjdk.btrace.core.types.BTraceCollection;
 import org.openjdk.btrace.core.types.BTraceDeque;
 import org.openjdk.btrace.core.types.BTraceMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import sun.misc.Unsafe;
 import sun.security.action.GetPropertyAction;
 
 @SuppressWarnings("deprecation")
 public final class BTraceRuntime {
+  private static final Logger log = LoggerFactory.getLogger(BTraceRuntime.class);
+
   public static final String CMD_QUEUE_LIMIT_KEY = "org.openjdk.btrace.core.cmdQueueLimit";
   private static final boolean messageTimestamp = false;
   private static final String LINE_SEPARATOR;
@@ -135,7 +139,7 @@ public final class BTraceRuntime {
         unsafe = Unsafe.getUnsafe();
       }
     } catch (SecurityException e) {
-      DebugSupport.warning("Unable to initialize Unsafe. BTrace will not function properly");
+      log.warn("Unable to initialize Unsafe. BTrace will not function properly");
     }
     return unsafe;
   }
@@ -505,7 +509,7 @@ public final class BTraceRuntime {
       return target.isAssignableFrom(objClass);
     } catch (ClassNotFoundException e) {
       // non-existing class
-      getRt().debugPrint(e);
+      log.debug("Class {} can not be found by classloader {}", className, cl, e);
       return false;
     }
   }
@@ -1197,10 +1201,6 @@ public final class BTraceRuntime {
    * instrumentation, clients)
    */
   public interface Impl {
-    void debugPrint(Throwable t);
-
-    void debugPrint(String msg);
-
     void send(String msg);
 
     void send(Command cmd);

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/BTraceUtils.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/BTraceUtils.java
@@ -55,6 +55,8 @@ import org.openjdk.btrace.core.annotations.ProbeMethodName;
 import org.openjdk.btrace.core.annotations.Self;
 import org.openjdk.btrace.core.jfr.JfrEvent;
 import org.openjdk.btrace.core.types.AnyType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is an all-in-one wrapper for BTrace DSL methods
@@ -63,11 +65,14 @@ import org.openjdk.btrace.core.types.AnyType;
  * @author Jaroslav Bachorik
  */
 public class BTraceUtils {
+  private static final Logger log = LoggerFactory.getLogger(BTraceUtils.class);
+
   // standard stack depth decrement for figuring out the caller class calls
   private static final int STACK_DEC = 2;
 
   static {
     BTraceRuntime.initUnsafe();
+    log.info("BTraceUtils initialized");
   }
 
   // do not allow object creation!

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/InstrumentCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/InstrumentCommand.java
@@ -30,33 +30,29 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Map;
 import org.openjdk.btrace.core.ArgsMap;
-import org.openjdk.btrace.core.DebugSupport;
-import org.openjdk.btrace.core.SharedSettings;
 
 public class InstrumentCommand extends Command {
   public static final int STATUS_FLAG = 1;
 
-  private final DebugSupport debug;
   private byte[] code;
   private ArgsMap args;
 
-  public InstrumentCommand(byte[] code, ArgsMap args, DebugSupport debug) {
+  public InstrumentCommand(byte[] code, ArgsMap args) {
     super(INSTRUMENT, true);
     this.code = code;
     this.args = args;
-    this.debug = debug;
   }
 
-  public InstrumentCommand(byte[] code, String[] args, DebugSupport debug) {
-    this(code, new ArgsMap(args, debug), debug);
+  public InstrumentCommand(byte[] code, String[] args) {
+    this(code, new ArgsMap(args));
   }
 
-  public InstrumentCommand(byte[] code, Map<String, String> args, DebugSupport debug) {
-    this(code, new ArgsMap(args, debug), debug);
+  public InstrumentCommand(byte[] code, Map<String, String> args) {
+    this(code, new ArgsMap(args));
   }
 
   protected InstrumentCommand() {
-    this(null, (Map<String, String>) null, new DebugSupport(SharedSettings.GLOBAL));
+    this(null, (Map<String, String>) null);
   }
 
   @Override
@@ -77,7 +73,7 @@ public class InstrumentCommand extends Command {
     code = new byte[len];
     in.readFully(code);
     len = in.readInt();
-    args = new ArgsMap(len, debug);
+    args = new ArgsMap(len);
     for (int i = 0; i < len; i++) {
       String key = in.readUTF();
       String val = in.readUTF();

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/InstrumentCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/InstrumentCommand.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import org.openjdk.btrace.core.ArgsMap;
 
 public class InstrumentCommand extends Command {
-  public static final int STATUS_FLAG = 1;
 
   private byte[] code;
   private ArgsMap args;

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/StatusCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/StatusCommand.java
@@ -30,6 +30,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
 public class StatusCommand extends Command {
+  public static final int STATUS_FLAG = 1;
   // custom flag
   private int flag;
 

--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -79,6 +79,7 @@ task agentJar(type: ShadowJar) {
     configurations = [project.configurations.artifact]
     relocate 'org.jctools', 'org.openjdk.btrace.libs.org.jctools'
     relocate 'org.objectweb.asm', 'org.openjdk.btrace.libs.org.objectweb.asm'
+    relocate 'org.slf4j', 'org.openjdk.btrace.libs.org.slf4j'
 }
 
 task bootJar(type: ShadowJar) {
@@ -117,7 +118,7 @@ task bootJar(type: ShadowJar) {
             }
             return true
         }
-        return it.path.startsWith('org/openjdk/btrace/runtime/') ||
+        return it.path.startsWith("org/slf4j/") || it.path.startsWith('org/openjdk/btrace/runtime/') ||
                 it.path.startsWith('org/openjdk/btrace/services/') ||
                 it.path.startsWith('org/openjdk/btrace/statsd/')
     }
@@ -125,6 +126,7 @@ task bootJar(type: ShadowJar) {
     configurations = [project.configurations.artifact]
     relocate 'org.jctools', 'org.openjdk.btrace.libs.org.jctools'
     relocate 'org.objectweb.asm', 'org.openjdk.btrace.libs.org.objectweb.asm'
+    relocate 'org.slf4j', 'org.openjdk.btrace.libs.org.slf4j'
 }
 
 task clientJar(type: ShadowJar) {
@@ -154,6 +156,7 @@ task clientJar(type: ShadowJar) {
     configurations = [project.configurations.artifact]
     relocate 'org.jctools', 'org.openjdk.btrace.libs.org.jctools'
     relocate 'org.objectweb.asm', 'org.openjdk.btrace.libs.org.objectweb.asm'
+    relocate 'org.slf4j', 'org.openjdk.btrace.libs.org.slf4j'
 }
 
 task fixPermissions(type: Exec) {

--- a/btrace-instr/build.gradle
+++ b/btrace-instr/build.gradle
@@ -18,6 +18,8 @@ sourceSets {
 }
 
 dependencies {
+    // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
     implementation group: 'org.ow2.asm', name: 'asm', version: "${rootProject.asmVersion}"
     implementation group: 'org.ow2.asm', name: 'asm-tree', version: "${rootProject.asmVersion}"
     implementation group: 'com.google.auto.service', name: 'auto-service', version: '1.0.1'

--- a/btrace-instr/src/main/java/org/openjdk/btrace/instr/BTraceBCPClassLoader.java
+++ b/btrace-instr/src/main/java/org/openjdk/btrace/instr/BTraceBCPClassLoader.java
@@ -6,16 +6,18 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
-import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.SharedSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class BTraceBCPClassLoader extends URLClassLoader {
+  private static final Logger log = LoggerFactory.getLogger(BTraceBCPClassLoader.class);
+
   BTraceBCPClassLoader(SharedSettings settings) {
     super(getBCPUrls(settings), null);
   }
 
   private static URL[] getBCPUrls(SharedSettings settings) {
-    DebugSupport debug = new DebugSupport(settings);
     String bcp = settings.getBootClassPath();
     if (bcp != null && !bcp.isEmpty()) {
       List<URL> urls = new ArrayList<>();
@@ -23,7 +25,7 @@ final class BTraceBCPClassLoader extends URLClassLoader {
         try {
           urls.add(new File(cpElement).toURI().toURL());
         } catch (MalformedURLException e) {
-          debug.debug(e);
+          log.debug("Invalid classpath definition: {}", cpElement, e);
         }
       }
       return urls.toArray(new URL[0]);

--- a/btrace-instr/src/main/java/org/openjdk/btrace/instr/BTraceMethodNode.java
+++ b/btrace-instr/src/main/java/org/openjdk/btrace/instr/BTraceMethodNode.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.MethodNode;
-import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.annotations.Kind;
 import org.openjdk.btrace.core.annotations.Sampled;
 import org.openjdk.btrace.core.annotations.Where;
@@ -41,7 +40,6 @@ public class BTraceMethodNode extends MethodNode {
   private final BTraceProbeNode cn;
   private final CallGraph graph;
   private final String methodId;
-  private final DebugSupport debug;
   private OnMethod om;
   private OnProbe op;
   private Location loc;
@@ -63,7 +61,6 @@ public class BTraceMethodNode extends MethodNode {
     this.cn = cn;
     graph = cn.getGraph();
     methodId = CallGraph.methodId(name, desc);
-    debug = cn.debug;
     isBTraceHandler = initBTraceHandler;
   }
 
@@ -90,7 +87,7 @@ public class BTraceMethodNode extends MethodNode {
       isBTraceHandler = true;
     }
     if (type.equals(Constants.ONMETHOD_DESC)) {
-      om = new OnMethod(this, debug);
+      om = new OnMethod(this);
       om.setTargetName(name);
       om.setTargetDescriptor(desc);
       return new AnnotationVisitor(Opcodes.ASM7, av) {

--- a/btrace-instr/src/main/java/org/openjdk/btrace/instr/BTraceProbeFactory.java
+++ b/btrace-instr/src/main/java/org/openjdk/btrace/instr/BTraceProbeFactory.java
@@ -50,8 +50,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import org.openjdk.btrace.core.ArgsMap;
-import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.SharedSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A factory class for {@link BTraceProbeNode} instances
@@ -59,8 +60,9 @@ import org.openjdk.btrace.core.SharedSettings;
  * @author Jaroslav Bachorik
  */
 public final class BTraceProbeFactory {
+  private static final Logger log = LoggerFactory.getLogger(BTraceProbeFactory.class);
+
   private final SharedSettings settings;
-  private final DebugSupport debug;
   private final boolean canLoadPack;
 
   public BTraceProbeFactory(SharedSettings settings) {
@@ -69,7 +71,6 @@ public final class BTraceProbeFactory {
 
   public BTraceProbeFactory(SharedSettings settings, boolean canLoadPack) {
     this.settings = settings;
-    debug = new DebugSupport(settings);
     this.canLoadPack = canLoadPack;
   }
 
@@ -104,7 +105,7 @@ public final class BTraceProbeFactory {
           bpp.read(dis);
           bp = bpp;
         } catch (IOException e) {
-          debug.debug(e);
+          log.debug("Failed to read BTrace pack", e);
         }
       }
     } else {
@@ -134,9 +135,7 @@ public final class BTraceProbeFactory {
         bp = new BTraceProbeNode(this, code);
       }
     } catch (IOException e) {
-      if (debug.isDebug()) {
-        debug.debug(e);
-      }
+      log.debug("Failed to create a probe", e);
     }
 
     applyArgs(bp, argsMap);

--- a/btrace-instr/src/main/java/org/openjdk/btrace/instr/BTraceProbeNode.java
+++ b/btrace-instr/src/main/java/org/openjdk/btrace/instr/BTraceProbeNode.java
@@ -458,7 +458,7 @@ public final class BTraceProbeNode extends ClassNode implements BTraceProbe {
         Class.forName("javax.xml.bind.JAXBException");
         mapOnProbes();
       } catch (ClassNotFoundException e) {
-        log.debug("XML bindings are missing. @OnProbe support is disabled.", e);
+        log.debug("XML bindings are missing. @OnProbe support is disabled.");
       }
     } catch (VerifierException e) {
       verifierException = e;

--- a/btrace-instr/src/main/java/org/openjdk/btrace/instr/BTraceProbeSupport.java
+++ b/btrace-instr/src/main/java/org/openjdk/btrace/instr/BTraceProbeSupport.java
@@ -32,26 +32,27 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import org.openjdk.btrace.core.ArgsMap;
 import org.openjdk.btrace.core.BTraceRuntime;
-import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.runtime.BTraceRuntimeAccess;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class BTraceProbeSupport {
+  private static final Logger log = LoggerFactory.getLogger(BTraceProbeSupport.class);
+
   private final List<OnMethod> onMethods;
   private final List<OnProbe> onProbes;
   private final Map<String, String> serviceFields;
 
   private final Object filterLock = new Object();
-  private final DebugSupport debug;
   private volatile ClassFilter filter;
   private boolean trustedScript = false;
   private boolean classRenamed = false;
   private String className, origName;
 
-  BTraceProbeSupport(DebugSupport dbg) {
+  BTraceProbeSupport() {
     onMethods = new ArrayList<>();
     onProbes = new ArrayList<>();
     serviceFields = new HashMap<>();
-    debug = dbg;
   }
 
   void setClassName(String name) {
@@ -203,12 +204,12 @@ public final class BTraceProbeSupport {
       // without BTraceRuntime.enter(). Please look at the
       // static initializer code of trace class.
       BTraceRuntime.leave();
-      if (debug.isDebug()) {
-        debug.debug("about to defineClass " + getClassName(true));
+      if (log.isDebugEnabled()) {
+        log.debug("about to defineClass {}", getClassName(false));
       }
       Class<?> clz = rt.defineClass(code, isTransforming());
-      if (debug.isDebug()) {
-        debug.debug("defineClass succeeded for " + getClassName(false));
+      if (log.isDebugEnabled()) {
+        log.debug("defineClass succeeded for {}", getClassName(false));
       }
       return clz;
     } finally {

--- a/btrace-instr/src/main/java/org/openjdk/btrace/instr/ClassInfo.java
+++ b/btrace-instr/src/main/java/org/openjdk/btrace/instr/ClassInfo.java
@@ -32,7 +32,8 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
-import org.openjdk.btrace.core.DebugSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Arbitrary class info type allowing access to supertype information also for not-already-loaded
@@ -41,6 +42,8 @@ import org.openjdk.btrace.core.DebugSupport;
  * @author Jaroslav Bachorik
  */
 public final class ClassInfo {
+  private static final Logger log = LoggerFactory.getLogger(ClassInfo.class);
+
   private static final ClassLoader SYS_CL = ClassLoader.getSystemClassLoader();
   private static volatile Method BSTRP_CHECK_MTD;
   private final String cLoaderId;
@@ -97,7 +100,7 @@ public final class ClassInfo {
         } catch (Throwable t) {
           // some containers can impose additional restrictions on loading resources and error on
           // unexpected state
-          DebugSupport.warning(t);
+          log.warn("Failed to get resource {}", rsrcName, t);
         }
         prev = cl;
         cl = cl.getParent();
@@ -113,7 +116,7 @@ public final class ClassInfo {
         return m.invoke(SYS_CL, className) != null;
       }
     } catch (Throwable t) {
-      DebugSupport.warning(t);
+      log.warn("Unable to check for class {} being loaded by bootstrap classloader", className, t);
     }
     return false;
   }
@@ -127,7 +130,7 @@ public final class ClassInfo {
       m = ClassLoader.class.getDeclaredMethod("findBootstrapClassOrNull", String.class);
       m.setAccessible(true);
     } catch (Throwable t) {
-      DebugSupport.warning(t);
+      log.warn("Can not resolve method 'findBootstrapClassOrNull'", t);
     }
     BSTRP_CHECK_MTD = m;
     return BSTRP_CHECK_MTD;
@@ -212,14 +215,13 @@ public final class ClassInfo {
           }
           isAvailable = true;
         } catch (IllegalArgumentException | IOException e) {
-          DebugSupport.warning("Unable to load class: " + className);
-          DebugSupport.warning(e);
+          log.warn("Unable to load class: {}", className, e);
         }
       }
     } catch (Throwable t) {
       // some containers can impose additional restrictions on classloaders throwing exceptions when
       // not in expected state
-      DebugSupport.warning(t);
+      log.warn("Failed to load class {}", className, t);
     }
   }
 

--- a/btrace-instr/src/main/java/org/openjdk/btrace/instr/HandlerRepositoryImpl.java
+++ b/btrace-instr/src/main/java/org/openjdk/btrace/instr/HandlerRepositoryImpl.java
@@ -11,8 +11,11 @@ import org.objectweb.asm.ClassWriter;
 import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.HandlerRepository;
 import org.openjdk.btrace.core.SharedSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class HandlerRepositoryImpl {
+  private static final Logger log = LoggerFactory.getLogger(HandlerRepositoryImpl.class);
 
   private static final Map<String, BTraceProbe> probeMap = new ConcurrentHashMap<>();
 
@@ -24,7 +27,7 @@ public final class HandlerRepositoryImpl {
     } catch (UnsupportedClassVersionError ignored) {
       // expected for pre Java 15 runtimes
     } catch (Throwable t) {
-      DebugSupport.warning(t);
+      log.warn("Unable to initialize BTrace Indy support", t);
     }
   }
 
@@ -61,7 +64,7 @@ public final class HandlerRepositoryImpl {
     if (debugSupport.isDumpClasses()) {
       try {
         String handlerPath = "/tmp/" + handlerClassName.replace('/', '_') + ".class";
-        debugSupport.debug("BTrace INDY handler dumped: " + handlerPath);
+        log.debug("BTrace INDY handler dumped: {}", handlerPath);
         Files.write(Paths.get(handlerPath), data, StandardOpenOption.CREATE);
       } catch (IOException e) {
         e.printStackTrace();

--- a/btrace-instr/src/main/java/org/openjdk/btrace/instr/InstrumentingMethodVisitor.java
+++ b/btrace-instr/src/main/java/org/openjdk/btrace/instr/InstrumentingMethodVisitor.java
@@ -39,7 +39,8 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.TypePath;
-import org.openjdk.btrace.core.DebugSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A method visitor providing support for introducing new local variables in bytecode recomputing
@@ -48,6 +49,8 @@ import org.openjdk.btrace.core.DebugSupport;
  */
 public final class InstrumentingMethodVisitor extends MethodVisitor
     implements MethodInstrumentorHelper {
+  private static final Logger log = LoggerFactory.getLogger(InstrumentingMethodVisitor.class);
+
   private static final Object TOP_EXT = -2;
   private final VariableMapper variableMapper;
   private final SimulatedStack stack = new SimulatedStack();
@@ -1325,7 +1328,7 @@ public final class InstrumentingMethodVisitor extends MethodVisitor
       return Constants.TOP_TYPE;
     }
     if (slotType instanceof Integer) {
-      DebugSupport.warning("Unknown slot type: " + slotType);
+      log.warn("Unknown slot type: {}", slotType);
       return Constants.OBJECT_TYPE;
     }
     return slotType != null ? Type.getObjectType((String) slotType) : Constants.OBJECT_TYPE;

--- a/btrace-instr/src/main/java/org/openjdk/btrace/instr/OnMethod.java
+++ b/btrace-instr/src/main/java/org/openjdk/btrace/instr/OnMethod.java
@@ -45,8 +45,6 @@
 package org.openjdk.btrace.instr;
 
 import org.openjdk.btrace.core.ArgsMap;
-import org.openjdk.btrace.core.DebugSupport;
-import org.openjdk.btrace.core.SharedSettings;
 import org.openjdk.btrace.core.annotations.Sampled;
 
 /**
@@ -59,7 +57,6 @@ import org.openjdk.btrace.core.annotations.Sampled;
  * @author A. Sundararajan
  */
 public final class OnMethod extends SpecialParameterHolder {
-  private final DebugSupport debug;
   private String clazz;
   private String method = "";
   private boolean exactTypeMatch;
@@ -81,17 +78,11 @@ public final class OnMethod extends SpecialParameterHolder {
   private BTraceMethodNode bmn;
 
   public OnMethod() {
-    this(new DebugSupport(SharedSettings.GLOBAL));
-  }
-
-  public OnMethod(DebugSupport debug) {
     // need this to deserialize from the probe descriptor
-    this.debug = debug;
   }
 
-  public OnMethod(BTraceMethodNode bmn, DebugSupport debug) {
+  public OnMethod(BTraceMethodNode bmn) {
     this.bmn = bmn;
-    this.debug = debug;
   }
 
   public void copyFrom(OnMethod other) {

--- a/btrace-instr/src/main/java/org/openjdk/btrace/instr/Preprocessor.java
+++ b/btrace-instr/src/main/java/org/openjdk/btrace/instr/Preprocessor.java
@@ -186,16 +186,11 @@ final class Preprocessor {
   private final Map<String, AnnotationNode> eventFlds = new HashMap<>();
   private final Map<String, AnnotationNode> injectedFlds = new HashMap<>();
   private final Map<String, Integer> serviceLocals = new HashMap<>();
-  private final DebugSupport debug;
   private MethodNode clinit = null;
   private FieldNode rtField = null;
 
   private final Map<MethodNode, EnumSet<MethodClassifier>> classifierMap = new HashMap<>();
   private AbstractInsnNode clinitEntryPoint;
-
-  public Preprocessor(DebugSupport debug) {
-    this.debug = debug;
-  }
 
   public static AnnotationNode getAnnotation(FieldNode fn, Type annotation) {
     if (fn == null || (fn.visibleAnnotations == null && fn.invisibleAnnotations == null))

--- a/btrace-instr/src/test/java/org/openjdk/btrace/BTraceFunctionalTests.java
+++ b/btrace-instr/src/test/java/org/openjdk/btrace/BTraceFunctionalTests.java
@@ -366,20 +366,22 @@ public class BTraceFunctionalTests extends RuntimeTest {
 
   @Test
   public void testOnMethodUnattended() throws Exception {
-    debugBTrace = true;
-    debugTestApp = true;
     TestApp testApp = launchTestApp("resources.Main");
     File traceFile = locateTrace("btrace/OnMethodTest.java");
 
     String pid = String.valueOf(testApp.getPid());
     String[] probeId = new String[1];
     AtomicBoolean hasError = new AtomicBoolean(false);
+    System.out.println("===> btrace -x");
+
+    // a workaround - for some reason the btrace output is not captured in the client in tests here
+    debugBTrace = true;
     runBTrace(
         new String[] {"-x", pid, traceFile.toString()},
         new ProcessOutputProcessor() {
           @Override
           public boolean onStdout(int lineno, String line) {
-            if (lineno > 50) {
+            if (lineno > 200) {
               return false;
             }
             System.out.println("[btrace #" + lineno + "] " + line);
@@ -405,6 +407,7 @@ public class BTraceFunctionalTests extends RuntimeTest {
     assertNotNull(probeId[0]);
 
     final boolean[] found = new boolean[] {false};
+    System.out.println("===> btrace -lp");
     runBTrace(
         new String[] {"-lp", pid},
         new ProcessOutputProcessor() {
@@ -430,13 +433,14 @@ public class BTraceFunctionalTests extends RuntimeTest {
     assertTrue(found[0]);
 
     found[0] = false;
+    System.out.println("===> btrace -r");
     runBTrace(
         new String[] {"-r", probeId[0], "exit", pid},
         new ProcessOutputProcessor() {
           @Override
           public boolean onStdout(int lineno, String line) {
-            System.out.println("===> " + line);
-            if (lineno > 3) {
+            System.out.println("[btrace #" + lineno + "] " + line);
+            if (lineno > 1000) {
               return false;
             }
             if (line.contains(probeId[0])) {

--- a/btrace-instr/src/test/java/org/openjdk/btrace/RuntimeTest.java
+++ b/btrace-instr/src/test/java/org/openjdk/btrace/RuntimeTest.java
@@ -637,9 +637,11 @@ public abstract class RuntimeTest {
                 "-d",
                 "/tmp/btrace-test",
                 "-pd",
-                traceFile.getParentFile().getAbsolutePath(),
-                pid,
-                traceFile.getAbsolutePath()));
+                traceFile.getParentFile().getAbsolutePath()));
+    if (debugBTrace) {
+      argVals.add("-v");
+    }
+    argVals.addAll(Arrays.asList(pid, traceFile.getAbsolutePath()));
     if (cmdArgs != null) {
       argVals.addAll(Arrays.asList(cmdArgs));
     }
@@ -706,7 +708,7 @@ public abstract class RuntimeTest {
                 while ((line = br.readLine()) != null) {
                   stdout.append(line).append('\n');
                   System.out.println("[btrace out] " + line);
-                  if (!(debugBTrace && line.contains("DEBUG:"))) {
+                  if (!(debugBTrace && line.contains("DEBUG"))) {
                     l.countDown();
                   }
                 }

--- a/btrace-instr/src/test/java/org/openjdk/btrace/instr/OnMethodTest.java
+++ b/btrace-instr/src/test/java/org/openjdk/btrace/instr/OnMethodTest.java
@@ -26,16 +26,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openjdk.btrace.core.ArgsMap;
-import org.openjdk.btrace.core.DebugSupport;
-import org.openjdk.btrace.core.SharedSettings;
 
 public class OnMethodTest {
   private ArgsMap instance;
 
   @BeforeEach
   public void setUp() {
-    DebugSupport debug = new DebugSupport(SharedSettings.GLOBAL);
-    instance = new ArgsMap(new String[] {"className=ClassA", "methodName=methodA"}, debug);
+    instance = new ArgsMap(new String[] {"className=ClassA", "methodName=methodA"});
   }
 
   @Test

--- a/btrace-instr/src/test/java/org/openjdk/btrace/instr/ProbeLoaderUpgradeTest.java
+++ b/btrace-instr/src/test/java/org/openjdk/btrace/instr/ProbeLoaderUpgradeTest.java
@@ -41,7 +41,6 @@ public class ProbeLoaderUpgradeTest {
               @Override
               public void onCommand(Command cmd) throws IOException {}
             },
-            null,
             null);
 
     BTraceProbe bp;

--- a/btrace-runtime/build.gradle
+++ b/btrace-runtime/build.gradle
@@ -62,6 +62,9 @@ dependencies {
         builtBy compileJava
     }
 
+    // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
+
     // https://mvnrepository.com/artifact/org.jctools/jctools-core
     implementation(group: 'org.jctools', name: 'jctools-core', version: '3.3.0')
 

--- a/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimeAccess.java
+++ b/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimeAccess.java
@@ -34,7 +34,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.openjdk.btrace.core.BTraceRuntime;
-import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.comm.Command;
 import org.openjdk.btrace.core.handlers.ErrorHandler;
 import org.openjdk.btrace.core.handlers.EventHandler;
@@ -43,6 +42,8 @@ import org.openjdk.btrace.core.handlers.LowMemoryHandler;
 import org.openjdk.btrace.core.handlers.TimerHandler;
 import org.openjdk.btrace.runtime.auxiliary.Auxiliary;
 import org.openjdk.btrace.services.api.RuntimeContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base class form multiple Java version specific implementation.
@@ -56,6 +57,8 @@ import org.openjdk.btrace.services.api.RuntimeContext;
  * @author KLynch
  */
 public abstract class BTraceRuntimeAccess implements RuntimeContext {
+  private static final Logger log = LoggerFactory.getLogger(BTraceRuntimeAccess.class);
+
   static final class RTWrapper {
     private BTraceRuntime.Impl rt = null;
 
@@ -247,24 +250,7 @@ public abstract class BTraceRuntimeAccess implements RuntimeContext {
         | IllegalArgumentException
         | NoSuchFieldException
         | SecurityException e) {
-      DebugSupport.warning(e);
+      log.warn("Failed to register runtime accessor", e);
     }
-  }
-
-  static void debugPrint0(String msg) {
-    BTraceRuntimeImplBase rt = getCurrent();
-    if (rt != null) {
-      rt.debugPrint(msg);
-    } else {
-      DebugSupport.info(msg);
-    }
-  }
-
-  private static void warning(String msg) {
-    DebugSupport.warning(msg);
-  }
-
-  private static void warning(Throwable t) {
-    DebugSupport.warning(t);
   }
 }

--- a/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimeImplFactory.java
+++ b/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimeImplFactory.java
@@ -3,7 +3,6 @@ package org.openjdk.btrace.runtime;
 import java.lang.instrument.Instrumentation;
 import org.openjdk.btrace.core.ArgsMap;
 import org.openjdk.btrace.core.BTraceRuntime;
-import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.comm.CommandListener;
 
 public abstract class BTraceRuntimeImplFactory<T extends BTraceRuntime.Impl> {
@@ -18,11 +17,7 @@ public abstract class BTraceRuntimeImplFactory<T extends BTraceRuntime.Impl> {
   }
 
   public abstract T getRuntime(
-      String className,
-      ArgsMap args,
-      CommandListener cmdListener,
-      DebugSupport ds,
-      Instrumentation inst);
+      String className, ArgsMap args, CommandListener cmdListener, Instrumentation inst);
 
   public abstract boolean isEnabled();
 }

--- a/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimeImpl_8.java
+++ b/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimeImpl_8.java
@@ -32,7 +32,6 @@ import java.security.AccessController;
 import java.util.Set;
 import org.openjdk.btrace.core.ArgsMap;
 import org.openjdk.btrace.core.BTraceRuntime;
-import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.comm.CommandListener;
 import org.openjdk.btrace.core.jfr.JfrEvent;
 import sun.misc.Perf;
@@ -58,12 +57,8 @@ public final class BTraceRuntimeImpl_8 extends BTraceRuntimeImplBase {
 
     @Override
     public BTraceRuntimeImpl_8 getRuntime(
-        String className,
-        ArgsMap args,
-        CommandListener cmdListener,
-        DebugSupport ds,
-        Instrumentation inst) {
-      return new BTraceRuntimeImpl_8(className, args, cmdListener, ds, inst);
+        String className, ArgsMap args, CommandListener cmdListener, Instrumentation inst) {
+      return new BTraceRuntimeImpl_8(className, args, cmdListener, inst);
     }
 
     @Override
@@ -102,12 +97,8 @@ public final class BTraceRuntimeImpl_8 extends BTraceRuntimeImplBase {
   }
 
   public BTraceRuntimeImpl_8(
-      String className,
-      ArgsMap args,
-      CommandListener cmdListener,
-      DebugSupport ds,
-      Instrumentation inst) {
-    super(className, args, cmdListener, ds, inst);
+      String className, ArgsMap args, CommandListener cmdListener, Instrumentation inst) {
+    super(className, args, cmdListener, inst);
     boolean jfr = false;
     try {
       Class.forName("jdk.jfr.Event");
@@ -194,7 +185,7 @@ public final class BTraceRuntimeImpl_8 extends BTraceRuntimeImplBase {
   @Override
   public JfrEvent.Factory createEventFactory(JfrEvent.Template template) {
     if (hasJfr) {
-      JfrEventFactoryImpl factory = new JfrEventFactoryImpl(template, debug);
+      JfrEventFactoryImpl factory = new JfrEventFactoryImpl(template);
       eventFactories.add(factory);
       return factory;
     }

--- a/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/JfrEventImpl.java
+++ b/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/JfrEventImpl.java
@@ -2,18 +2,19 @@ package org.openjdk.btrace.runtime;
 
 import java.util.Map;
 import jdk.jfr.Event;
-import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.jfr.JfrEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class JfrEventImpl extends JfrEvent {
+  private static final Logger log = LoggerFactory.getLogger(JfrEventImpl.class);
+
   private final Event event;
   private final Map<String, Integer> fieldIndex;
-  private final DebugSupport debug;
 
-  JfrEventImpl(Event event, Map<String, Integer> fieldIndex, DebugSupport debug) {
+  JfrEventImpl(Event event, Map<String, Integer> fieldIndex) {
     this.event = event;
     this.fieldIndex = fieldIndex;
-    this.debug = debug;
   }
 
   @Override
@@ -110,7 +111,9 @@ class JfrEventImpl extends JfrEvent {
 
   private boolean checkField(String fieldName) {
     if (!fieldIndex.containsKey(fieldName)) {
-      DebugSupport.warning("Invalid event field: " + fieldName);
+      if (log.isDebugEnabled()) {
+        log.debug("Invalid event field: {}", fieldName);
+      }
       return false;
     }
     return true;

--- a/btrace-runtime/src/main/java11/org/openjdk/btrace/runtime/BTraceRuntimeImpl_11.java
+++ b/btrace-runtime/src/main/java11/org/openjdk/btrace/runtime/BTraceRuntimeImpl_11.java
@@ -41,7 +41,6 @@ import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
 import jdk.jfr.EventType;
 import org.openjdk.btrace.core.ArgsMap;
-import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.comm.CommandListener;
 import org.openjdk.btrace.core.jfr.JfrEvent;
 import org.openjdk.btrace.runtime.auxiliary.Auxiliary;
@@ -64,12 +63,8 @@ public final class BTraceRuntimeImpl_11 extends BTraceRuntimeImplBase {
 
     @Override
     public BTraceRuntimeImpl_11 getRuntime(
-        String className,
-        ArgsMap args,
-        CommandListener cmdListener,
-        DebugSupport ds,
-        Instrumentation inst) {
-      return new BTraceRuntimeImpl_11(className, args, cmdListener, ds, inst);
+        String className, ArgsMap args, CommandListener cmdListener, Instrumentation inst) {
+      return new BTraceRuntimeImpl_11(className, args, cmdListener, inst);
     }
 
     @Override
@@ -93,12 +88,8 @@ public final class BTraceRuntimeImpl_11 extends BTraceRuntimeImplBase {
   public BTraceRuntimeImpl_11() {}
 
   public BTraceRuntimeImpl_11(
-      String className,
-      ArgsMap args,
-      CommandListener cmdListener,
-      DebugSupport ds,
-      Instrumentation inst) {
-    super(className, args, cmdListener, ds, fixExports(inst));
+      String className, ArgsMap args, CommandListener cmdListener, Instrumentation inst) {
+    super(className, args, cmdListener, fixExports(inst));
   }
 
   private static Instrumentation fixExports(Instrumentation instr) {
@@ -224,7 +215,7 @@ public final class BTraceRuntimeImpl_11 extends BTraceRuntimeImplBase {
 
   @Override
   public JfrEvent.Factory createEventFactory(JfrEvent.Template template) {
-    JfrEventFactoryImpl factory = new JfrEventFactoryImpl(template, debug);
+    JfrEventFactoryImpl factory = new JfrEventFactoryImpl(template);
     eventFactories.add(factory);
     return factory;
   }

--- a/btrace-runtime/src/main/java9/org/openjdk/btrace/runtime/BTraceRuntimeImpl_9.java
+++ b/btrace-runtime/src/main/java9/org/openjdk/btrace/runtime/BTraceRuntimeImpl_9.java
@@ -40,7 +40,6 @@ import jdk.internal.perf.Perf;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
 import org.openjdk.btrace.core.ArgsMap;
-import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.comm.CommandListener;
 import org.openjdk.btrace.core.jfr.JfrEvent;
 import org.openjdk.btrace.runtime.auxiliary.Auxiliary;
@@ -62,12 +61,8 @@ public final class BTraceRuntimeImpl_9 extends BTraceRuntimeImplBase {
 
     @Override
     public BTraceRuntimeImpl_9 getRuntime(
-        String className,
-        ArgsMap args,
-        CommandListener cmdListener,
-        DebugSupport ds,
-        Instrumentation inst) {
-      return new BTraceRuntimeImpl_9(className, args, cmdListener, ds, inst);
+        String className, ArgsMap args, CommandListener cmdListener, Instrumentation inst) {
+      return new BTraceRuntimeImpl_9(className, args, cmdListener, inst);
     }
 
     @Override
@@ -89,12 +84,8 @@ public final class BTraceRuntimeImpl_9 extends BTraceRuntimeImplBase {
   public BTraceRuntimeImpl_9() {}
 
   public BTraceRuntimeImpl_9(
-      String className,
-      ArgsMap args,
-      CommandListener cmdListener,
-      DebugSupport ds,
-      Instrumentation inst) {
-    super(className, args, cmdListener, ds, fixExports(inst));
+      String className, ArgsMap args, CommandListener cmdListener, Instrumentation inst) {
+    super(className, args, cmdListener, fixExports(inst));
   }
 
   private static Instrumentation fixExports(Instrumentation instr) {


### PR DESCRIPTION
This PR is introducing SLF4J SimpleLogger as a replacement for a very sub-par BTrace logging implementation.

In addition to using a standard logging API the SimpleLogger also provides a few configuration knobs (https://www.slf4j.org/api/org/slf4j/impl/SimpleLogger.html).

The downside is that the logging level is shared amongst all the deployed probes and the loggers are not dynamically reconfigured. Given that such behaviour is already quite ill defined and not running with debug verbosity is mostly useful when debugging a particular problem this might turn out to be a non-problem.