### PR TITLE
fix(core): ListProbesCommand thread-safety and PrefixMap micro-optimization

### DIFF
--- a/btrace-core/src/main/java/org/openjdk/btrace/core/PrefixMap.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/PrefixMap.java
@@ -71,9 +71,7 @@ public class PrefixMap {
     }
 
     public void addReferencedNode(char ch, Node n) {
-      if (!refs.containsKey(ch)) {
-        refs.put(ch, n);
-      }
+      refs.putIfAbsent(ch, n);
     }
 
     public void setValue(CharSequence val) {

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/ErrorCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/ErrorCommand.java
@@ -59,6 +59,11 @@ public class ErrorCommand extends Command implements PrintableCommand {
   @Override
   public void print(PrintWriter out) {
     out.append("! ERROR\n");
-    getCause().printStackTrace(out);
+    Throwable cause = getCause();
+    if (cause != null) {
+      cause.printStackTrace(out);
+    } else {
+      out.append("(No exception information available)\n");
+    }
   }
 }

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/GridDataCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/GridDataCommand.java
@@ -114,6 +114,9 @@ public class GridDataCommand extends DataCommand {
   private Map<Integer, Integer> getColumnWidth(List<Object[]> objects) {
     Map<Integer, Integer> columnWidth = new LinkedHashMap<>();
     for (Object[] obj : objects) {
+      if (obj == null) {
+        continue;
+      }
       for (int column = 0; column < obj.length; ++column) {
         int length = obj[column].toString().length();
         Integer width = 0;
@@ -137,7 +140,9 @@ public class GridDataCommand extends DataCommand {
       }
       Map<Integer, Integer> columnWidth = getColumnWidth(data);
       for (Object[] dataRow : data) {
-
+        if (dataRow == null) {
+          continue;
+        }
         // Convert histograms to strings, and pretty-print multi-line text
         Object[] printRow = dataRow.clone();
         for (int i = 0; i < printRow.length; i++) {

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/GridDataCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/GridDataCommand.java
@@ -133,7 +133,6 @@ public class GridDataCommand extends DataCommand {
 
   @Override
   public void print(PrintWriter out) {
-
     if (data != null) {
       if (name != null && !name.isEmpty()) {
         out.println(name);

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/comm/ListProbesCommand.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/comm/ListProbesCommand.java
@@ -4,15 +4,16 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.PrintWriter;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * @since WireIO v.1
  */
 public class ListProbesCommand extends Command implements PrintableCommand {
-  private final List<String> probes = new ArrayList<>();
+  // CopyOnWriteArrayList ensures safe iteration during concurrent updates without CME
+  private final List<String> probes = new CopyOnWriteArrayList<>();
 
   public ListProbesCommand() {
     super(Command.LIST_PROBES, true);
@@ -20,7 +21,9 @@ public class ListProbesCommand extends Command implements PrintableCommand {
 
   public void setProbes(Collection<String> probes) {
     this.probes.clear();
-    this.probes.addAll(probes);
+    if (probes != null && !probes.isEmpty()) {
+      this.probes.addAll(probes);
+    }
   }
 
   @Override

--- a/btrace-core/src/test/java/org/openjdk/btrace/core/PrefixMapTest.java
+++ b/btrace-core/src/test/java/org/openjdk/btrace/core/PrefixMapTest.java
@@ -1,0 +1,22 @@
+package org.openjdk.btrace.core;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class PrefixMapTest {
+  @Test
+  void addAndContainsWorkWithDuplicates() {
+    PrefixMap pm = new PrefixMap();
+    pm.add("abc");
+    pm.add("abc"); // duplicate
+    pm.add("abcd");
+
+    assertTrue(pm.contains("abc"));
+    assertTrue(pm.contains("abcdef"));
+    assertTrue(pm.contains("abcd"));
+    assertFalse(pm.contains("ab"));
+    assertFalse(pm.contains("abX"));
+  }
+}
+

--- a/btrace-core/src/test/java/org/openjdk/btrace/core/comm/ListProbesCommandConcurrencyTest.java
+++ b/btrace-core/src/test/java/org/openjdk/btrace/core/comm/ListProbesCommandConcurrencyTest.java
@@ -1,0 +1,75 @@
+package org.openjdk.btrace.core.comm;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class ListProbesCommandConcurrencyTest {
+
+  @Test
+  void concurrentSetAndIterateDoesNotThrow() throws Exception {
+    ListProbesCommand cmd = new ListProbesCommand();
+
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(2);
+
+    Runnable writer = () -> {
+      try {
+        start.await();
+        for (int r = 0; r < 500; r++) {
+          int size = (r % 10) + 1;
+          List<String> list = new ArrayList<>(size);
+          for (int i = 0; i < size; i++) {
+            list.add("probe-" + r + '-' + i);
+          }
+          cmd.setProbes(list);
+        }
+      } catch (InterruptedException ignored) {
+        Thread.currentThread().interrupt();
+      } finally {
+        done.countDown();
+      }
+    };
+
+    Runnable reader = () -> {
+      try {
+        start.await();
+        for (int r = 0; r < 500; r++) {
+          // print()
+          StringWriter sw = new StringWriter();
+          PrintWriter pw = new PrintWriter(sw);
+          assertDoesNotThrow(() -> cmd.print(pw));
+
+          // write()
+          assertDoesNotThrow(
+              () -> {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+                  cmd.write(oos);
+                }
+              });
+        }
+      } catch (InterruptedException ignored) {
+        Thread.currentThread().interrupt();
+      } finally {
+        done.countDown();
+      }
+    };
+
+    new Thread(writer).start();
+    new Thread(reader).start();
+    start.countDown();
+
+    // Ensure both loops finished
+    done.await(10, TimeUnit.SECONDS);
+  }
+}
+

--- a/btrace-core/src/test/java/org/openjdk/btrace/core/comm/NullSafetyTest.java
+++ b/btrace-core/src/test/java/org/openjdk/btrace/core/comm/NullSafetyTest.java
@@ -1,0 +1,55 @@
+/*
+ * Tests for null safety in command print() methods to prevent NullPointerExceptions.
+ */
+package org.openjdk.btrace.core.comm;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NullSafetyTest {
+
+  @Test
+  void testErrorCommandPrintWithNullCause() {
+    ErrorCommand cmd = new ErrorCommand(null);
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+
+    assertDoesNotThrow(() -> cmd.print(pw));
+
+    String output = sw.toString();
+    assertTrue(output.contains("! ERROR"));
+    assertTrue(output.contains("No exception information available"));
+  }
+
+  @Test
+  void testGridDataCommandWithNullRow() {
+    List<Object[]> data = new ArrayList<>();
+    data.add(new Object[] {"Row1", 100});
+    data.add(null);
+    data.add(new Object[] {"Row3", 300});
+
+    GridDataCommand cmd = new GridDataCommand("TestGrid", data);
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+
+    assertDoesNotThrow(() -> cmd.print(pw));
+    String output = sw.toString();
+    assertTrue(output.contains("Row1"));
+    assertTrue(output.contains("Row3"));
+  }
+
+  @Test
+  void testMessageCommandWithNullMessage() {
+    MessageCommand cmd = new MessageCommand((String) null);
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+
+    assertDoesNotThrow(() -> cmd.print(pw));
+  }
+}
+


### PR DESCRIPTION
This PR addresses two items from the remaining-fixes plan (Medium priority):

1) ListProbesCommand thread-safety
- Use CopyOnWriteArrayList for `probes` to make iteration safe during concurrent updates
- Make setProbes null-safe
- Add ListProbesCommandConcurrencyTest exercising concurrent set/iterate and write/print paths

2) PrefixMap micro-optimization
- Replace containsKey+put with putIfAbsent to avoid double lookup
- Add PrefixMapTest covering duplicate insert and contains behavior

All :btrace-core tests pass locally.
