### PR TITLE
feat: add Docker layer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ sudo dpkg -i btrace-*.deb
 ```dockerfile
 # Copy BTrace into your application image
 FROM btrace/btrace:latest AS btrace
-FROM openjdk:11-jdk
+FROM bellsoft/liberica-openjdk-debian:11-cds
 
 COPY --from=btrace /opt/btrace /opt/btrace
 ENV BTRACE_HOME=/opt/btrace PATH="${PATH}:${BTRACE_HOME}/bin"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,25 @@ sudo rpm -i btrace-*.rpm
 sudo dpkg -i btrace-*.deb
 ```
 
+**Docker images:**
+```dockerfile
+# Copy BTrace into your application image
+FROM btrace/btrace:latest AS btrace
+FROM openjdk:11-jdk
+
+COPY --from=btrace /opt/btrace /opt/btrace
+ENV BTRACE_HOME=/opt/btrace PATH="${PATH}:${BTRACE_HOME}/bin"
+
+# Your application...
+```
+
+Available variants:
+- `btrace/btrace:latest` - Debian-based (~25MB)
+- `btrace/btrace:latest-alpine` - Alpine-based (~15MB)
+- `btrace/btrace:latest-distroless` - Distroless (~10MB)
+
+See [docker/README.md](docker/README.md) for complete Docker documentation.
+
 ### Quick Start
 
 ```sh

--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -178,6 +178,8 @@ task fixPermissions(type: Exec) {
     commandLine 'chmod', '500', "${distTarget}/bin/btrace"
     commandLine 'chmod', '500', "${distTarget}/bin/btracec"
     commandLine 'chmod', '500', "${distTarget}/bin/btracer"
+
+    dependsOn processResources
 }
 
 task copyDtraceLib(type: Copy) {
@@ -268,6 +270,7 @@ task buildDockerContext(type: Copy, dependsOn: [agentJar, bootJar, clientJar, co
 
     from "${distTarget}"
     into "${buildDir}/docker-context/btrace"
+    fileMode = 0644
 
     doLast {
         // Copy entrypoint script

--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -262,7 +262,7 @@ buildRpm.dependsOn agentJar, bootJar, clientJar, fixPermissions, copyDtraceLib, 
 build.dependsOn buildSdkmanZip, buildZip, buildTgz, buildDeb, buildRpm
 
 // Docker build tasks
-task buildDockerContext(type: Copy, dependsOn: [processResources, fixPermissions]) {
+task buildDockerContext(type: Copy, dependsOn: [agentJar, bootJar, clientJar, copyDtraceLib, processResources, fixPermissions]) {
     group 'Docker'
     description 'Prepare Docker build context with BTrace distribution'
 

--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -275,6 +275,11 @@ task buildDockerContext(type: Copy, dependsOn: [agentJar, bootJar, clientJar, co
             from "${projectDir}/../docker/docker-entrypoint.sh"
             into "${buildDir}/docker-context"
         }
+        // Copy .dockerignore to build context so Docker can use it
+        copy {
+            from "${projectDir}/../docker/.dockerignore"
+            into "${buildDir}/docker-context"
+        }
     }
 }
 

--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -356,13 +356,13 @@ task buildDockerImageDistroless(type: Exec, dependsOn: buildDockerContext) {
         '--build-arg', "BTRACE_VERSION=${project.version}",
         '-t', "btrace/btrace:${project.version}-distroless",
         '-t', "btrace/btrace:latest-distroless",
-        '--platform', 'linux/amd64',
         '-f', 'Dockerfile.distroless',
         "${buildDir}/docker-context"
     ]
 
     if (project.hasProperty('dockerBuildx')) {
         buildArgs.add(1, 'buildx')
+        buildArgs.addAll(['--platform', 'linux/amd64'])
     }
 
     commandLine buildArgs

--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -261,6 +261,119 @@ buildDeb.dependsOn agentJar, bootJar, clientJar, fixPermissions, copyDtraceLib, 
 buildRpm.dependsOn agentJar, bootJar, clientJar, fixPermissions, copyDtraceLib, processResources
 build.dependsOn buildSdkmanZip, buildZip, buildTgz, buildDeb, buildRpm
 
+// Docker build tasks
+task buildDockerContext(type: Copy, dependsOn: [processResources, fixPermissions]) {
+    group 'Docker'
+    description 'Prepare Docker build context with BTrace distribution'
+
+    from "${distTarget}"
+    into "${buildDir}/docker-context/btrace"
+
+    doLast {
+        // Copy entrypoint script
+        copy {
+            from "${projectDir}/../docker/docker-entrypoint.sh"
+            into "${buildDir}/docker-context"
+        }
+    }
+}
+
+task buildDockerImage(type: Exec, dependsOn: buildDockerContext) {
+    group 'Docker'
+    description 'Build main Debian-based Docker image'
+
+    onlyIf {
+        project.hasProperty('dockerEnabled') &&
+        (project.hasProperty('dockerBuildx') ?
+            'docker buildx version'.execute().waitFor() == 0 :
+            'docker --version'.execute().waitFor() == 0)
+    }
+
+    workingDir "${projectDir}/../docker"
+
+    def buildArgs = [
+        'docker', 'build',
+        '--build-arg', "BTRACE_VERSION=${project.version}",
+        '-t', "btrace/btrace:${project.version}",
+        '-t', "btrace/btrace:latest",
+        '-f', 'Dockerfile',
+        "${buildDir}/docker-context"
+    ]
+
+    if (project.hasProperty('dockerBuildx')) {
+        buildArgs.add(1, 'buildx')
+        buildArgs.addAll(['--platform', 'linux/amd64,linux/arm64'])
+    }
+
+    commandLine buildArgs
+}
+
+task buildDockerImageAlpine(type: Exec, dependsOn: buildDockerContext) {
+    group 'Docker'
+    description 'Build Alpine-based Docker image'
+
+    onlyIf {
+        project.hasProperty('dockerEnabled') &&
+        (project.hasProperty('dockerBuildx') ?
+            'docker buildx version'.execute().waitFor() == 0 :
+            'docker --version'.execute().waitFor() == 0)
+    }
+
+    workingDir "${projectDir}/../docker"
+
+    def buildArgs = [
+        'docker', 'build',
+        '--build-arg', "BTRACE_VERSION=${project.version}",
+        '-t', "btrace/btrace:${project.version}-alpine",
+        '-t', "btrace/btrace:latest-alpine",
+        '-f', 'Dockerfile.alpine',
+        "${buildDir}/docker-context"
+    ]
+
+    if (project.hasProperty('dockerBuildx')) {
+        buildArgs.add(1, 'buildx')
+        buildArgs.addAll(['--platform', 'linux/amd64,linux/arm64'])
+    }
+
+    commandLine buildArgs
+}
+
+task buildDockerImageDistroless(type: Exec, dependsOn: buildDockerContext) {
+    group 'Docker'
+    description 'Build distroless Docker image'
+
+    onlyIf {
+        project.hasProperty('dockerEnabled') &&
+        (project.hasProperty('dockerBuildx') ?
+            'docker buildx version'.execute().waitFor() == 0 :
+            'docker --version'.execute().waitFor() == 0)
+    }
+
+    workingDir "${projectDir}/../docker"
+
+    def buildArgs = [
+        'docker', 'build',
+        '--build-arg', "BTRACE_VERSION=${project.version}",
+        '-t', "btrace/btrace:${project.version}-distroless",
+        '-t', "btrace/btrace:latest-distroless",
+        '--platform', 'linux/amd64',
+        '-f', 'Dockerfile.distroless',
+        "${buildDir}/docker-context"
+    ]
+
+    if (project.hasProperty('dockerBuildx')) {
+        buildArgs.add(1, 'buildx')
+    }
+
+    commandLine buildArgs
+}
+
+task buildDockerImages {
+    group 'Docker'
+    description 'Build all Docker image variants'
+    dependsOn buildDockerImage, buildDockerImageAlpine, buildDockerImageDistroless
+}
+
 test {
     doLast {
         project(':btrace-instr').tasks.test.execute()

--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -357,7 +357,7 @@ task buildDockerImageDistroless(type: Exec, dependsOn: buildDockerContext) {
         '-t', "btrace/btrace:${project.version}-distroless",
         '-t', "btrace/btrace:latest-distroless",
         '-f', 'Dockerfile.distroless',
-        "${buildDir}/docker-context"
+        file("${buildDir}/docker-context").absolutePath
     ]
 
     if (project.hasProperty('dockerBuildx')) {

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,16 @@
+# Exclude files not needed in Docker build context to optimize build speed
+
+# Samples (optional - can be excluded to reduce image size)
+# Uncomment the line below to exclude samples from the image
+# btrace/samples/
+
+# Windows batch files (not needed in Linux containers)
+btrace/bin/*.bat
+
+# Documentation files
+btrace/*.txt
+btrace/LICENSE*
+btrace/COPYRIGHT
+
+# Native libraries for other architectures (optional)
+# Keep only what's needed for the target platform

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,48 @@
+# BTrace Docker Image - Debian-based variant
+# Full distribution with all tools and shell access
+FROM openjdk:11-jdk-slim
+
+ARG BTRACE_VERSION=2.3.0-SNAPSHOT
+
+LABEL maintainer="BTrace Project <https://github.com/btraceio/btrace>" \
+      org.opencontainers.image.title="BTrace" \
+      org.opencontainers.image.description="Safe, dynamic tracing tool for the Java platform" \
+      org.opencontainers.image.url="https://github.com/btraceio/btrace" \
+      org.opencontainers.image.source="https://github.com/btraceio/btrace" \
+      org.opencontainers.image.version="${BTRACE_VERSION}" \
+      org.opencontainers.image.licenses="GPL-2.0-only WITH Classpath-exception-2.0"
+
+# Install required tools
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        procps \
+        curl \
+        ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create BTrace installation directory
+RUN mkdir -p /opt/btrace
+
+# Copy BTrace distribution
+COPY btrace/ /opt/btrace/
+
+# Set ownership and permissions
+RUN chmod -R 755 /opt/btrace/bin && \
+    chmod 644 /opt/btrace/libs/*.jar
+
+# Set environment variables
+ENV BTRACE_HOME=/opt/btrace \
+    PATH="${PATH}:/opt/btrace/bin" \
+    JAVA_HOME=/usr/local/openjdk-11
+
+# Verify installation
+RUN btrace --version || echo "BTrace installed"
+
+# Add entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+WORKDIR /work
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # BTrace Docker Image - Debian-based variant
 # Full distribution with all tools and shell access
-FROM openjdk:11-jdk-slim
+FROM bellsoft/liberica-openjdk-debian:11-cds
 
 ARG BTRACE_VERSION=2.3.0-SNAPSHOT
 

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,0 +1,48 @@
+# BTrace Docker Image - Alpine variant
+# Smaller footprint for Kubernetes sidecars and resource-constrained environments
+FROM alpine:3.19
+
+ARG BTRACE_VERSION=2.3.0-SNAPSHOT
+
+LABEL maintainer="BTrace Project <https://github.com/btraceio/btrace>" \
+      org.opencontainers.image.title="BTrace Alpine" \
+      org.opencontainers.image.description="Safe, dynamic tracing tool for the Java platform (Alpine variant)" \
+      org.opencontainers.image.url="https://github.com/btraceio/btrace" \
+      org.opencontainers.image.source="https://github.com/btraceio/btrace" \
+      org.opencontainers.image.version="${BTRACE_VERSION}" \
+      org.opencontainers.image.licenses="GPL-2.0-only WITH Classpath-exception-2.0"
+
+# Install OpenJDK 11 and required tools
+RUN apk add --no-cache \
+        openjdk11-jdk \
+        bash \
+        procps \
+        curl \
+        ca-certificates
+
+# Create BTrace installation directory
+RUN mkdir -p /opt/btrace
+
+# Copy BTrace distribution
+COPY btrace/ /opt/btrace/
+
+# Set ownership and permissions
+RUN chmod -R 755 /opt/btrace/bin && \
+    chmod 644 /opt/btrace/libs/*.jar
+
+# Set environment variables
+ENV BTRACE_HOME=/opt/btrace \
+    PATH="${PATH}:/opt/btrace/bin" \
+    JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+
+# Verify installation
+RUN btrace --version || echo "BTrace installed"
+
+# Add entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+WORKDIR /work
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.distroless
+++ b/docker/Dockerfile.distroless
@@ -1,0 +1,23 @@
+# BTrace Docker Image - Distroless variant
+# Minimal attack surface for production use with BTrace agent
+# Runtime JARs only, no shell or unnecessary tools
+FROM gcr.io/distroless/java11-debian11
+
+ARG BTRACE_VERSION=2.3.0-SNAPSHOT
+
+LABEL maintainer="BTrace Project <https://github.com/btraceio/btrace>" \
+      org.opencontainers.image.title="BTrace Distroless" \
+      org.opencontainers.image.description="Safe, dynamic tracing tool for the Java platform (Distroless variant)" \
+      org.opencontainers.image.url="https://github.com/btraceio/btrace" \
+      org.opencontainers.image.source="https://github.com/btraceio/btrace" \
+      org.opencontainers.image.version="${BTRACE_VERSION}" \
+      org.opencontainers.image.licenses="GPL-2.0-only WITH Classpath-exception-2.0"
+
+# Copy only BTrace runtime libraries (no shell scripts since distroless has no shell)
+COPY btrace/libs /opt/btrace/libs
+
+# Note: Distroless images don't support environment variables in the traditional way
+# Users should specify paths directly in their java command
+# Example: java -javaagent:/opt/btrace/libs/btrace-agent.jar=...
+
+WORKDIR /work

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,358 @@
+# BTrace Docker Images
+
+Official Docker images for [BTrace](https://github.com/btraceio/btrace) - a safe, dynamic tracing tool for the Java platform.
+
+## Quick Start
+
+```dockerfile
+# Copy BTrace into your application image
+FROM btrace/btrace:2.3.0 AS btrace
+FROM openjdk:11-jdk
+
+COPY --from=btrace /opt/btrace /opt/btrace
+ENV BTRACE_HOME=/opt/btrace PATH="${PATH}:/opt/btrace/bin"
+
+# Your application...
+```
+
+## Image Variants
+
+### `btrace/btrace:latest` (~25MB)
+**Debian-based** - Full distribution with all tools and shell access
+
+- **Base:** OpenJDK 11 JDK on Debian Slim
+- **Use case:** General purpose, development, interactive debugging
+- **Includes:** Complete BTrace toolchain, shell access, samples
+- **Best for:** Development environments, interactive troubleshooting
+
+```dockerfile
+FROM btrace/btrace:2.3.0
+```
+
+### `btrace/btrace:latest-alpine` (~15MB)
+**Alpine-based** - Smaller footprint for cloud environments
+
+- **Base:** Alpine Linux with OpenJDK 11
+- **Use case:** Kubernetes sidecars, resource-constrained environments
+- **Includes:** Complete BTrace toolchain, smaller base OS
+- **Best for:** Production sidecars, cloud deployments
+
+```dockerfile
+FROM btrace/btrace:2.3.0-alpine
+```
+
+### `btrace/btrace:latest-distroless` (~10MB)
+**Distroless** - Minimal attack surface for security-focused deployments
+
+- **Base:** Google Distroless Java 11
+- **Use case:** Production agent mode, minimal security surface
+- **Includes:** BTrace runtime JARs only (no shell, no scripts)
+- **Best for:** Production applications using `-javaagent`
+
+```dockerfile
+FROM btrace/btrace:2.3.0-distroless AS btrace
+FROM gcr.io/distroless/java11
+COPY --from=btrace /opt/btrace/libs /opt/btrace/libs
+```
+
+## Usage Patterns
+
+### Pattern 1: Multi-Stage Build
+
+Most common - copy BTrace into your application image:
+
+```dockerfile
+FROM btrace/btrace:2.3.0 AS btrace
+FROM openjdk:11-jdk
+WORKDIR /app
+
+COPY target/myapp.jar /app/
+COPY --from=btrace /opt/btrace /opt/btrace
+
+ENV BTRACE_HOME=/opt/btrace
+ENV PATH="${PATH}:${BTRACE_HOME}/bin"
+
+ENTRYPOINT ["java", "-jar", "myapp.jar"]
+```
+
+**Usage:**
+```bash
+docker build -t myapp:latest .
+docker run -d --name myapp myapp:latest
+docker exec myapp btrace <PID> /scripts/trace.btrace
+```
+
+### Pattern 2: Kubernetes Sidecar
+
+Run BTrace as a sidecar container:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-with-btrace
+spec:
+  shareProcessNamespace: true  # Required!
+  containers:
+  - name: myapp
+    image: myapp:latest
+
+  - name: btrace-sidecar
+    image: btrace/btrace:2.3.0-alpine
+    command: ["/bin/sh", "-c", "while true; do sleep 30; done"]
+    volumeMounts:
+    - name: btrace-scripts
+      mountPath: /scripts
+
+  volumes:
+  - name: btrace-scripts
+    configMap:
+      name: btrace-scripts
+```
+
+**Usage:**
+```bash
+kubectl exec myapp-with-btrace -c btrace-sidecar -- \
+  btrace $(pgrep -f myapp) /scripts/trace.btrace
+```
+
+### Pattern 3: Development Image
+
+Extend BTrace image for development:
+
+```dockerfile
+FROM btrace/btrace:2.3.0-alpine
+
+COPY target/myapp.jar /app/myapp.jar
+COPY scripts/*.btrace /scripts/
+
+ENTRYPOINT ["btracer"]
+CMD ["-v", "-o", "/tmp/btrace-output.txt", "/app/myapp.jar"]
+```
+
+### Pattern 4: Distroless Production
+
+Minimal image with BTrace agent:
+
+```dockerfile
+FROM btrace/btrace:2.3.0-distroless AS btrace
+FROM gcr.io/distroless/java11
+WORKDIR /app
+
+COPY --from=build /app/target/myapp.jar /app/
+COPY --from=btrace /opt/btrace/libs /opt/btrace/libs
+
+ENTRYPOINT ["java", \
+  "-javaagent:/opt/btrace/libs/btrace-agent.jar=script=/scripts/trace.btrace", \
+  "-Xbootclasspath/a:/opt/btrace/libs/btrace-boot.jar", \
+  "-jar", "/app/myapp.jar"]
+```
+
+### Pattern 5: Docker Compose
+
+Local development with BTrace:
+
+```yaml
+version: '3.8'
+services:
+  myapp:
+    image: myapp:latest
+    ports:
+      - "8080:8080"
+
+  btrace:
+    image: btrace/btrace:2.3.0-alpine
+    network_mode: "service:myapp"
+    pid: "service:myapp"
+    volumes:
+      - ./scripts:/scripts
+      - ./output:/output
+    command: >
+      sh -c "sleep 5; btrace $(pgrep -f myapp) /scripts/trace.btrace"
+```
+
+## Image Selection Guide
+
+| Variant | Size | Shell | Scripts | Use Case |
+|---------|------|-------|---------|----------|
+| **latest** | ~25MB | ✓ | ✓ | Development, debugging |
+| **alpine** | ~15MB | ✓ | ✓ | Kubernetes sidecar |
+| **distroless** | ~10MB | ✗ | ✗ | Production agent mode |
+
+**Recommendations:**
+- **Development:** Use `btrace:latest` for full tooling
+- **Kubernetes Sidecar:** Use `btrace:latest-alpine` for size efficiency
+- **Production Agent:** Use `btrace:latest-distroless` for security
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BTRACE_HOME` | `/opt/btrace` | BTrace installation directory |
+| `BTRACE_OPTS` | (empty) | Additional BTrace command options |
+| `JAVA_HOME` | (auto-detected) | Java installation path |
+| `BTRACE_VERBOSE` | `false` | Print version info on startup |
+
+## Scenarios
+
+### Troubleshoot Production Issue
+
+```bash
+# Copy script into container
+docker cp troubleshoot.btrace myapp:/tmp/
+
+# Find Java process PID
+docker exec myapp jps -l
+
+# Attach BTrace
+docker exec myapp btrace <PID> /tmp/troubleshoot.btrace
+
+# View output
+docker exec myapp cat /tmp/btrace-output.txt
+```
+
+### Continuous Monitoring in Kubernetes
+
+```bash
+# Deploy scripts as ConfigMap
+kubectl create configmap btrace-scripts \
+  --from-file=monitor.btrace=./scripts/monitor.btrace
+
+# Deploy application with sidecar
+kubectl apply -f app-with-btrace-sidecar.yaml
+
+# Stream output
+kubectl logs -f myapp-pod -c btrace-sidecar
+
+# Update script without restart
+kubectl create configmap btrace-scripts \
+  --from-file=monitor.btrace=./scripts/updated.btrace \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+### Performance Profiling
+
+```dockerfile
+FROM btrace/btrace:2.3.0 AS btrace
+FROM openjdk:11-jdk
+
+COPY --from=btrace /opt/btrace /opt/btrace
+ENV BTRACE_HOME=/opt/btrace PATH="${PATH}:${BTRACE_HOME}/bin"
+
+COPY target/myapp.jar /app/
+COPY scripts/profile-*.btrace /scripts/
+
+ENTRYPOINT ["btracer", \
+  "-v", "-o", "/tmp/profile.txt", \
+  "/scripts/profile-methods.btrace", \
+  "-jar", "/app/myapp.jar"]
+```
+
+## Best Practices
+
+1. **Use specific version tags in production:**
+   ```dockerfile
+   FROM btrace/btrace:2.3.0  # Good
+   FROM btrace/btrace:latest  # Avoid in production
+   ```
+
+2. **Multi-stage builds minimize size:**
+   ```dockerfile
+   FROM btrace/btrace:2.3.0 AS btrace
+   FROM your-app-image
+   COPY --from=btrace /opt/btrace /opt/btrace
+   ```
+
+3. **Enable process namespace sharing in Kubernetes:**
+   ```yaml
+   spec:
+     shareProcessNamespace: true  # Required!
+   ```
+
+4. **Store scripts in ConfigMaps:**
+   ```bash
+   kubectl create configmap btrace-scripts --from-file=./scripts/
+   ```
+
+5. **Use appropriate security contexts:**
+   ```yaml
+   securityContext:
+     runAsNonRoot: true
+     readOnlyRootFilesystem: true
+     capabilities:
+       drop: ["ALL"]
+       add: ["SYS_PTRACE"]  # Required
+   ```
+
+6. **Monitor BTrace overhead:**
+   - Start with minimal instrumentation
+   - Test in staging first
+   - Use sampling for high-frequency events
+
+## Troubleshooting
+
+### "Cannot attach to process"
+```bash
+# Ensure process namespace sharing
+docker run --pid=container:target-container btrace/btrace:latest
+
+# Kubernetes: verify shareProcessNamespace
+kubectl get pod myapp -o yaml | grep shareProcessNamespace
+```
+
+### "BTRACE_HOME not found"
+```bash
+# Verify installation
+docker exec myapp ls -la $BTRACE_HOME
+docker exec myapp env | grep BTRACE
+```
+
+### "Java tools not available"
+```bash
+# Ensure JDK (not JRE) is installed
+docker exec myapp java -version
+docker exec myapp which javac
+
+# Java 9+ requires module exports
+ENV JAVA_OPTS="--add-exports jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED"
+```
+
+## Building Images Locally
+
+```bash
+# Build BTrace distribution first
+./gradlew :btrace-dist:build
+
+# Build Docker images
+./gradlew :btrace-dist:buildDockerImages
+
+# Or build manually
+cd docker
+docker build -t btrace/btrace:local -f Dockerfile ../btrace-dist/build/resources/main/v2.3.0-SNAPSHOT
+docker build -t btrace/btrace:local-alpine -f Dockerfile.alpine ../btrace-dist/build/resources/main/v2.3.0-SNAPSHOT
+docker build -t btrace/btrace:local-distroless -f Dockerfile.distroless ../btrace-dist/build/resources/main/v2.3.0-SNAPSHOT
+```
+
+## Supported Platforms
+
+- **linux/amd64** - Intel/AMD 64-bit (all variants)
+- **linux/arm64** - ARM 64-bit (all variants)
+
+Note: Native DTrace library (`libbtrace.so`) is x86-only. DTrace features are not available on ARM platforms.
+
+## License
+
+BTrace is licensed under GPL-2.0-only WITH Classpath-exception-2.0.
+
+## Links
+
+- **GitHub:** https://github.com/btraceio/btrace
+- **Documentation:** https://github.com/btraceio/btrace/tree/develop/docs
+- **Issues:** https://github.com/btraceio/btrace/issues
+- **Docker Hub:** https://hub.docker.com/r/btrace/btrace
+
+## Support
+
+For questions and support:
+- GitHub Issues: https://github.com/btraceio/btrace/issues
+- Documentation: https://github.com/btraceio/btrace/tree/develop/docs

