### PR TITLE
fix: Add type safety validation for Command deserialization

### DIFF
--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/ErrorCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/ErrorCommand.java
@@ -49,7 +49,12 @@ public class ErrorCommand extends Command implements PrintableCommand {
 
   @Override
   protected void read(ObjectInput in) throws IOException, ClassNotFoundException {
-    cause = (Throwable) in.readObject();
+    Object obj = in.readObject();
+    if (obj != null && !(obj instanceof Throwable)) {
+      throw new IOException(
+          "Invalid data type: expected Throwable, got " + obj.getClass().getName());
+    }
+    cause = (Throwable) obj;
   }
 
   public Throwable getCause() {

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/NumberDataCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/NumberDataCommand.java
@@ -69,6 +69,11 @@ public class NumberDataCommand extends DataCommand {
   @Override
   protected void read(ObjectInput in) throws IOException, ClassNotFoundException {
     name = in.readUTF();
-    value = (Number) in.readObject();
+    Object obj = in.readObject();
+    if (obj != null && !(obj instanceof Number)) {
+      throw new IOException(
+          "Invalid data type: expected Number, got " + obj.getClass().getName());
+    }
+    value = (Number) obj;
   }
 }

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/SetSettingsCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/SetSettingsCommand.java
@@ -64,10 +64,21 @@ public class SetSettingsCommand extends Command {
   @Override
   protected void read(ObjectInput in) throws IOException, ClassNotFoundException {
     int size = in.readInt();
+    if (size < 0 || size > 10000) { // Reasonable limit to prevent memory exhaustion
+      throw new IOException("Invalid params size: " + size);
+    }
     for (int i = 0; i < size; i++) {
       String k = in.readUTF();
       Object v = in.readObject();
-
+      // Validate that value is a reasonable settings type
+      if (v != null
+          && !(v instanceof String)
+          && !(v instanceof Number)
+          && !(v instanceof Boolean)) {
+        throw new IOException(
+            "Invalid settings value type: expected String/Number/Boolean, got "
+                + v.getClass().getName());
+      }
       params.put(k, v);
     }
   }

--- a/btrace-core/src/test/java/org/openjdk/btrace/core/comm/TypeSafetyTest.java
+++ b/btrace-core/src/test/java/org/openjdk/btrace/core/comm/TypeSafetyTest.java
@@ -226,3 +226,4 @@ class TypeSafetyTest {
     return clazz.cast(result);
   }
 }
+

--- a/btrace-core/src/test/java/org/openjdk/btrace/core/comm/TypeSafetyTest.java
+++ b/btrace-core/src/test/java/org/openjdk/btrace/core/comm/TypeSafetyTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the Classpath exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.btrace.core.comm;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for type safety validation in Command deserialization.
+ * These tests ensure that malformed or malicious data cannot cause
+ * ClassCastException at runtime.
+ */
+class TypeSafetyTest {
+
+  @Test
+  void testNumberDataCommandValidNumber() throws Exception {
+    NumberDataCommand cmd = new NumberDataCommand("test", 42);
+
+    // Serialize and deserialize
+    NumberDataCommand deserialized = roundTrip(cmd, NumberDataCommand.class);
+
+    assertEquals("test", deserialized.name);
+    assertEquals(42, deserialized.getValue());
+  }
+
+  @Test
+  void testNumberDataCommandNullValue() throws Exception {
+    NumberDataCommand cmd = new NumberDataCommand("test", null);
+
+    NumberDataCommand deserialized = roundTrip(cmd, NumberDataCommand.class);
+
+    assertEquals("test", deserialized.name);
+    assertNull(deserialized.getValue());
+  }
+
+  @Test
+  void testNumberDataCommandRejectsInvalidType() throws Exception {
+    // Create a command and manually serialize with wrong type
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(baos);
+
+    // Write command header
+    oos.writeByte(Command.NUMBER);
+
+    // Write name
+    oos.writeUTF("test");
+
+    // Write WRONG type (String instead of Number)
+    oos.writeObject("not a number");
+    oos.flush();
+
+    // Try to deserialize - should fail during WireIO.read()
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    ObjectInputStream ois = new ObjectInputStream(bais);
+
+    IOException thrown = assertThrows(IOException.class, () -> {
+      WireIO.read(ois);
+    });
+    assertTrue(thrown.getMessage().contains("Invalid data type"));
+  }
+
+  @Test
+  void testErrorCommandValidThrowable() throws Exception {
+    Throwable cause = new RuntimeException("test error");
+    ErrorCommand cmd = new ErrorCommand(cause);
+
+    ErrorCommand deserialized = roundTrip(cmd, ErrorCommand.class);
+
+    assertNotNull(deserialized.getCause());
+    assertEquals("test error", deserialized.getCause().getMessage());
+  }
+
+  @Test
+  void testErrorCommandNullCause() throws Exception {
+    ErrorCommand cmd = new ErrorCommand(null);
+
+    ErrorCommand deserialized = roundTrip(cmd, ErrorCommand.class);
+
+    assertNull(deserialized.getCause());
+  }
+
+  @Test
+  void testErrorCommandRejectsInvalidType() throws Exception {
+    // Create a command and manually serialize with wrong type
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(baos);
+
+    // Write command header
+    oos.writeByte(Command.ERROR);
+
+    // Write WRONG type (String instead of Throwable)
+    oos.writeObject("not a throwable");
+    oos.flush();
+
+    // Try to deserialize
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    ObjectInputStream ois = new ObjectInputStream(bais);
+
+    IOException thrown = assertThrows(IOException.class, () -> {
+      WireIO.read(ois);
+    });
+    assertTrue(thrown.getMessage().contains("Invalid data type"));
+  }
+
+  @Test
+  void testSetSettingsCommandValidTypes() throws Exception {
+    Map<String, Object> params = new HashMap<>();
+    params.put("string_param", "value");
+    params.put("int_param", 42);
+    params.put("bool_param", true);
+    params.put("long_param", 123L);
+    params.put("double_param", 3.14);
+
+    SetSettingsCommand cmd = new SetSettingsCommand(params);
+    SetSettingsCommand deserialized = roundTrip(cmd, SetSettingsCommand.class);
+
+    assertEquals(5, deserialized.getParams().size());
+    assertEquals("value", deserialized.getParams().get("string_param"));
+    assertEquals(42, deserialized.getParams().get("int_param"));
+    assertEquals(true, deserialized.getParams().get("bool_param"));
+    assertEquals(123L, deserialized.getParams().get("long_param"));
+    assertEquals(3.14, deserialized.getParams().get("double_param"));
+  }
+
+  @Test
+  void testSetSettingsCommandRejectsInvalidType() throws Exception {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(baos);
+
+    // Write command header
+    oos.writeByte(Command.SET_PARAMS);
+
+    // Write params with invalid type (use a serializable but invalid type)
+    oos.writeInt(1); // size
+    oos.writeUTF("bad_param");
+    oos.writeObject(new java.util.ArrayList<>()); // Invalid type - ArrayList is serializable but not a valid settings type
+    oos.flush();
+
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    ObjectInputStream ois = new ObjectInputStream(bais);
+
+    IOException thrown = assertThrows(IOException.class, () -> {
+      WireIO.read(ois);
+    });
+    assertTrue(thrown.getMessage().contains("Invalid settings value type"));
+  }
+
+  @Test
+  void testSetSettingsCommandRejectsNegativeSize() throws Exception {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(baos);
+
+    oos.writeByte(Command.SET_PARAMS);
+    oos.writeInt(-1); // Negative size!
+    oos.flush();
+
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    ObjectInputStream ois = new ObjectInputStream(bais);
+
+    IOException thrown = assertThrows(IOException.class, () -> {
+      WireIO.read(ois);
+    });
+    assertTrue(thrown.getMessage().contains("Invalid params size"));
+  }
+
+  @Test
+  void testSetSettingsCommandRejectsExcessiveSize() throws Exception {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(baos);
+
+    oos.writeByte(Command.SET_PARAMS);
+    oos.writeInt(100000); // Excessive size!
+    oos.flush();
+
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    ObjectInputStream ois = new ObjectInputStream(bais);
+
+    IOException thrown = assertThrows(IOException.class, () -> {
+      WireIO.read(ois);
+    });
+    assertTrue(thrown.getMessage().contains("Invalid params size"));
+  }
+
+  // Helper method to serialize and deserialize a command
+  private <T extends Command> T roundTrip(T cmd, Class<T> clazz) throws Exception {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(baos);
+    WireIO.write(oos, cmd);
+    oos.flush();
+
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    ObjectInputStream ois = new ObjectInputStream(bais);
+    Command result = WireIO.read(ois);
+
+    assertInstanceOf(clazz, result);
+    return clazz.cast(result);
+  }
+}


### PR DESCRIPTION
## Problem

Three command classes performed **unsafe casts during deserialization** without validating object types, making them vulnerable to `ClassCastException` from malformed or malicious serialized data.

### Vulnerable Code:

**NumberDataCommand.java (line 72):**
```java
value = (Number) in.readObject();  // No validation!
```

**ErrorCommand.java (line 52):**
```java
cause = (Throwable) in.readObject();  // No validation!
```

**SetSettingsCommand.java (line 69-71):**
```java
String k = in.readUTF();
Object v = in.readObject();  // Accepts ANY type!
params.put(k, v);
```

### Security Impact:

1. **ClassCastException from untrusted data**
   - Attacker sends serialized data with wrong types
   - Cast fails at runtime → application crash

2. **Type confusion attacks**
   - Settings map could contain arbitrary objects
   - Consumer code expects String/Number/Boolean
   - Unexpected types cause failures

3. **Memory exhaustion**
   - SetSettingsCommand accepted unlimited map size
   - Attacker could send size = Integer.MAX_VALUE
   - OOM crash

## Solution

Added validation before all unsafe casts:

### NumberDataCommand
```java
@Override
protected void read(ObjectInput in) throws IOException, ClassNotFoundException {
    name = in.readUTF();
    Object obj = in.readObject();
    if (obj != null && !(obj instanceof Number)) {
        throw new IOException(
            "Invalid data type: expected Number, got " + obj.getClass().getName());
    }
    value = (Number) obj;
}
```

### ErrorCommand
```java
@Override
protected void read(ObjectInput in) throws IOException, ClassNotFoundException {
    Object obj = in.readObject();
    if (obj != null && !(obj instanceof Throwable)) {
        throw new IOException(
            "Invalid data type: expected Throwable, got " + obj.getClass().getName());
    }
    cause = (Throwable) obj;
}
```

### SetSettingsCommand
```java
@Override
protected void read(ObjectInput in) throws IOException, ClassNotFoundException {
    int size = in.readInt();
    if (size < 0 || size > 10000) {  // Prevent memory exhaustion
        throw new IOException("Invalid params size: " + size);
    }
    for (int i = 0; i < size; i++) {
        String k = in.readUTF();
        Object v = in.readObject();
        // Only allow String, Number, Boolean
        if (v != null && !(v instanceof String) 
                      && !(v instanceof Number) 
                      && !(v instanceof Boolean)) {
            throw new IOException(
                "Invalid settings value type: expected String/Number/Boolean, got " 
                + v.getClass().getName());
        }
        params.put(k, v);
    }
}
```

## Testing

Added comprehensive test suite (`TypeSafetyTest.java`) with **10 tests**:

### Valid Type Handling
- ✅ NumberDataCommand with valid Number
- ✅ ErrorCommand with valid Throwable
- ✅ SetSettingsCommand with String/Number/Boolean values

### Null Handling
- ✅ NumberDataCommand with null value
- ✅ ErrorCommand with null cause

### Invalid Type Rejection
- ✅ NumberDataCommand rejects String (expects Number)
- ✅ ErrorCommand rejects String (expects Throwable)
- ✅ SetSettingsCommand rejects ArrayList (expects String/Number/Boolean)

### Boundary Conditions
- ✅ SetSettingsCommand rejects negative size
- ✅ SetSettingsCommand rejects excessive size (>10,000)

**All 10 tests pass** ✅

## Verification

### Before (vulnerable):
```java
// Attacker sends malicious data
ByteArrayOutputStream baos = new ByteArrayOutputStream();
ObjectOutputStream oos = new ObjectOutputStream(baos);
oos.writeByte(Command.NUMBER);
oos.writeUTF("value");
oos.writeObject("not a number");  // Malicious string instead of Number
oos.flush();

// Victim deserializes
ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
Command cmd = WireIO.read(ois);
// Result: ClassCastException at runtime ❌
```

### After (protected):
```java
// Same malicious data
Command cmd = WireIO.read(ois);
// Result: IOException during deserialization with clear message ✅
// "Invalid data type: expected Number, got java.lang.String"
```

## Security Benefits

- ✅ Fail-fast with clear error messages
- ✅ Prevents ClassCastException from propagating
- ✅ Protects against memory exhaustion attacks
- ✅ Type safety enforced at deserialization boundary
- ✅ No breaking changes to public API

## Review Checklist
- [x] Security fix (prevents crashes from untrusted data)
- [x] Tests added (10 comprehensive tests)
- [x] All tests pass
- [x] No breaking API changes
- [x] Clear error messages for debugging

## Priority
🔴 **CRITICAL** - Security vulnerability allowing remote crashes

---

Part of btrace-core analysis and improvement initiative.