### PR TITLE
Workaround functional test failures on JDK 22

### DIFF
--- a/btrace-client/src/main/java/org/openjdk/btrace/client/Main.java
+++ b/btrace-client/src/main/java/org/openjdk/btrace/client/Main.java
@@ -29,6 +29,10 @@ import java.io.Console;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Properties;
+
 import org.openjdk.btrace.core.DebugSupport;
 import org.openjdk.btrace.core.Messages;
 import org.openjdk.btrace.core.comm.Command;
@@ -83,8 +87,20 @@ public final class Main {
       if (log.isDebugEnabled()) log.debug("dumpDir is {}", DUMP_DIR);
     }
     PROBE_DESC_PATH = System.getProperty("com.sun.btrace.probeDescPath", ".");
-    con = System.console();
+    String javaVersion = getJavaVersion();
+    // In Java 22 the console will write standard output to stderr :shrug:
+    con = javaVersion == null || !javaVersion.startsWith("22") ? System.console() : null;
     out = getOutWriter(con);
+  }
+
+  private static String getJavaVersion() {
+    Properties props = new Properties();
+    try {
+      props.load(Files.newInputStream(Paths.get(System.getenv("JAVA_HOME"), "release")));
+      return props.getProperty("JAVA_VERSION").replace("\"", "");
+    } catch (IOException ignored) {
+      return null;
+    }
   }
 
   @SuppressWarnings("DefaultCharset")

--- a/integration-tests/src/test/java/tests/RuntimeTest.java
+++ b/integration-tests/src/test/java/tests/RuntimeTest.java
@@ -151,6 +151,7 @@ public abstract class RuntimeTest {
     }
     args.add("-XX:+AllowRedefinitionToAddDeleteMethods");
     args.add("-XX:+IgnoreUnrecognizedVMOptions");
+    args.add("-XX:+EnableDynamicAgentLoading");
     // uncomment the following line to get extra JFR logs
     //    args.add("-Xlog:jfr*=trace");
     args.addAll(extraJvmArgs);


### PR DESCRIPTION
For unknown reasons the JDK 22 `Console` is writing by default to stderr. This will confuse the functional tests.

The workaround is not to use console for JDK 22 until the problem is resolved.