### PR TITLE
Add automated JDK version update workflow

### DIFF
--- a/.github/workflows/update-jdk-versions.yml
+++ b/.github/workflows/update-jdk-versions.yml
@@ -1,0 +1,50 @@
+name: Update JDK Test Versions
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+
+      - name: Check for version updates
+        id: update
+        run: |
+          chmod +x scripts/update-jdk-versions.sh
+          if changes=$(scripts/update-jdk-versions.sh); then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "body<<EOF"
+              echo "$changes"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Pull Request
+        if: steps.update.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automation/update-jdk-versions
+          base: develop
+          title: 'chore: update JDK test versions'
+          draft: true
+          labels: automation
+          commit-message: 'chore: update JDK test versions'
+          body: |
+            Automated JDK version update detected by SDKMan API.
+
+            ### Changes
+            ${{ steps.update.outputs.body }}

--- a/scripts/update-jdk-versions.sh
+++ b/scripts/update-jdk-versions.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Checks for newer JDK versions on SDKMan and updates workflow files.
+# Exit 0 = changes made, exit 1 = no changes needed, exit 2 = error.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CONTINUOUS="$REPO_ROOT/.github/workflows/continuous.yml"
+RELEASE="$REPO_ROOT/.github/workflows/release.yml"
+
+SDKMAN_API="https://api.sdkman.io/2/candidates/java/linuxx64/versions/all"
+
+# Portable in-place sed (works on both GNU and BSD sed)
+sed_i() {
+  local expr=$1; shift
+  for f in "$@"; do
+    sed -i.bak "$expr" "$f" && rm -f "$f.bak"
+  done
+}
+
+echo "Fetching SDKMan version list..." >&2
+ALL_VERSIONS=$(curl -sf "$SDKMAN_API") || {
+  echo "ERROR: Failed to fetch SDKMan version list" >&2
+  exit 2
+}
+
+VERSION_LIST=$(printf '%s' "$ALL_VERSIONS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+# Find the latest Temurin GA release for a given major version.
+# Handles both X.0.N-tem and bare X-tem identifiers.
+latest_temurin_ga() {
+  local major=$1
+  printf '%s\n' "$VERSION_LIST" | grep -E "^${major}(\\.0\\.[0-9]+)?-tem$" | sort -V | tail -1
+}
+
+# Find the latest OpenJDK EA build for a given major version.
+latest_ea_open() {
+  local major=$1
+  printf '%s\n' "$VERSION_LIST" | grep -E "^${major}\\.ea\\.[0-9]+-open$" | sort -t. -k3 -n | tail -1
+}
+
+# --- Extract current versions ---
+
+# Test matrix from continuous.yml (superset of release.yml)
+MATRIX_VERSIONS=$(grep 'java:.*\[' "$CONTINUOUS" | head -1 \
+  | sed 's/.*\[//;s/\].*//' | tr ',' '\n' \
+  | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+# Build JDK from the "echo 'y' | sdk install java" line
+BUILD_JDK=$(grep "echo 'y' | sdk install java" "$CONTINUOUS" | head -1 \
+  | sed "s/.*sdk install java //" | tr -d "[:space:]")
+
+# --- Resolve and apply updates ---
+
+CHANGES=()
+
+for ver in $MATRIX_VERSIONS; do
+  if [[ "$ver" =~ ^([0-9]+)(\.0\.[0-9]+)?-tem$ ]]; then
+    major="${BASH_REMATCH[1]}"
+    latest=$(latest_temurin_ga "$major")
+    if [[ -n "$latest" && "$latest" != "$ver" ]]; then
+      CHANGES+=("$ver -> $latest")
+      # Only replace on matrix lines to avoid substring matches (e.g. 25-tem inside 11.0.25-tem)
+      sed_i "/java:.*\[/s|${ver}|${latest}|g" "$CONTINUOUS" "$RELEASE"
+    fi
+  elif [[ "$ver" =~ ^([0-9]+)\.ea\.([0-9]+)-open$ ]]; then
+    major="${BASH_REMATCH[1]}"
+    latest=$(latest_ea_open "$major")
+    if [[ -n "$latest" && "$latest" != "$ver" ]]; then
+      CHANGES+=("$ver -> $latest")
+      sed_i "/java:.*\[/s|${ver}|${latest}|g" "$CONTINUOUS" "$RELEASE"
+    fi
+  fi
+done
+
+# Update build JDK if stale
+if [[ -n "$BUILD_JDK" && "$BUILD_JDK" =~ ^([0-9]+) ]]; then
+  build_major="${BASH_REMATCH[1]}"
+  latest_build=$(latest_temurin_ga "$build_major")
+  if [[ -n "$latest_build" && "$latest_build" != "$BUILD_JDK" ]]; then
+    CHANGES+=("build JDK: $BUILD_JDK -> $latest_build")
+    sed_i "s|sdk install java ${BUILD_JDK}|sdk install java ${latest_build}|g" "$CONTINUOUS" "$RELEASE"
+  fi
+fi
+
+# --- Report results ---
+
+if [[ ${#CHANGES[@]} -eq 0 ]]; then
+  echo "All JDK versions are up to date." >&2
+  exit 1
+fi
+
+for change in "${CHANGES[@]}"; do
+  echo "- $change"
+done
+exit 0


### PR DESCRIPTION
## Summary
- Add `scripts/update-jdk-versions.sh` that queries the SDKMan API for latest JDK versions and updates `continuous.yml` / `release.yml` in-place
- Add `.github/workflows/update-jdk-versions.yml` scheduled workflow (weekly Monday 6 AM UTC + manual trigger) that runs the script and opens a draft PR via `peter-evans/create-pull-request`
- Covers Temurin GA (8, 11, 17, 21, 25), OpenJDK EA (26), and the build JDK (currently stale at 11.0.25-tem vs matrix 11.0.27-tem)

## Test plan
- [x] Script runs locally and correctly detects version drift against live SDKMan API
- [x] Workflow YAML validates
- [x] sed replacements scoped to matrix lines only (avoids substring collision e.g. `25-tem` inside `11.0.25-tem`)
- [ ] Trigger workflow manually via `gh workflow run update-jdk-versions.yml` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)