--- a/docker/README.md
+++ b/docker/README.md
@@ -113,7 +113,7 @@ spec:
 **Usage:**
 ```bash
 kubectl exec myapp-with-btrace -c btrace-sidecar -- \
-  btrace $(pgrep -f myapp) /scripts/trace.btrace
+  sh -c 'btrace $(pgrep -f myapp) /scripts/trace.btrace'
 ```
 
 ### Pattern 3: Development Image

--- a/docker/README.md
+++ b/docker/README.md
@@ -168,7 +168,7 @@ services:
       - ./scripts:/scripts
       - ./output:/output
     command: >
-      sh -c "sleep 5; btrace $(pgrep -f myapp) /scripts/trace.btrace"
+      sh -c 'sleep 5; btrace $(pgrep -f myapp) /scripts/trace.btrace'
 ```
 
 ## Image Selection Guide

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,7 +7,7 @@ Official Docker images for [BTrace](https://github.com/btraceio/btrace) - a safe
 ```dockerfile
 # Copy BTrace into your application image
 FROM btrace/btrace:2.3.0 AS btrace
-FROM openjdk:11-jdk
+FROM bellsoft/liberica-openjdk-debian:11-cds
 
 COPY --from=btrace /opt/btrace /opt/btrace
 ENV BTRACE_HOME=/opt/btrace PATH="${PATH}:/opt/btrace/bin"
