### PR TITLE
runtime: align isBootstrapClass on JDK 9 with 8/11

### DIFF
--- a/btrace-runtime/src/main/java9/org/openjdk/btrace/runtime/BTraceRuntimeImpl_9.java
+++ b/btrace-runtime/src/main/java9/org/openjdk/btrace/runtime/BTraceRuntimeImpl_9.java
@@ -253,7 +253,8 @@ public final class BTraceRuntimeImpl_9 extends BTraceRuntimeImplBase {
   @Override
   public boolean isBootstrapClass(String className) {
     try {
-      return findBootstrapOrNullMtd != null && findBootstrapOrNullMtd.invoke(null, className) != null;
+      return findBootstrapOrNullMtd != null
+          && findBootstrapOrNullMtd.invoke(ClassLoader.getSystemClassLoader(), className) != null;
     } catch (IllegalAccessException | InvocationTargetException ignored) {}
     return false;
   }


### PR DESCRIPTION
Summary:\n\n- JDK 9 runtime now invokes  on the system ClassLoader, matching the approach used in JDK 8 and 11 implementations.\n\nBehavior:\n\n- No functional changes expected for supported JDKs; improves consistency and avoids potential NPEs or lookups on null loader.\n\nBase:\n\n- develop