### PR TITLE
Do not drop CHECKCAST instructions

### DIFF
--- a/btrace-compiler/src/main/java/org/openjdk/btrace/compiler/Postprocessor.java
+++ b/btrace-compiler/src/main/java/org/openjdk/btrace/compiler/Postprocessor.java
@@ -271,7 +271,7 @@ public class Postprocessor extends ClassVisitor {
         case Opcodes.DLOAD:
           {
             simulatedStack.push(Boolean.FALSE);
-            // long and double occoupy 2 stack slots; fall through
+            // long and double occupy 2 stack slots; fall through
           }
         case Opcodes.ILOAD:
         case Opcodes.FLOAD:
@@ -283,7 +283,7 @@ public class Postprocessor extends ClassVisitor {
         case Opcodes.DSTORE:
           {
             simulatedStack.poll();
-            // long and double occoupy 2 stack slots; fall through
+            // long and double occupy 2 stack slots; fall through
           }
         case Opcodes.ASTORE:
         case Opcodes.ISTORE:

--- a/btrace-compiler/src/main/java/org/openjdk/btrace/compiler/Verifier.java
+++ b/btrace-compiler/src/main/java/org/openjdk/btrace/compiler/Verifier.java
@@ -65,7 +65,7 @@ import org.openjdk.btrace.core.annotations.BTrace;
  * @author A. Sundararajan
  */
 @SupportedAnnotationTypes("*")
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class Verifier extends AbstractProcessor implements TaskListener {
   private final List<String> classNames = new ArrayList<>();
   private final List<CompilationUnitTree> compUnits = new ArrayList<>();

--- a/btrace-compiler/src/test/java/org/openjdk/btrace/compiler/TypeErasureTest.java
+++ b/btrace-compiler/src/test/java/org/openjdk/btrace/compiler/TypeErasureTest.java
@@ -1,0 +1,47 @@
+package org.openjdk.btrace.compiler;
+
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.util.CheckClassAdapter;
+import org.openjdk.btrace.core.SharedSettings;
+import org.openjdk.btrace.instr.BTraceProbe;
+import org.openjdk.btrace.instr.BTraceProbeFactory;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URL;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TypeErasureTest {
+    @Test
+    void testTypeErasure() throws Exception {
+        URL input = TypeErasureTest.class.getResource("/HistoProbe.java");
+        File inputFile = new File(input.toURI());
+        Map<String, byte[]> data =
+                new Compiler(true)
+                        .compile(
+                                inputFile,
+                                new PrintWriter(System.err),
+                                null,
+                                System.getProperty("java.class.path"));
+        BTraceProbeFactory factory = new BTraceProbeFactory(SharedSettings.GLOBAL);
+        for (byte[] bytes : data.values()) {
+            BTraceProbe probe = factory.createProbe(bytes);
+            verifyCode(probe.getFullBytecode());
+            verifyCode(probe.getDataHolderBytecode());
+        }
+    }
+
+    private void verifyCode(byte[] code) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        CheckClassAdapter.verify(new ClassReader(code), true, pw);
+        if (sw.toString().contains("AnalyzerException")) {
+            System.err.println(sw);
+            fail();
+        }
+    }
+}

--- a/btrace-compiler/src/test/resources/HistoProbe.java
+++ b/btrace-compiler/src/test/resources/HistoProbe.java
@@ -1,0 +1,27 @@
+package test;
+
+import static org.openjdk.btrace.core.BTraceUtils.*;
+import org.openjdk.btrace.core.annotations.*;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@BTrace public class HistoProbe {
+    private static Map<String, AtomicInteger> histo = newHashMap();
+    @OnMethod(clazz = "javax.swing.JComponent", method = "<init>")
+    public static void onMethod(@Self Object obj) {
+        String cn = name(classOf(obj));
+        AtomicInteger ai = get((Map<String, AtomicInteger>)histo, cn);
+        if (ai == null) {
+            ai = newAtomicInteger(1);
+            put(histo, cn, ai);
+        } else {
+            incrementAndGet(ai);	// WORKS if commented out
+        }
+    }
+
+    @OnTimer(1000)
+    public static void print() {
+        printNumberMap("Component Histogram", histo);
+    }
+}

--- a/btrace-instr/src/main/java/org/openjdk/btrace/instr/BTraceProbeSupport.java
+++ b/btrace-instr/src/main/java/org/openjdk/btrace/instr/BTraceProbeSupport.java
@@ -82,7 +82,7 @@ public final class BTraceProbeSupport {
   }
 
   boolean isTransforming() {
-    return onMethods.size() > 0;
+    return !onMethods.isEmpty();
   }
 
   Collection<OnMethod> getApplicableHandlers(BTraceClassReader cr) {

--- a/btrace-instr/src/main/java/org/openjdk/btrace/instr/MethodVerifier.java
+++ b/btrace-instr/src/main/java/org/openjdk/btrace/instr/MethodVerifier.java
@@ -261,6 +261,7 @@ final class MethodVerifier extends StackTrackingMethodVisitor {
       }
       Verifier.reportError("no.new.object", desc);
     }
+    super.visitTypeInsn(opcode, desc);
   }
 
   @Override


### PR DESCRIPTION
`MethodVerifier` was erroneously dropping `CHECKCAST` instructions, breaking verification for things like generified map access etc.

Fixes #644