### PR TITLE
runtime: medium cleanups (DOTWriter, perf string, path sanitize, queue backoff, logging)

### DIFF
--- a/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimeAccess.java
+++ b/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimeAccess.java
@@ -200,7 +200,7 @@ public abstract class BTraceRuntimeAccess implements RuntimeContext {
               m.setAccessible(true);
               return m.invoke(initValue);
             } catch (Exception e) {
-              e.printStackTrace();
+              log.warn("Failed to clone TLS initial value", e);
               return null;
             }
           }

--- a/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimeImplBase.java
+++ b/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimeImplBase.java
@@ -175,7 +175,7 @@ public abstract class BTraceRuntimeImplBase implements BTraceRuntime.Impl, Runti
     byte t = 0;
     int i = 0;
     synchronized (b) {
-      while ((t = b.get()) != '\0') {
+      while (b.hasRemaining() && (t = b.get()) != '\0') {
         buf[i++] = t;
       }
       b.rewind();
@@ -208,7 +208,7 @@ public abstract class BTraceRuntimeImplBase implements BTraceRuntime.Impl, Runti
       try {
         cmdHandler.onCommand(t);
       } catch (IOException e) {
-        e.printStackTrace(System.err);
+        log.warn("Command handler I/O error", e);
       }
       if (t.getType() == Command.EXIT) {
         exitSignal.set(true);
@@ -749,7 +749,7 @@ public abstract class BTraceRuntimeImplBase implements BTraceRuntime.Impl, Runti
         try {
           dotWriterProps.load(is);
         } catch (IOException ioExp) {
-          ioExp.printStackTrace();
+          log.warn("Failed to load DOTWriter properties from classpath", ioExp);
         }
       }
       try {
@@ -760,7 +760,7 @@ public abstract class BTraceRuntimeImplBase implements BTraceRuntime.Impl, Runti
           dotWriterProps.load(is);
         }
       } catch (Exception exp) {
-        exp.printStackTrace();
+        log.warn("Failed to load DOTWriter properties from user home", exp);
       }
     }
   }
@@ -1023,7 +1023,7 @@ public abstract class BTraceRuntimeImplBase implements BTraceRuntime.Impl, Runti
               try {
                 m = th.getMethod(clazz);
               } catch (Throwable t) {
-                t.printStackTrace();
+                log.warn("Failed to acquire timer handler method", t);
               }
               mthd = m;
             }
@@ -1034,7 +1034,7 @@ public abstract class BTraceRuntimeImplBase implements BTraceRuntime.Impl, Runti
                 try {
                   mthd.invoke(null, (Object[]) null);
                 } catch (Throwable th) {
-                  th.printStackTrace();
+                  log.warn("Timer task execution failed", th);
                 }
               }
             }
@@ -1095,7 +1095,11 @@ public abstract class BTraceRuntimeImplBase implements BTraceRuntime.Impl, Runti
     buf.append(File.separatorChar);
     buf.append("btrace");
     if (args != null && args.size() > 0) {
-      buf.append(args.get(0));
+      String arg0 = args.get(0);
+      String sanitized = sanitizePathSegment(arg0);
+      if (!sanitized.isEmpty()) {
+        buf.append(sanitized);
+      }
     }
     buf.append(File.separatorChar);
     buf.append(className);
@@ -1103,6 +1107,16 @@ public abstract class BTraceRuntimeImplBase implements BTraceRuntime.Impl, Runti
     buf.append(File.separatorChar);
     buf.append(name);
     return buf.toString();