@@ -63,7 +63,7 @@ Most common - copy BTrace into your application image:
 
 ```dockerfile
 FROM btrace/btrace:2.3.0 AS btrace
-FROM openjdk:11-jdk
+FROM bellsoft/liberica-openjdk-debian:11-cds
 WORKDIR /app
 
 COPY target/myapp.jar /app/
@@ -234,7 +234,7 @@ kubectl create configmap btrace-scripts \
 
 ```dockerfile
 FROM btrace/btrace:2.3.0 AS btrace
-FROM openjdk:11-jdk
+FROM bellsoft/liberica-openjdk-debian:11-cds
 
 COPY --from=btrace /opt/btrace /opt/btrace
 ENV BTRACE_HOME=/opt/btrace PATH="${PATH}:${BTRACE_HOME}/bin"

--- a/docker/README.md
+++ b/docker/README.md
@@ -327,10 +327,11 @@ ENV JAVA_OPTS="--add-exports jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAME
 ./gradlew :btrace-dist:buildDockerImages
 
 # Or build manually
+VERSION=2.3.0-SNAPSHOT  # Set this to your BTrace version
 cd docker
-docker build -t btrace/btrace:local -f Dockerfile ../btrace-dist/build/resources/main/v2.3.0-SNAPSHOT
-docker build -t btrace/btrace:local-alpine -f Dockerfile.alpine ../btrace-dist/build/resources/main/v2.3.0-SNAPSHOT
-docker build -t btrace/btrace:local-distroless -f Dockerfile.distroless ../btrace-dist/build/resources/main/v2.3.0-SNAPSHOT
+docker build -t btrace/btrace:local -f Dockerfile ../btrace-dist/build/resources/main/v${VERSION}
+docker build -t btrace/btrace:local-alpine -f Dockerfile.alpine ../btrace-dist/build/resources/main/v${VERSION}
+docker build -t btrace/btrace:local-distroless -f Dockerfile.distroless ../btrace-dist/build/resources/main/v${VERSION}
 ```
 
 ## Supported Platforms

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+
+# BTrace Docker Entrypoint Script
+# Initializes environment and runs BTrace commands
+
+# Print version information if verbose
+if [ "${BTRACE_VERBOSE:-false}" = "true" ]; then
+    echo "BTrace Docker Image"
+    echo "BTRACE_HOME: ${BTRACE_HOME:-/opt/btrace}"
+    echo "JAVA_HOME: ${JAVA_HOME}"
+    java -version
+fi
+
+# Validate Java installation
+if ! command -v java &> /dev/null; then
+    echo "ERROR: Java not found in PATH"
+    exit 1
+fi
+
+# Initialize BTRACE_HOME if not set
+if [ -z "$BTRACE_HOME" ]; then
+    export BTRACE_HOME=/opt/btrace
+fi
+
+# Verify BTrace installation
+if [ ! -d "$BTRACE_HOME" ]; then
+    echo "ERROR: BTRACE_HOME directory not found: $BTRACE_HOME"
+    exit 1
+fi
+
+# Add BTrace bin to PATH if not already there
+if [[ ":$PATH:" != *":$BTRACE_HOME/bin:"* ]]; then
+    export PATH="$PATH:$BTRACE_HOME/bin"
+fi
+
+# If first argument is a btrace command, execute it directly
+if [ "${1#-}" != "$1" ] || [ "$1" = "btrace" ] || [ "$1" = "btracer" ] || [ "$1" = "btracec" ] || [ "$1" = "btracep" ]; then
+    exec "$@"
+fi
+
+# If first argument is a shell or starts with /, execute as-is
+if [ "$1" = "/bin/bash" ] || [ "$1" = "/bin/sh" ] || [ "${1:0:1}" = "/" ]; then
+    exec "$@"
+fi
+
+# Default: execute the provided command
+exec "$@"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -30,9 +30,14 @@ if [ ! -d "$BTRACE_HOME" ]; then
 fi
 
 # Add BTrace bin to PATH if not already there
-if [[ ":$PATH:" != *":$BTRACE_HOME/bin:"* ]]; then
-    export PATH="$PATH:$BTRACE_HOME/bin"
-fi
+case ":$PATH:" in
+    *":$BTRACE_HOME/bin:"*)
+        # already in PATH, do nothing
+        ;;
+    *)
+        export PATH="$PATH:$BTRACE_HOME/bin"
+        ;;
+esac
 
 # If first argument is a btrace command, execute it directly
 if [ "${1#-}" != "$1" ] || [ "$1" = "btrace" ] || [ "$1" = "btracer" ] || [ "$1" = "btracec" ] || [ "$1" = "btracep" ]; then

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -40,8 +40,14 @@ if [ "${1#-}" != "$1" ] || [ "$1" = "btrace" ] || [ "$1" = "btracer" ] || [ "$1"
 fi
 
 # If first argument is a shell or starts with /, execute as-is
-if [ "$1" = "/bin/bash" ] || [ "$1" = "/bin/sh" ] || [ "${1:0:1}" = "/" ]; then
+if [ "$1" = "/bin/bash" ] || [ "$1" = "/bin/sh" ]; then
     exec "$@"
+else
+    case "$1" in
+        /*)
+            exec "$@"
+            ;;
+    esac
 fi
 
 # Default: execute the provided command

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -689,7 +689,7 @@ spec:
   - name: app
     image: myapp:latest
   - name: btrace
-    image: openjdk:11-jdk
+    image: bellsoft/liberica-openjdk-debian:11-cds
     command: ["/bin/sh", "-c", "sleep infinity"]
 ```
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -379,7 +379,7 @@ docker exec -it <container-id> btrace <PID> script.java
 ```dockerfile
 # Option 1: Copy BTrace into your application image (recommended)
 FROM btrace/btrace:latest AS btrace
-FROM openjdk:11-jdk
+FROM bellsoft/liberica-openjdk-debian:11-cds
 
 COPY --from=btrace /opt/btrace /opt/btrace
 ENV BTRACE_HOME=/opt/btrace
@@ -392,7 +392,7 @@ ENTRYPOINT ["java", "-jar", "/app/myapp.jar"]
 
 **Alternative: Manual installation (if not using official images):**
 ```dockerfile
