### PR TITLE
chore: update JDK test versions

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8.0.452-tem, 11.0.27-tem, 17.0.15-tem, 21.0.7-tem, 25-tem, 26.ea.2-open ]
+        java: [ 8.0.482-tem, 11.0.30-tem, 17.0.18-tem, 21.0.10-tem, 25.0.2-tem, 26.ea.35-open ]
     env:
       TEST_JAVA_HOME: "/home/runner/.sdkman/candidates/java/${{ matrix.java }}"
     steps:
@@ -112,7 +112,7 @@ jobs:
           source "$HOME/.sdkman/bin/sdkman-init.sh"
           echo 'n' | sdk install java ${{ matrix.java }}
           which java
-          echo 'y' | sdk install java 11.0.25-tem
+          echo 'y' | sdk install java 11.0.30-tem
       - name: Cache Gradle
         uses: actions/cache@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8.0.452-tem, 11.0.27-tem, 17.0.15-tem, 21.0.7-tem]
+        java: [8.0.482-tem, 11.0.30-tem, 17.0.18-tem, 21.0.10-tem]
     env:
       TEST_JAVA_HOME: "/home/runner/.sdkman/candidates/java/${{ matrix.java }}"
     steps:
@@ -249,7 +249,7 @@ jobs:
           source "$HOME/.sdkman/bin/sdkman-init.sh"
           echo 'n' | sdk install java ${{ matrix.java }}
           which java
-          echo 'y' | sdk install java 11.0.25-tem
+          echo 'y' | sdk install java 11.0.30-tem
 
       - name: Cache Gradle
         uses: actions/cache@v5


### PR DESCRIPTION
Automated JDK version update detected by SDKMan API.

### Changes
- 8.0.452-tem -> 8.0.482-tem
- 11.0.27-tem -> 11.0.30-tem
- 17.0.15-tem -> 17.0.18-tem
- 21.0.7-tem -> 21.0.10-tem
- 25-tem -> 25.0.2-tem
- 26.ea.2-open -> 26.ea.35-open
- build JDK: 11.0.25-tem -> 11.0.30-tem