+  }
+
+  private static String sanitizePathSegment(String s) {
+    if (s == null) return "";
+    // replace path separators and control chars with underscore; allow alnum, dash, underscore, dot
+    String sanitized = s.replace(File.separatorChar, '_').replace('/', '_').replace('\\', '_');
+    sanitized = sanitized.replaceAll("[^a-zA-Z0-9._-]", "_");
+    // collapse multiple underscores
+    sanitized = sanitized.replaceAll("_+", "_");
+    return sanitized;
   }
 
   private static void initMemoryPoolList() {

--- a/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/CommandQueue.java
+++ b/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/CommandQueue.java
@@ -11,6 +11,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
 
 final class CommandQueue {
+    private static final long DROP_TIMEOUT_MS = Long.getLong("org.openjdk.btrace.runtime.cmd.dropTimeoutMillis", 1L);
+    private static final int BACKOFF_YIELD_ITERS = Integer.getInteger("org.openjdk.btrace.runtime.cmd.backoffYieldIters", 3000);
+    private static final int BACKOFF_SLEEP_ITERS = Integer.getInteger("org.openjdk.btrace.runtime.cmd.backoffSleepIters", 100);
     private final MpscChunkedArrayQueue<Command> queue;
     private final AtomicLong droppedCommands = new AtomicLong();
 
@@ -41,11 +44,11 @@ final class CommandQueue {
 
     public boolean enqueue(Command cmd) {
         int backoffCntr = 0;
-        long tsCutOff = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(1);
+        long tsCutOff = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(DROP_TIMEOUT_MS);
         while (!Thread.interrupted() && !queue.relaxedOffer(cmd)) {
-            if (backoffCntr < 3000) {
+            if (backoffCntr < BACKOFF_YIELD_ITERS) {
                 Thread.yield();
-            } else if (backoffCntr < 3100) {
+            } else if (backoffCntr < BACKOFF_YIELD_ITERS + BACKOFF_SLEEP_ITERS) {
                 LockSupport.parkNanos(1_000_000);
             }
             backoffCntr++;

--- a/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/DOTWriter.java
+++ b/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/DOTWriter.java
@@ -305,7 +305,11 @@ public class DOTWriter {
     if (prop != null) {
       expandCollections(Boolean.parseBoolean(prop));
     }
-    prop = props.getProperty(DOTWRITER_PREFIX + "diaplayLinks");
+    // accept both the correct property and the legacy misspelling for compatibility
+    prop = props.getProperty(DOTWRITER_PREFIX + "displayLinks");
+    if (prop == null) {
+      prop = props.getProperty(DOTWRITER_PREFIX + "diaplayLinks");
+    }
     if (prop != null) {
       displayLinks(Boolean.parseBoolean(prop));
     }

--- a/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/JfrEventFactoryImpl.java
+++ b/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/JfrEventFactoryImpl.java
@@ -166,7 +166,7 @@ final class JfrEventFactoryImpl implements JfrEvent.Factory {
                           JfrEvent event = newEvent();
                           return handlerMethod.invoke(null, event);
                         } catch (Throwable t) {
-                          t.printStackTrace(System.out);
+                          log.warn("Periodic JFR handler invocation failed", t);
                           throw t;
                         }
                       } else {
@@ -178,7 +178,6 @@ final class JfrEventFactoryImpl implements JfrEvent.Factory {
       FlightRecorder.addPeriodicEvent(eClz, hook);
       periodicHook = hook;
     } catch (ClassNotFoundException e) {
-      e.printStackTrace();
       StringBuilder msg = new StringBuilder("Unable to register periodic JFR event of type '");
       String eMsg = e.getMessage();
       msg.append(eMsg.replace('/', '.'));


### PR DESCRIPTION
runtime: medium cleanups in btrace-runtime

Changes:

- DOTWriter: accept both `dotwriter.displayLinks` (correct) and legacy `dotwriter.diaplayLinks`.
- Perf string: guard `getPerfString` to stop when buffer exhausted (handles missing NUL terminator).
- Output path: sanitize the first CLI arg segment in `resolveFileName` to prevent odd paths.
- CommandQueue: make drop timeout and backoff thresholds configurable via system properties:
  - `org.openjdk.btrace.runtime.cmd.dropTimeoutMillis` (default 1)
  - `org.openjdk.btrace.runtime.cmd.backoffYieldIters` (default 3000)
  - `org.openjdk.btrace.runtime.cmd.backoffSleepIters` (default 100)
- Logging: replace `printStackTrace` in key paths with structured logging.

Behavior / risk:

- No public API changes; behavior preserved with safer defaults and configurability.
- Minimal risk; changes are additive or more robust handling.

Notes:

- Based on `develop`.
- Happy to split further or add small tests if useful.