### PR TITLE
Add the required jctools classes to the client jar.

### DIFF
--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -144,8 +144,16 @@ task clientJar(type: ShadowJar) {
     exclude 'org/checkerframework/**'
     exclude 'org/codehaus/**'
 
-    exclude 'org/jctools/maps/**'
-    exclude 'org/jctools/util/**'
+    exclude {
+        it.path.startsWith('org/jctools/maps/') &&
+        !it.path.startsWith("org/jctools/maps/NonBlockingIdentityHashMap") &&
+        !it.path.startsWith("org/jctools/maps/NonBlockingHashMap")
+    }
+    exclude {
+        // 'org/jctools/util/**'
+        it.path.startsWith('org/jctools/util/') &&
+        !it.path.startsWith("org/jctools/util/UnsafeAccess")
+    }
     exclude 'META-INF/services/com.sun.*'
     exclude 'META-INF/services/javax.annotation.*'
 


### PR DESCRIPTION
There was an omission in the packaging when some JCTools classes required by the compiler didn't end up in the client jar.

This PR is adding those classes.

Fixes #632