### PR TITLE
Platform agnosticism

### DIFF
--- a/benchmarks/agent-benchmark/build.gradle
+++ b/benchmarks/agent-benchmark/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 task btracec(type: JavaExec) {
   group 'Build'
   inputs.files 'src/main/resources/scripts'
-  outputs.dir "${buildDir}/classes/java/main"
+  outputs.dir buildDir.toPath().resolve("classes/java/main")
 
   environment('BTRACE_HOME', "$projectDir")
   classpath configurations.implementation
@@ -53,8 +53,9 @@ jmh {
   fork = 2
   jvm = "${env['JAVA_HOME']}/bin/java"
   duplicateClassesStrategy = DuplicatesStrategy.WARN
-  def agent = "-javaagent:${project.buildDir}/../../../btrace-dist/build/resources/main/${project.version}/libs/btrace-agent.jar=stdout=true,noServer=true,debug=true,script=${project.buildDir}/classes/java/main/TraceScript.btclass"
-  println(agent)
-  jvmArgsAppend = ["\"-Djmh.basedir=${project.buildDir}/.. -Dproject.version=${project.version} -Xmx128m ${agent.toString()}\""]
+  def agentJarPath = tasks.getByPath(':btrace-dist:agentJar').outputs.getFiles().getSingleFile()
+  def scriptPath = buildDir.toPath().resolve('classes/java/main/TraceScript.btclass')
+  def agent = "-javaagent:${agentJarPath}=stdout=true,noServer=true,debug=true,script=${scriptPath}"
+  jvmArgsAppend = ["\"-Djmh.basedir=${buildDir.getParentFile()} -Dproject.version=${project.version} -Xmx128m ${agent}\""]
   includes = ['.*BTraceBench.*']
 }

--- a/benchmarks/runtime-benchmarks/build.gradle
+++ b/benchmarks/runtime-benchmarks/build.gradle
@@ -60,7 +60,7 @@ jmhJar {
 
 jmh {
   duplicateClassesStrategy = DuplicatesStrategy.WARN
-  jvmArgsAppend = ["-Djmh.basedir=${project.buildDir}/..", "-Dproject.version=${project.version}"]
+  jvmArgsAppend = ["-Djmh.basedir=${project.buildDir.getParent()}", "-Dproject.version=${project.version}"]
 //  jmhVersion = '1.27'
   includes = ['org.openjdk.btrace.bench.ClassFilterBenchmark']
   verbosity = 'EXTRA'

--- a/btrace-compiler/src/main/java/org/openjdk/btrace/compiler/CompilerHelper.java
+++ b/btrace-compiler/src/main/java/org/openjdk/btrace/compiler/CompilerHelper.java
@@ -140,7 +140,7 @@ class CompilerHelper {
     OutputStream os = null;
     try {
       name = name.replace(".", "_") + ".class";
-      File f = new File("/tmp/" + name);
+      File f = new File(System.getProperty("java.io.tmpdir"), name);
       if (!f.exists()) {
         f.getParentFile().createNewFile();
       }

--- a/btrace-instr/build.gradle
+++ b/btrace-instr/build.gradle
@@ -44,9 +44,9 @@ task compileTestProbes {
 
         def loader = new URLClassLoader(path.collect { f -> f.toURL() } as URL[])
         def compiler = loader.loadClass('org.openjdk.btrace.compiler.Compiler')
-        def rtCp = sourceSets.main.runtimeClasspath.collect { it.absolutePath }.join(':')
+        def rtCp = sourceSets.main.runtimeClasspath
 
-        def args = ["-cp", "${buildDir}/classes/java/test:${buildDir}/classes/java/java11_dummy:${rtCp}", "-d", "${buildDir}/classes"]
+        def args = ["-cp", rtCp.plus(files(buildDir.toPath().resolve("classes/java/test"), buildDir.toPath().resolve("classes/java/java11_dummy"))).getAsPath(), "-d", buildDir.toPath().resolve("classes")]
 
         def files = fileTree(dir: "src/test/btrace", include: '**/*.java', exclude: 'verifier/**/*.java').findAll {
             it != null
@@ -61,7 +61,6 @@ task compileTestProbes {
 test {
     dependsOn cleanTest
     inputs.files compileTestProbes.outputs
-    //inputs.files buildDTrace.outputs
     testLogging.showStandardStreams = true
 
     def props = new Properties()

--- a/btrace-instr/src/test/java/org/openjdk/btrace/instr/InstrumentorTest.java
+++ b/btrace-instr/src/test/java/org/openjdk/btrace/instr/InstrumentorTest.java
@@ -25,8 +25,8 @@
 package org.openjdk.btrace.instr;
 
 import java.lang.reflect.Field;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -5635,7 +5635,7 @@ public class InstrumentorTest extends InstrumentorTestBase {
     loadTargetClass("OnMethodTest");
     transform("TLSTest");
 
-    Files.write(FileSystems.getDefault().getPath("/tmp/TLSTest.class"), traceCode);
+    Files.write(Paths.get(System.getProperty("java.io.tmpdir"), "TLSTest.class"), traceCode);
 
     checkTrace(
         "public static Lorg/openjdk/btrace/core/BTraceRuntime; runtime\n"

--- a/btrace-instr/src/test/java/org/openjdk/btrace/instr/InstrumentorTestBase.java
+++ b/btrace-instr/src/test/java/org/openjdk/btrace/instr/InstrumentorTestBase.java
@@ -262,7 +262,7 @@ public abstract class InstrumentorTestBase {
     transformedBC = cw.instrument();
 
     if (transformedBC != null) {
-      try (OutputStream os = new FileOutputStream("/tmp/dummy.class")) {
+      try (OutputStream os = new FileOutputStream(new File(System.getProperty("java.io.tmpdir"), "dummy.class"))) {
         os.write(transformedBC);
       }
     } else {
@@ -356,7 +356,7 @@ public abstract class InstrumentorTestBase {
     if (DEBUG) {
       System.err.println("=== Loaded Trace: " + bcn + "\n");
       System.err.println(asmify(this.traceCode));
-      Files.write(FileSystems.getDefault().getPath("/tmp/jingle.class"), traceCode);
+      Files.write(FileSystems.getDefault().getPath(System.getProperty("java.io.tmpdir"), "jingle.class"), traceCode);
     }
 
     bcn.checkVerified();

--- a/integration-tests/src/test/java/tests/RuntimeTest.java
+++ b/integration-tests/src/test/java/tests/RuntimeTest.java
@@ -416,7 +416,7 @@ public abstract class RuntimeTest {
                 "-cp",
                 eventsClassPath,
                 "-d",
-                "/tmp/btrace-test"));
+                Paths.get(System.getProperty("java.io.tmpdir"), "btrace-test").toString()));
     argVals.addAll(Arrays.asList(args));
     String testJavaHome = System.getenv("TEST_JAVA_HOME");
     testJavaHome = testJavaHome != null ? testJavaHome : System.getenv("JAVA_HOME");
@@ -512,7 +512,7 @@ public abstract class RuntimeTest {
                 "-cp",
                 eventsClassPath,
                 "-d",
-                "/tmp/btrace-test"));
+                Paths.get(System.getProperty("java.io.tmpdir"), "btrace-test").toString()));
     argVals.addAll(Arrays.asList(args));
     if (Files.exists(Paths.get(System.getenv("TEST_JAVA_HOME"), "jmods"))) {
       argVals.addAll(
@@ -656,7 +656,7 @@ public abstract class RuntimeTest {
                 "-cp",
                 eventsClassPath,
                 "-d",
-                "/tmp/btrace-test",
+                Paths.get(System.getProperty("java.io.tmpdir"), "btrace-test").toString(),
                 "-pd",
                 traceFile.getParentFile().getAbsolutePath()));
     if (debugBTrace) {


### PR DESCRIPTION
Use Gradle-provided getAsPath() on FileCollections.
Replace '/tmp' usages by System.getProperty("java.io.tmpdir").
