### PR TITLE
Returning false if file does not end with .class

### DIFF
--- a/btrace-agent/src/main/java/org/openjdk/btrace/agent/Main.java
+++ b/btrace-agent/src/main/java/org/openjdk/btrace/agent/Main.java
@@ -750,6 +750,10 @@ public final class Main {
   }
 
   private static boolean loadBTraceScript(String filePath, boolean traceToStdOut) {
+    if (!filePath.endsWith(".class")) {
+      return false;
+    }
+
     try {
       String scriptName = "";
       String scriptParent = "";


### PR DESCRIPTION
When using scriptOutputDir as a param to -javaagent, the folder might contain non Java class files. Ensuring that the files loaded into BTrace is a .class file.