### PR TITLE
fix: Use Long constants in Minimum/Maximum clear() methods

### DIFF
--- a/btrace-core/src/main/java/org/openjdk/btrace/core/aggregation/Maximum.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/aggregation/Maximum.java
@@ -37,7 +37,7 @@ class Maximum implements AggregationValue {
 
   @Override
   public synchronized void clear() {
-    max = Integer.MIN_VALUE;
+    max = Long.MIN_VALUE;
   }
 
   @Override

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/aggregation/Minimum.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/aggregation/Minimum.java
@@ -37,7 +37,7 @@ class Minimum implements AggregationValue {
 
   @Override
   public synchronized void clear() {
-    min = Integer.MAX_VALUE;
+    min = Long.MAX_VALUE;
   }
 
   @Override

--- a/btrace-core/src/test/java/org/openjdk/btrace/core/aggregation/MaximumTest.java
+++ b/btrace-core/src/test/java/org/openjdk/btrace/core/aggregation/MaximumTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the Classpath exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.btrace.core.aggregation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MaximumTest {
+
+  private Maximum maximum;
+
+  @BeforeEach
+  void setUp() {
+    maximum = new Maximum();
+  }
+
+  @Test
+  void testInitialValue() {
+    assertEquals(Long.MIN_VALUE, maximum.getValue(),
+        "Initial maximum should be Long.MIN_VALUE");
+  }
+
+  @Test
+  void testSimpleMaximum() {
+    maximum.add(10);
+    maximum.add(30);
+    maximum.add(20);
+    assertEquals(30L, maximum.getValue(), "Maximum of 10, 30, 20 should be 30");
+  }
+
+  @Test
+  void testNegativeValues() {
+    maximum.add(-50);
+    maximum.add(-10);
+    maximum.add(-100);
+    assertEquals(-10L, maximum.getValue(), "Maximum should handle negative values");
+  }
+
+  @Test
+  void testMixedValues() {
+    maximum.add(-50);
+    maximum.add(100);
+    maximum.add(0);
+    assertEquals(100L, maximum.getValue(), "Maximum of mixed values should be 100");
+  }
+
+  @Test
+  void testLargeValues() {
+    long largeValue1 = Long.MAX_VALUE - 100;
+    long largeValue2 = Long.MAX_VALUE - 50;
+    maximum.add(largeValue1);
+    maximum.add(largeValue2);
+
+    assertEquals(largeValue2, maximum.getValue(),
+        "Maximum should handle large values correctly");
+  }
+
+  @Test
+  void testValuesExceedingIntegerRange() {
+    // Test values > Integer.MAX_VALUE
+    long value1 = 3_000_000_000L;  // > Integer.MAX_VALUE
+    long value2 = 4_000_000_000L;
+
+    maximum.add(value1);
+    maximum.add(value2);
+
+    assertEquals(value2, maximum.getValue(),
+        "Maximum should work correctly with values > Integer.MAX_VALUE");
+  }
+
+  @Test
+  void testClearResetsToLongMinValue() {
+    maximum.add(100);
+    maximum.add(200);
+    assertEquals(200L, maximum.getValue());
+
+    maximum.clear();
+    assertEquals(Long.MIN_VALUE, maximum.getValue(),
+        "After clear(), maximum should reset to Long.MIN_VALUE");
+  }
+
+  @Test
+  void testClearThenAddLargeValue() {
+    maximum.add(100);
+    maximum.clear();
+
+    // Add a value > Integer.MAX_VALUE
+    long largeValue = 3_000_000_000L;
+    maximum.add(largeValue);
+
+    assertEquals(largeValue, maximum.getValue(),
+        "After clear(), should correctly track values > Integer.MAX_VALUE");
+  }
+
+  @Test
+  void testClearDoesNotTruncateToIntRange() {
+    // This test specifically validates the bug fix:
+    // clear() should set max = Long.MIN_VALUE, not Integer.MIN_VALUE
+
+    maximum.add(-1000);
+    maximum.clear();
+
+    // Add a value between Integer.MIN_VALUE and Long.MIN_VALUE
+    long valueInLongRange = (long) Integer.MIN_VALUE - 1000L;
+    maximum.add(valueInLongRange);
+
+    // If clear() incorrectly used Integer.MIN_VALUE, this comparison would fail
+    // because Integer.MIN_VALUE > valueInLongRange
+    assertEquals(valueInLongRange, maximum.getValue(),
+        "After clear(), maximum should use Long.MIN_VALUE not Integer.MIN_VALUE");
+  }
+
+  @Test
+  void testGetData() {
+    maximum.add(42);
+
+    Object data = maximum.getData();
+    assertInstanceOf(Long.class, data, "getData should return Long");
+    assertEquals(42L, data, "getData should return same as getValue");
+  }
+
+  @Test
+  void testZero() {
+    maximum.add(0);
+    maximum.add(100);
+    maximum.add(-100);
+
+    assertEquals(100L, maximum.getValue(), "Maximum should correctly handle zero");
+  }
+
+  @Test
+  void testSingleValue() {
+    maximum.add(42);
+    assertEquals(42L, maximum.getValue(), "Maximum of single value should be that value");
+  }
+
+  @Test
+  void testLongMaxValue() {
+    maximum.add(Long.MIN_VALUE);
+    maximum.add(0);
+    maximum.add(Long.MAX_VALUE);
+
+    assertEquals(Long.MAX_VALUE, maximum.getValue(),
+        "Maximum should correctly handle Long.MAX_VALUE");
+  }
+}

--- a/btrace-core/src/test/java/org/openjdk/btrace/core/aggregation/MinimumTest.java
+++ b/btrace-core/src/test/java/org/openjdk/btrace/core/aggregation/MinimumTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the Classpath exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.btrace.core.aggregation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MinimumTest {
+
+  private Minimum minimum;
+
+  @BeforeEach
+  void setUp() {
+    minimum = new Minimum();
+  }
+
+  @Test
+  void testInitialValue() {
+    assertEquals(Long.MAX_VALUE, minimum.getValue(),
+        "Initial minimum should be Long.MAX_VALUE");
+  }
+
+  @Test
+  void testSimpleMinimum() {
+    minimum.add(30);
+    minimum.add(10);
+    minimum.add(20);
+    assertEquals(10L, minimum.getValue(), "Minimum of 30, 10, 20 should be 10");
+  }
+
+  @Test
+  void testNegativeValues() {
+    minimum.add(-10);
+    minimum.add(-50);
+    minimum.add(-5);
+    assertEquals(-50L, minimum.getValue(), "Minimum should handle negative values");
+  }
+
+  @Test
+  void testMixedValues() {
+    minimum.add(100);
+    minimum.add(-50);
+    minimum.add(0);
+    assertEquals(-50L, minimum.getValue(), "Minimum of mixed values should be -50");
+  }
+
+  @Test
+  void testLargeValues() {
+    long largeValue1 = Long.MAX_VALUE - 100;
+    long largeValue2 = Long.MAX_VALUE - 50;
+    minimum.add(largeValue2);
+    minimum.add(largeValue1);
+
+    assertEquals(largeValue1, minimum.getValue(),
+        "Minimum should handle large values correctly");
+  }
+
+  @Test
+  void testValuesExceedingIntegerRange() {
+    // Test values > Integer.MAX_VALUE
+    long value1 = 3_000_000_000L;  // > Integer.MAX_VALUE
+    long value2 = 4_000_000_000L;
+
+    minimum.add(value2);
+    minimum.add(value1);
+
+    assertEquals(value1, minimum.getValue(),
+        "Minimum should work correctly with values > Integer.MAX_VALUE");
+  }
+
+  @Test
+  void testClearResetsToLongMaxValue() {
+    minimum.add(10);
+    minimum.add(5);
+    assertEquals(5L, minimum.getValue());
+
+    minimum.clear();
+    assertEquals(Long.MAX_VALUE, minimum.getValue(),
+        "After clear(), minimum should reset to Long.MAX_VALUE");
+  }
+
+  @Test
+  void testClearThenAddLargeValue() {
+    minimum.add(100);
+    minimum.clear();
+
+    // Add a value > Integer.MAX_VALUE
+    long largeValue = 3_000_000_000L;
+    minimum.add(largeValue);
+
+    assertEquals(largeValue, minimum.getValue(),
+        "After clear(), should correctly track values > Integer.MAX_VALUE");
+  }
+
+  @Test
+  void testClearDoesNotTruncateToIntRange() {
+    // This test specifically validates the bug fix:
+    // clear() should set min = Long.MAX_VALUE, not Integer.MAX_VALUE
+
+    minimum.add(100);
+    minimum.clear();
+
+    // Add a value between Integer.MAX_VALUE and Long.MAX_VALUE
+    long valueInLongRange = (long) Integer.MAX_VALUE + 1000L;
+    minimum.add(valueInLongRange);
+
+    // If clear() incorrectly used Integer.MAX_VALUE, this comparison would fail
+    // because Integer.MAX_VALUE < valueInLongRange
+    assertEquals(valueInLongRange, minimum.getValue(),
+        "After clear(), minimum should use Long.MAX_VALUE not Integer.MAX_VALUE");
+  }
+
+  @Test
+  void testGetData() {
+    minimum.add(42);
+
+    Object data = minimum.getData();
+    assertInstanceOf(Long.class, data, "getData should return Long");
+    assertEquals(42L, data, "getData should return same as getValue");
+  }
+
+  @Test
+  void testZero() {
+    minimum.add(0);
+    minimum.add(100);
+    minimum.add(-100);
+
+    assertEquals(-100L, minimum.getValue(), "Minimum should correctly handle zero");
+  }
+
+  @Test
+  void testSingleValue() {
+    minimum.add(42);
+    assertEquals(42L, minimum.getValue(), "Minimum of single value should be that value");
+  }
+
+  @Test
+  void testLongMinValue() {
+    minimum.add(Long.MIN_VALUE);
+    minimum.add(0);
+    minimum.add(Long.MAX_VALUE);
+
+    assertEquals(Long.MIN_VALUE, minimum.getValue(),
+        "Minimum should correctly handle Long.MIN_VALUE");
+  }
+}


### PR DESCRIPTION
## Problem

The `Minimum` and `Maximum` aggregation functions had a **type mismatch bug** in their `clear()` methods that caused incorrect behavior when tracking values outside the 32-bit integer range.

### Buggy Code:

**Minimum.java (line 40):**
```java
long min = Long.MAX_VALUE;  // Initialized as long

@Override
public synchronized void clear() {
    min = Integer.MAX_VALUE;  // ❌ Reset with Integer constant!
}
```

**Maximum.java (line 40):**
```java
long max = Long.MIN_VALUE;  // Initialized as long

@Override
public synchronized void clear() {
    max = Integer.MIN_VALUE;  // ❌ Reset with Integer constant!
}
```

### Impact:

#### Minimum Bug:
- After `clear()`, `min` is set to `Integer.MAX_VALUE` (2,147,483,647)
- If you then add a value like `3,000,000,000L` (which exceeds Integer range):
  - Comparison: `3,000,000,000 < 2,147,483,647` → **false** ❌
  - The large value is incorrectly ignored as "not minimum"
  - Result: Wrong minimum tracked

#### Maximum Bug:
- After `clear()`, `max` is set to `Integer.MIN_VALUE` (-2,147,483,648)
- If you then add a very negative value like `-3,000,000,000L`:
  - Comparison: `-3,000,000,000 > -2,147,483,648` → **false** ❌
  - The very negative value is incorrectly ignored as "not maximum"
  - Result: Wrong maximum tracked

## Solution

Use the correct `Long` constants to match the field type:

```java
// Minimum.java
@Override
public synchronized void clear() {
    min = Long.MAX_VALUE;  // ✅ Correct
}

// Maximum.java
@Override
public synchronized void clear() {
    max = Long.MIN_VALUE;  // ✅ Correct
}
```

## Testing

Added comprehensive test suites for both classes:

### MinimumTest.java (13 tests)
- ✅ Initial value is Long.MAX_VALUE
- ✅ Simple minimum operations
- ✅ Values exceeding Integer.MAX_VALUE
- ✅ clear() resets to Long.MAX_VALUE (not Integer.MAX_VALUE)
- ✅ After clear(), correctly tracks large values
- ✅ Negative values, mixed values, boundary conditions

### MaximumTest.java (13 tests)
- ✅ Initial value is Long.MIN_VALUE
- ✅ Simple maximum operations
- ✅ Values exceeding Integer range
- ✅ clear() resets to Long.MIN_VALUE (not Integer.MIN_VALUE)
- ✅ After clear(), correctly tracks very negative values
- ✅ Negative values, mixed values, boundary conditions

**All 26 tests pass** ✅

## Verification

### Before (with bug):
```java
Minimum min = new Minimum();
min.add(100);
min.clear();
min.add(3_000_000_000L);  // > Integer.MAX_VALUE
System.out.println(min.getValue());
// Expected: 3000000000
// Actual: 2147483647  ❌ (Integer.MAX_VALUE - wrong!)
```

### After (fixed):
```java
Minimum min = new Minimum();
min.add(100);
min.clear();
min.add(3_000_000_000L);
System.out.println(min.getValue());
// Result: 3000000000  ✅ (correct!)
```

## Review Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests added for the fixed bug
- [x] All tests pass (26/26)
- [x] No breaking API changes
- [x] No dependencies added

## Priority
🔴 **CRITICAL** - This bug causes incorrect aggregation results for values outside 32-bit range

---

Part of btrace-core analysis and improvement initiative.