### PR TITLE
ci: consolidate dependency bots — remove Dependabot, keep Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,21 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended",
+    ":semanticCommits",
+    "group:allNonMajor"
+  ],
+  "baseBranches": ["develop"],
+  "schedule": ["before 9am on monday"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "additionalLabels": ["github-actions"]
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Remove `.github/dependabot.yml` and `.github/workflows/dependabot-auto-merge.yml`
- Enhance `renovate.json` to fully replace Dependabot with Renovate's native capabilities

## Why Renovate over Dependabot
- **Grouped PRs**: Minor/patch updates are grouped into a single PR instead of one per dependency
- **Built-in auto-merge**: No separate workflow needed — Renovate handles it natively
- **Semantic commits**: Automatic `chore(deps):` / `fix(deps):` prefixes
- **Better Gradle support**: More mature dependency detection and update strategies

## What the new Renovate config does
- Targets `develop` branch (same as Dependabot was)
- Weekly schedule (Mondays before 9am), same cadence as before
- Labels PRs with `dependencies` (and `github-actions` for action updates)
- Auto-merges minor and patch updates
- Groups all non-major updates into a single PR

## Test plan
- [ ] Verify Renovate bot picks up the new config and creates dependency update PRs
- [ ] Confirm auto-merge works for minor/patch updates
- [ ] Verify no more Dependabot PRs are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/823)
<!-- Reviewable:end -->