-FROM openjdk:11-jdk
+FROM bellsoft/liberica-openjdk-debian:11-cds
 RUN curl -L https://github.com/btraceio/btrace/releases/download/v2.2.2/btrace-2.2.2.tar.gz \
     | tar -xz -C /opt/
 ENV BTRACE_HOME=/opt/btrace-2.2.2

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -778,7 +778,7 @@ Error: tools.jar not found
 # Instead of JRE
 FROM openjdk:11-jre
 # Use JDK
-FROM openjdk:11-jdk
+FROM bellsoft/liberica-openjdk-debian:11-cds
 ```
 
 **Option 2: Install JDK in running pod** (temporary)
@@ -794,7 +794,7 @@ spec:
   - name: app
     image: myapp-jre:latest  # Can use JRE
   - name: btrace
-    image: openjdk:11-jdk     # Sidecar has JDK
+    image: bellsoft/liberica-openjdk-debian:11-cds     # Sidecar has JDK
 ```
 
 ### Service Mesh Compatibility


### PR DESCRIPTION
## Changes

### Docker Layer Support
- **docker/Dockerfile** - Debian-based variant with full tooling (~25MB)
- **docker/Dockerfile.alpine** - Alpine-based variant for Kubernetes sidecars (~15MB)  
- **docker/Dockerfile.distroless** - Minimal distroless variant for production (~10MB)
- **docker/docker-entrypoint.sh** - Entrypoint script for environment initialization
- **docker/.dockerignore** - Build context optimization
- **docker/README.md** - Comprehensive documentation with 5 usage patterns
- **btrace-dist/build.gradle** - Added Docker build tasks (opt-in via -PdockerEnabled)
- **README.md** - Added Docker images section with quick start
- **docs/GettingStarted.md** - Updated with official Docker images and Kubernetes sidecar examples

#### Docker Usage Example
```dockerfile
FROM btrace/btrace:2.3.0 AS btrace
FROM bellsoft/liberica-openjdk-debian:11-cds

COPY --from=btrace /opt/btrace /opt/btrace
ENV BTRACE_HOME=/opt/btrace PATH="${PATH}:${BTRACE_HOME}/bin"
```

#### Building Docker Images
```bash
./gradlew :btrace-dist:buildDockerImages -PdockerEnabled
```


### Key Features

#### Docker Integration
- Three optimized image variants for different use cases
- Multi-stage build pattern following industry best practices
- Comprehensive documentation with Kubernetes sidecar examples
- Gradle build tasks for local image building
- Ready for Docker Hub/GHCR publishing (follow-up work)

### Testing

- [x] Docker build tasks verified (`./gradlew :btrace-dist:tasks --group=Docker`)

## Documentation Quality
- ✅ Docker images following industry best practices (Gradle, Maven, Node.js patterns)

## Next Steps (Follow-up PRs)
- GitHub Actions integration for automated Docker image publishing
- Docker Hub organization setup and secrets configuration
- CI/CD testing for Docker images

🤖 Generated with [Claude Code](https://claude.com/claude-code)