### PR TITLE
runtime: resilient factory loading order (TCCL → lib CL → system CL)

### DIFF
--- a/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimes.java
+++ b/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimes.java
@@ -25,14 +25,29 @@ public final class BTraceRuntimes {
   private static boolean loadFactory(String clzName) {
     try {
       log.debug("Attempting to load BTrace runtime implementation: {}", clzName);
-      Class<BTraceRuntimeImplFactory<?>> factoryClz =
-          (Class<BTraceRuntimeImplFactory<?>>)
-              ClassLoader.getSystemClassLoader().loadClass(clzName);
-      BTraceRuntimeImplFactory<?> instance = factoryClz.getConstructor().newInstance();
-      if (instance.isEnabled()) {
-        FACTORY = instance;
-        log.debug("BTrace runtime implementation {} is loaded", clzName);
-        return true;
+      ClassLoader[] loaders = new ClassLoader[] {
+          Thread.currentThread().getContextClassLoader(),
+          BTraceRuntimes.class.getClassLoader(),
+          ClassLoader.getSystemClassLoader()
+      };
+      for (ClassLoader loader : loaders) {
+        if (loader == null) continue;
+        try {
+          @SuppressWarnings("unchecked")
+          Class<BTraceRuntimeImplFactory<?>> factoryClz =
+              (Class<BTraceRuntimeImplFactory<?>>) loader.loadClass(clzName);
+          BTraceRuntimeImplFactory<?> instance = factoryClz.getConstructor().newInstance();
+          if (instance.isEnabled()) {
+            FACTORY = instance;
+            log.debug("BTrace runtime implementation {} loaded via {}", clzName, loader);
+            return true;
+          }
+        } catch (ClassNotFoundException | UnsupportedClassVersionError e) {
+          // try next loader
+          if (log.isDebugEnabled()) {
+            log.debug("Loader {} could not load {}: {}", loader, clzName, e.toString());
+          }
+        }
       }
     } catch (ClassNotFoundException | UnsupportedClassVersionError ignored) {
     } catch (Exception e) {

--- a/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimes.java
+++ b/btrace-runtime/src/main/java/org/openjdk/btrace/runtime/BTraceRuntimes.java
@@ -21,10 +21,9 @@ public final class BTraceRuntimes {
     BTraceRuntimeAccess.registerRuntimeAccessor();
   }
 
-  @SuppressWarnings("unchecked")
-  private static boolean loadFactory(String clzName) {
+  private static boolean loadFactory(String className) {
     try {
-      log.debug("Attempting to load BTrace runtime implementation: {}", clzName);
+      log.debug("Attempting to load BTrace runtime implementation: {}", className);
       ClassLoader[] loaders = new ClassLoader[] {
           Thread.currentThread().getContextClassLoader(),
           BTraceRuntimes.class.getClassLoader(),
@@ -33,25 +32,24 @@ public final class BTraceRuntimes {
       for (ClassLoader loader : loaders) {
         if (loader == null) continue;
         try {
-          @SuppressWarnings("unchecked")
+          @SuppressWarnings("unchecked") // generic cast due to dynamic classloading of a known API type
           Class<BTraceRuntimeImplFactory<?>> factoryClz =
-              (Class<BTraceRuntimeImplFactory<?>>) loader.loadClass(clzName);
+              (Class<BTraceRuntimeImplFactory<?>>) loader.loadClass(className);
           BTraceRuntimeImplFactory<?> instance = factoryClz.getConstructor().newInstance();
           if (instance.isEnabled()) {
             FACTORY = instance;
-            log.debug("BTrace runtime implementation {} loaded via {}", clzName, loader);
+            log.debug("BTrace runtime implementation {} loaded via {}", className, loader);
             return true;
           }
         } catch (ClassNotFoundException | UnsupportedClassVersionError e) {
           // try next loader
           if (log.isDebugEnabled()) {
-            log.debug("Loader {} could not load {}: {}", loader, clzName, e.toString());
+            log.debug("Loader {} could not load {}: {}", loader, className, e.toString());
           }
         }
       }
-    } catch (ClassNotFoundException | UnsupportedClassVersionError ignored) {
     } catch (Exception e) {
-      log.warn("Failed to load BTrace runtime implementation {}", clzName, e);
+      log.error("Failed to load BTrace runtime implementation: {}", className, e);
     }
     return false;
   }


### PR DESCRIPTION
runtime: resilient factory loading order (TCCL → lib CL → system CL)

Summary:

- Discover runtime factory using classloaders in order:
  1) Thread Context ClassLoader (TCCL)
  2) BTraceRuntimes' class loader (library)
  3) System class loader
- First loader that finds an enabled factory wins.

Motivation:

- In containers/app servers/test runners/agent setups, classes are often only visible via TCCL or the library loader, not the system loader.
- Aligns with common framework patterns and improves robustness under JPMS.

Behavior / risk:

- No public API changes. Behavior is unchanged where the system loader already works.
- Minimal risk; additional attempts are no-ops on failure (debug-logged).

Base:

- develop