### PR TITLE
Fix grgit-core dependency resolution issue

### DIFF
--- a/btrace-client/build.gradle
+++ b/btrace-client/build.gradle
@@ -1,3 +1,7 @@
+buildscript { scriptHandler ->
+    apply from: rootProject.file('buildSrc/shared.gradle'), to: scriptHandler
+}
+
 plugins {
     alias(libs.plugins.versioning)
 }

--- a/btrace-core/build.gradle
+++ b/btrace-core/build.gradle
@@ -1,5 +1,9 @@
 import org.apache.tools.ant.filters.*
 
+buildscript { scriptHandler ->
+    apply from: rootProject.file('buildSrc/shared.gradle'), to: scriptHandler
+}
+
 plugins {
     alias(libs.plugins.versioning)
 }

--- a/btrace-ui/build.gradle
+++ b/btrace-ui/build.gradle
@@ -1,3 +1,7 @@
+buildscript { scriptHandler ->
+    apply from: rootProject.file('buildSrc/shared.gradle'), to: scriptHandler
+}
+
 plugins {
   alias(libs.plugins.versioning)
 }

--- a/buildSrc/shared.gradle
+++ b/buildSrc/shared.gradle
@@ -1,0 +1,10 @@
+configurations.all {
+    resolutionStrategy.eachDependency { details ->
+        if (details.requested.group == 'org.ajoberstar.grgit' &&
+                details.requested.name == 'grgit-core' &&
+                details.requested.version == '4.0.1') {
+            details.useVersion '4.1.1'
+            details.because '4.0.1 has been removed'
+        }
+    }
+}


### PR DESCRIPTION
By using the version 4.1.1 instead of 4.0.1.
The version 4.0.1 has been removed from the Maven Central Repository.

It can be found on JCenter repository,
so the dependency issue can also be fixed by following configuration in settings.gradle:

```groovy
pluginManagement {
    repositories {
        jcenter()
        gradlePluginPortal()
    }
}
```

But JCenter repository is deprecated and unreliable.

Fixes #631