### PR TITLE
feat: @ExternalType adapter generator for provided-style extensions

### DIFF
--- a/btrace-client/src/main/java/org/openjdk/btrace/client/Client.java
+++ b/btrace-client/src/main/java/org/openjdk/btrace/client/Client.java
@@ -726,15 +726,31 @@ public class Client {
       String allowExternalLibs = System.getProperty("btrace.allowExternalLibs");
       String testSkipLibs = System.getProperty("btrace.test.skipLibs");
       if (manifestLibs != null && !manifestLibs.isEmpty()) {
+        if (manifestLibs.indexOf(',') >= 0) {
+          throw new IllegalArgumentException(
+              "System property btrace.feature.manifestLibs must not contain ','");
+        }
         agentArgs += "," + "$btrace.feature.manifestLibs" + "=" + manifestLibs;
       }
       if (sysAppendJar != null && !sysAppendJar.isEmpty()) {
+        if (sysAppendJar.indexOf(',') >= 0) {
+          throw new IllegalArgumentException(
+              "System property btrace.system.appendJar must not contain ','");
+        }
         agentArgs += "," + "$btrace.system.appendJar" + "=" + sysAppendJar;
       }
       if (allowExternalLibs != null && !allowExternalLibs.isEmpty()) {
+        if (allowExternalLibs.indexOf(',') >= 0) {
+          throw new IllegalArgumentException(
+              "System property btrace.allowExternalLibs must not contain ','");
+        }
         agentArgs += "," + "$btrace.allowExternalLibs" + "=" + allowExternalLibs;
       }
       if (testSkipLibs != null && !testSkipLibs.isEmpty()) {
+        if (testSkipLibs.indexOf(',') >= 0) {
+          throw new IllegalArgumentException(
+              "System property btrace.test.skipLibs must not contain ','");
+        }
         agentArgs += "," + "$btrace.test.skipLibs" + "=" + testSkipLibs;
       }
       if (log.isDebugEnabled()) {

--- a/btrace-core/src/main/java/org/openjdk/btrace/core/extensions/ExternalType.java
+++ b/btrace-core/src/main/java/org/openjdk/btrace/core/extensions/ExternalType.java
@@ -1,0 +1,33 @@
+package org.openjdk.btrace.core.extensions;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an interface as the build-time contract for an <em>external</em> application type — one
+ * whose class is not available at the extension's compile/link time and must be resolved at run
+ * time via the application's class loader.
+ *
+ * <p>When combined with the {@code @ExternalType} annotation processor, a companion adapter class
+ * named {@code <InterfaceSimpleName>$Ext} is generated in the same package with static dispatchers
+ * for each declared method. Dispatchers lazily resolve the target class and method via {@link
+ * java.lang.invoke.MethodHandles#publicLookup()} and cache the resulting {@link
+ * java.lang.invoke.MethodHandle}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ExternalType {
+  /** Fully-qualified name of the external type this interface adapts. */
+  String value();
+
+  /**
+   * Marks an interface method as a static method on the external type. Without this annotation,
+   * methods are resolved with {@code findVirtual} and dispatched against the receiver passed as the
+   * first adapter argument.
+   */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.METHOD)
+  @interface Static {}
+}

--- a/btrace-core/src/test/java/org/openjdk/btrace/core/extensions/ExternalTypeAnnotationTest.java
+++ b/btrace-core/src/test/java/org/openjdk/btrace/core/extensions/ExternalTypeAnnotationTest.java
@@ -1,0 +1,39 @@
+package org.openjdk.btrace.core.extensions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.annotation.*;
+import org.junit.jupiter.api.Test;
+
+class ExternalTypeAnnotationTest {
+  @ExternalType("com.example.App")
+  interface FakeApi {
+    @ExternalType.Static
+    Object create(String name);
+
+    int counter();
+  }
+
+  @Test
+  void annotationValuePreserved() {
+    ExternalType a = FakeApi.class.getAnnotation(ExternalType.class);
+    assertNotNull(a);
+    assertEquals("com.example.App", a.value());
+  }
+
+  @Test
+  void staticAnnotationOnMethod() throws NoSuchMethodException {
+    assertNotNull(
+        FakeApi.class
+            .getDeclaredMethod("create", String.class)
+            .getAnnotation(ExternalType.Static.class));
+    assertNull(
+        FakeApi.class.getDeclaredMethod("counter").getAnnotation(ExternalType.Static.class));
+  }
+
+  @Test
+  void retentionIsRuntime() {
+    Retention r = ExternalType.class.getAnnotation(Retention.class);
+    assertEquals(RetentionPolicy.RUNTIME, r.value());
+  }
+}

--- a/btrace-extension-processor/build.gradle
+++ b/btrace-extension-processor/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+  implementation project(':btrace-core')
+}

--- a/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/AdapterEmitter.java
+++ b/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/AdapterEmitter.java
@@ -1,0 +1,35 @@
+package org.openjdk.btrace.extension.processor;
+
+import java.io.PrintWriter;
+
+final class AdapterEmitter {
+  private final AdapterSpec spec;
+
+  AdapterEmitter(AdapterSpec spec) {
+    this.spec = spec;
+  }
+
+  void render(PrintWriter w) {
+    if (!spec.pkg.isEmpty()) w.println("package " + spec.pkg + ";");
+    w.println();
+    w.println("public final class " + spec.adapterSimpleName() + " {");
+    w.println("  private " + spec.adapterSimpleName() + "() {}");
+    for (MethodSpec m : spec.methods) {
+      renderMethod(w, m);
+    }
+    w.println("}");
+  }
+
+  private void renderMethod(PrintWriter w, MethodSpec m) {
+    StringBuilder params = new StringBuilder();
+    if (!m.isStatic) params.append("java.lang.Object self");
+    for (int i = 0; i < m.paramTypes.size(); i++) {
+      if (params.length() > 0) params.append(", ");
+      params.append(m.paramTypes.get(i)).append(" p").append(i);
+    }
+    w.println();
+    w.println("  public static " + m.returnType + " " + m.name + "(" + params + ") {");
+    w.println("    throw new UnsupportedOperationException(\"not implemented\");");
+    w.println("  }");
+  }
+}

--- a/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/AdapterEmitter.java
+++ b/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/AdapterEmitter.java
@@ -12,24 +12,92 @@ final class AdapterEmitter {
   void render(PrintWriter w) {
     if (!spec.pkg.isEmpty()) w.println("package " + spec.pkg + ";");
     w.println();
+    w.println("import java.lang.invoke.MethodHandle;");
+    w.println("import java.lang.invoke.MethodHandles;");
+    w.println("import java.lang.invoke.MethodType;");
+    w.println();
     w.println("public final class " + spec.adapterSimpleName() + " {");
+    w.println("  private static final String OWNER = \"" + spec.externalFqn + "\";");
     w.println("  private " + spec.adapterSimpleName() + "() {}");
-    for (MethodSpec m : spec.methods) {
-      renderMethod(w, m);
-    }
+    for (MethodSpec m : spec.methods) renderMethod(w, m);
+    renderSneak(w);
     w.println("}");
   }
 
   private void renderMethod(PrintWriter w, MethodSpec m) {
-    StringBuilder params = new StringBuilder();
-    if (!m.isStatic) params.append("java.lang.Object self");
-    for (int i = 0; i < m.paramTypes.size(); i++) {
-      if (params.length() > 0) params.append(", ");
-      params.append(m.paramTypes.get(i)).append(" p").append(i);
-    }
+    String mhField = "$" + m.name + "$mh";
+    String paramList = paramList(m);
+    String argList = argList(m);
+    String loaderExpr =
+        m.isStatic
+            ? "Thread.currentThread().getContextClassLoader()"
+            : "self.getClass().getClassLoader()";
+
     w.println();
-    w.println("  public static " + m.returnType + " " + m.name + "(" + params + ") {");
-    w.println("    throw new UnsupportedOperationException(\"not implemented\");");
+    w.println("  private static volatile java.lang.invoke.MethodHandle " + mhField + ";");
+    w.println();
+    w.println("  public static " + m.returnType + " " + m.name + "(" + paramList + ") {");
+    w.println("    try {");
+    w.println("      MethodHandle h = " + mhField + ";");
+    w.println("      if (h == null) h = $" + m.name + "$resolve(" + loaderExpr + ");");
+    w.print("      ");
+    if (!"void".equals(m.returnType)) w.print("return (" + m.returnType + ") ");
+    w.println("h.invoke(" + argList + ");");
+    w.println("    } catch (Throwable t) { throw sneak(t); }");
     w.println("  }");
+    renderResolver(w, m, mhField);
+  }
+
+  private void renderResolver(PrintWriter w, MethodSpec m, String field) {
+    w.println();
+    w.println(
+        "  private static MethodHandle $" + m.name + "$resolve(ClassLoader cl) throws Exception {");
+    w.println("    MethodHandle local = " + field + ";");
+    w.println("    if (local == null) {");
+    w.println("      Class<?> c = Class.forName(OWNER, false, cl);");
+    w.print("      MethodType mt = MethodType.methodType(");
+    w.print(m.returnType + ".class");
+    for (String p : m.paramTypes) w.print(", " + p + ".class");
+    w.println(");");
+    if (m.isStatic) {
+      w.println(
+          "      local = MethodHandles.publicLookup().findStatic(c, \"" + m.name + "\", mt);");
+    } else {
+      w.println(
+          "      local = MethodHandles.publicLookup().findVirtual(c, \"" + m.name + "\", mt);");
+    }
+    w.println("      " + field + " = local;");
+    w.println("    }");
+    w.println("    return local;");
+    w.println("  }");
+  }
+
+  private void renderSneak(PrintWriter w) {
+    w.println();
+    w.println("  @SuppressWarnings(\"unchecked\")");
+    w.println(
+        "  private static <T extends Throwable> RuntimeException sneak(Throwable t) throws T {");
+    w.println("    throw (T) t;");
+    w.println("  }");
+  }
+
+  private String paramList(MethodSpec m) {
+    StringBuilder sb = new StringBuilder();
+    if (!m.isStatic) sb.append("java.lang.Object self");
+    for (int i = 0; i < m.paramTypes.size(); i++) {
+      if (sb.length() > 0) sb.append(", ");
+      sb.append(m.paramTypes.get(i)).append(" p").append(i);
+    }
+    return sb.toString();
+  }
+
+  private String argList(MethodSpec m) {
+    StringBuilder sb = new StringBuilder();
+    if (!m.isStatic) sb.append("self");
+    for (int i = 0; i < m.paramTypes.size(); i++) {
+      if (sb.length() > 0) sb.append(", ");
+      sb.append("p").append(i);
+    }
+    return sb.toString();
   }
 }

--- a/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/AdapterSpec.java
+++ b/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/AdapterSpec.java
@@ -1,0 +1,26 @@
+package org.openjdk.btrace.extension.processor;
+
+import java.util.Collections;
+import java.util.List;
+
+final class AdapterSpec {
+  final String pkg;
+  final String interfaceSimpleName;
+  final String externalFqn;
+  final List<MethodSpec> methods;
+
+  AdapterSpec(String pkg, String interfaceSimpleName, String externalFqn, List<MethodSpec> methods) {
+    this.pkg = pkg;
+    this.interfaceSimpleName = interfaceSimpleName;
+    this.externalFqn = externalFqn;
+    this.methods = Collections.unmodifiableList(new java.util.ArrayList<>(methods));
+  }
+
+  String adapterSimpleName() {
+    return interfaceSimpleName + "$Ext";
+  }
+
+  String adapterFqn() {
+    return pkg.isEmpty() ? adapterSimpleName() : pkg + "." + adapterSimpleName();
+  }
+}

--- a/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessor.java
+++ b/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessor.java
@@ -1,0 +1,19 @@
+/* (C) 2024 */
+package org.openjdk.btrace.extension.processor;
+
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+
+@SupportedAnnotationTypes("org.openjdk.btrace.core.extensions.ExternalType")
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+public final class ExternalTypeProcessor extends AbstractProcessor {
+  @Override
+  public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    return false;
+  }
+}

--- a/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessor.java
+++ b/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessor.java
@@ -1,7 +1,10 @@
 /* (C) 2024 */
 package org.openjdk.btrace.extension.processor;
 
+import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
@@ -10,7 +13,10 @@ import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 import org.openjdk.btrace.core.extensions.ExternalType;
@@ -23,19 +29,9 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
     for (Element e : roundEnv.getElementsAnnotatedWith(ExternalType.class)) {
       if (e.getKind() != ElementKind.INTERFACE) continue;
       TypeElement iface = (TypeElement) e;
-      String pkg =
-          processingEnv.getElementUtils().getPackageOf(iface).getQualifiedName().toString();
-      String simple = iface.getSimpleName().toString();
-      String adapterFqn = (pkg.isEmpty() ? "" : pkg + ".") + simple + "$Ext";
+      AdapterSpec spec = buildSpec(iface);
       try {
-        JavaFileObject jfo = processingEnv.getFiler().createSourceFile(adapterFqn, iface);
-        try (PrintWriter w = new PrintWriter(jfo.openWriter())) {
-          if (!pkg.isEmpty()) w.println("package " + pkg + ";");
-          w.println();
-          w.println("public final class " + simple + "$Ext {");
-          w.println("  private " + simple + "$Ext() {}");
-          w.println("}");
-        }
+        emit(spec, iface);
       } catch (Exception ex) {
         processingEnv
             .getMessager()
@@ -46,5 +42,31 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
       }
     }
     return true;
+  }
+
+  private AdapterSpec buildSpec(TypeElement iface) {
+    String pkg =
+        processingEnv.getElementUtils().getPackageOf(iface).getQualifiedName().toString();
+    String simple = iface.getSimpleName().toString();
+    String externalFqn = iface.getAnnotation(ExternalType.class).value();
+    List<MethodSpec> methods = new ArrayList<>();
+    for (Element m : iface.getEnclosedElements()) {
+      if (m.getKind() != ElementKind.METHOD) continue;
+      ExecutableElement em = (ExecutableElement) m;
+      if (em.isDefault() || em.getModifiers().contains(Modifier.STATIC)) continue;
+      boolean isStatic = em.getAnnotation(ExternalType.Static.class) != null;
+      String rt = em.getReturnType().toString();
+      List<String> params = new ArrayList<>();
+      for (VariableElement p : em.getParameters()) params.add(p.asType().toString());
+      methods.add(new MethodSpec(em.getSimpleName().toString(), rt, params, isStatic));
+    }
+    return new AdapterSpec(pkg, simple, externalFqn, methods);
+  }
+
+  private void emit(AdapterSpec spec, TypeElement origin) throws IOException {
+    JavaFileObject jfo = processingEnv.getFiler().createSourceFile(spec.adapterFqn(), origin);
+    try (PrintWriter w = new PrintWriter(jfo.openWriter())) {
+      new AdapterEmitter(spec).render(w);
+    }
   }
 }

--- a/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessor.java
+++ b/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessor.java
@@ -1,19 +1,50 @@
 /* (C) 2024 */
 package org.openjdk.btrace.extension.processor;
 
+import java.io.PrintWriter;
 import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import org.openjdk.btrace.core.extensions.ExternalType;
 
 @SupportedAnnotationTypes("org.openjdk.btrace.core.extensions.ExternalType")
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 public final class ExternalTypeProcessor extends AbstractProcessor {
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-    return false;
+    for (Element e : roundEnv.getElementsAnnotatedWith(ExternalType.class)) {
+      if (e.getKind() != ElementKind.INTERFACE) continue;
+      TypeElement iface = (TypeElement) e;
+      String pkg =
+          processingEnv.getElementUtils().getPackageOf(iface).getQualifiedName().toString();
+      String simple = iface.getSimpleName().toString();
+      String adapterFqn = (pkg.isEmpty() ? "" : pkg + ".") + simple + "$Ext";
+      try {
+        JavaFileObject jfo = processingEnv.getFiler().createSourceFile(adapterFqn, iface);
+        try (PrintWriter w = new PrintWriter(jfo.openWriter())) {
+          if (!pkg.isEmpty()) w.println("package " + pkg + ";");
+          w.println();
+          w.println("public final class " + simple + "$Ext {");
+          w.println("  private " + simple + "$Ext() {}");
+          w.println("}");
+        }
+      } catch (Exception ex) {
+        processingEnv
+            .getMessager()
+            .printMessage(
+                Diagnostic.Kind.ERROR,
+                "Failed to emit adapter for " + iface.getQualifiedName() + ": " + ex,
+                iface);
+      }
+    }
+    return true;
   }
 }

--- a/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessor.java
+++ b/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessor.java
@@ -27,8 +27,29 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
     for (Element e : roundEnv.getElementsAnnotatedWith(ExternalType.class)) {
-      if (e.getKind() != ElementKind.INTERFACE) continue;
+      if (e.getKind() != ElementKind.INTERFACE) {
+        processingEnv
+            .getMessager()
+            .printMessage(
+                Diagnostic.Kind.ERROR,
+                "@ExternalType can only be applied to interfaces; found "
+                    + e.getKind()
+                    + " "
+                    + e,
+                e);
+        continue;
+      }
       TypeElement iface = (TypeElement) e;
+      String externalFqn = iface.getAnnotation(ExternalType.class).value();
+      if (externalFqn == null || externalFqn.isEmpty()) {
+        processingEnv
+            .getMessager()
+            .printMessage(
+                Diagnostic.Kind.ERROR,
+                "@ExternalType.value() must be a non-empty class name on " + iface.getQualifiedName(),
+                iface);
+        continue;
+      }
       AdapterSpec spec = buildSpec(iface);
       try {
         emit(spec, iface);

--- a/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessor.java
+++ b/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessor.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -22,8 +21,13 @@ import javax.tools.JavaFileObject;
 import org.openjdk.btrace.core.extensions.ExternalType;
 
 @SupportedAnnotationTypes("org.openjdk.btrace.core.extensions.ExternalType")
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public final class ExternalTypeProcessor extends AbstractProcessor {
+
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latestSupported();
+  }
+
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
     for (Element e : roundEnv.getElementsAnnotatedWith(ExternalType.class)) {
@@ -76,9 +80,11 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
       ExecutableElement em = (ExecutableElement) m;
       if (em.isDefault() || em.getModifiers().contains(Modifier.STATIC)) continue;
       boolean isStatic = em.getAnnotation(ExternalType.Static.class) != null;
-      String rt = em.getReturnType().toString();
+      String rt = processingEnv.getTypeUtils().erasure(em.getReturnType()).toString();
       List<String> params = new ArrayList<>();
-      for (VariableElement p : em.getParameters()) params.add(p.asType().toString());
+      for (VariableElement p : em.getParameters()) {
+        params.add(processingEnv.getTypeUtils().erasure(p.asType()).toString());
+      }
       methods.add(new MethodSpec(em.getSimpleName().toString(), rt, params, isStatic));
     }
     return new AdapterSpec(pkg, simple, externalFqn, methods);

--- a/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/MethodSpec.java
+++ b/btrace-extension-processor/src/main/java/org/openjdk/btrace/extension/processor/MethodSpec.java
@@ -1,0 +1,18 @@
+package org.openjdk.btrace.extension.processor;
+
+import java.util.Collections;
+import java.util.List;
+
+final class MethodSpec {
+  final String name;
+  final String returnType;
+  final List<String> paramTypes;
+  final boolean isStatic;
+
+  MethodSpec(String name, String returnType, List<String> paramTypes, boolean isStatic) {
+    this.name = name;
+    this.returnType = returnType;
+    this.paramTypes = Collections.unmodifiableList(new java.util.ArrayList<>(paramTypes));
+    this.isStatic = isStatic;
+  }
+}

--- a/btrace-extension-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/btrace-extension-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.openjdk.btrace.extension.processor.ExternalTypeProcessor

--- a/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/CompileTestHarness.java
+++ b/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/CompileTestHarness.java
@@ -88,6 +88,13 @@ public final class CompileTestHarness {
       if (kind == JavaFileObject.Kind.SOURCE) {
         return new SimpleJavaFileObject(
             URI.create("mem:///" + className.replace('.', '/') + kind.extension), kind) {
+          private String content = null;
+
+          @Override
+          public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+            return content != null ? content : "";
+          }
+
           @Override
           public Writer openWriter() {
             StringWriter sw = new StringWriter();
@@ -102,7 +109,8 @@ public final class CompileTestHarness {
 
               @Override
               public void close() {
-                sources.put(className, sw.toString());
+                content = sw.toString();
+                sources.put(className, content);
               }
             };
           }

--- a/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/CompileTestHarness.java
+++ b/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/CompileTestHarness.java
@@ -59,7 +59,66 @@ public final class CompileTestHarness {
     return new Result(ok, mgr.generatedSources(), diags.getDiagnostics());
   }
 
-  private static final class StringSource extends SimpleJavaFileObject {
+  public static final class RunnableResult {
+    public final boolean success;
+    public final List<Diagnostic<? extends JavaFileObject>> diagnostics;
+    public final ClassLoader loader;
+
+    RunnableResult(
+        boolean success,
+        List<Diagnostic<? extends JavaFileObject>> diags,
+        ClassLoader loader) {
+      this.success = success;
+      this.diagnostics = diags;
+      this.loader = loader;
+    }
+
+    public String errors() {
+      return diagnostics.stream()
+          .filter(d -> d.getKind() == Diagnostic.Kind.ERROR)
+          .map(Object::toString)
+          .collect(Collectors.joining("\n"));
+    }
+  }
+
+  public static RunnableResult compileAndLoad(Map<String, String> sources) throws IOException {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    if (compiler == null) {
+      throw new IllegalStateException("No JavaCompiler available — run tests on a JDK, not JRE");
+    }
+    DiagnosticCollector<JavaFileObject> diags = new DiagnosticCollector<>();
+    StandardJavaFileManager std =
+        compiler.getStandardFileManager(diags, Locale.ROOT, StandardCharsets.UTF_8);
+    InMemoryFileManager mgr = new InMemoryFileManager(std);
+
+    List<JavaFileObject> units = new ArrayList<>();
+    for (Map.Entry<String, String> e : sources.entrySet()) {
+      units.add(new StringSource(e.getKey(), e.getValue()));
+    }
+    List<String> options =
+        Arrays.asList(
+            "-classpath", System.getProperty("java.class.path"),
+            "-processor", ExternalTypeProcessor.class.getName());
+
+    JavaCompiler.CompilationTask task =
+        compiler.getTask(null, mgr, diags, options, null, units);
+    boolean ok = task.call();
+    if (!ok) return new RunnableResult(false, diags.getDiagnostics(), null);
+
+    ClassLoader loader =
+        new ClassLoader(CompileTestHarness.class.getClassLoader()) {
+          @Override
+          protected Class<?> findClass(String name) throws ClassNotFoundException {
+            ByteArrayOutputStream baos = mgr.bytes.get(name);
+            if (baos == null) throw new ClassNotFoundException(name);
+            byte[] b = baos.toByteArray();
+            return defineClass(name, b, 0, b.length);
+          }
+        };
+    return new RunnableResult(true, diags.getDiagnostics(), loader);
+  }
+
+  static final class StringSource extends SimpleJavaFileObject {
     private final String src;
 
     StringSource(String fqn, String src) {

--- a/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/CompileTestHarness.java
+++ b/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/CompileTestHarness.java
@@ -1,0 +1,128 @@
+package org.openjdk.btrace.extension.processor;
+
+import java.io.*;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
+import javax.tools.*;
+
+/**
+ * In-memory javac harness. Feeds the processor a set of named source strings and returns the
+ * generated source files + diagnostics.
+ */
+public final class CompileTestHarness {
+  public static final class Result {
+    public final boolean success;
+    public final Map<String, String> generatedSources;
+    public final List<Diagnostic<? extends JavaFileObject>> diagnostics;
+
+    Result(
+        boolean success,
+        Map<String, String> generated,
+        List<Diagnostic<? extends JavaFileObject>> diags) {
+      this.success = success;
+      this.generatedSources = generated;
+      this.diagnostics = diags;
+    }
+
+    public String errors() {
+      return diagnostics.stream()
+          .filter(d -> d.getKind() == Diagnostic.Kind.ERROR)
+          .map(Object::toString)
+          .collect(Collectors.joining("\n"));
+    }
+  }
+
+  public static Result compile(Map<String, String> sources) throws IOException {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    if (compiler == null) {
+      throw new IllegalStateException("No JavaCompiler available — run tests on a JDK, not JRE");
+    }
+    DiagnosticCollector<JavaFileObject> diags = new DiagnosticCollector<>();
+    StandardJavaFileManager std =
+        compiler.getStandardFileManager(diags, Locale.ROOT, StandardCharsets.UTF_8);
+    InMemoryFileManager mgr = new InMemoryFileManager(std);
+
+    List<JavaFileObject> units = new ArrayList<>();
+    for (Map.Entry<String, String> e : sources.entrySet()) {
+      units.add(new StringSource(e.getKey(), e.getValue()));
+    }
+
+    String cp = System.getProperty("java.class.path");
+    List<String> options =
+        Arrays.asList("-classpath", cp, "-processor", ExternalTypeProcessor.class.getName());
+
+    JavaCompiler.CompilationTask task =
+        compiler.getTask(null, mgr, diags, options, null, units);
+    boolean ok = task.call();
+    return new Result(ok, mgr.generatedSources(), diags.getDiagnostics());
+  }
+
+  private static final class StringSource extends SimpleJavaFileObject {
+    private final String src;
+
+    StringSource(String fqn, String src) {
+      super(
+          URI.create("string:///" + fqn.replace('.', '/') + Kind.SOURCE.extension), Kind.SOURCE);
+      this.src = src;
+    }
+
+    @Override
+    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+      return src;
+    }
+  }
+
+  static final class InMemoryFileManager extends ForwardingJavaFileManager<JavaFileManager> {
+    final Map<String, ByteArrayOutputStream> bytes = new LinkedHashMap<>();
+    private final Map<String, String> sources = new LinkedHashMap<>();
+
+    InMemoryFileManager(JavaFileManager m) {
+      super(m);
+    }
+
+    @Override
+    public JavaFileObject getJavaFileForOutput(
+        Location location, String className, JavaFileObject.Kind kind, FileObject sibling) {
+      if (kind == JavaFileObject.Kind.SOURCE) {
+        return new SimpleJavaFileObject(
+            URI.create("mem:///" + className.replace('.', '/') + kind.extension), kind) {
+          @Override
+          public Writer openWriter() {
+            StringWriter sw = new StringWriter();
+            return new Writer() {
+              @Override
+              public void write(char[] cbuf, int off, int len) {
+                sw.write(cbuf, off, len);
+              }
+
+              @Override
+              public void flush() {}
+
+              @Override
+              public void close() {
+                sources.put(className, sw.toString());
+              }
+            };
+          }
+        };
+      }
+      ByteArrayOutputStream baos =
+          bytes.computeIfAbsent(className, k -> new ByteArrayOutputStream());
+      return new SimpleJavaFileObject(
+          URI.create("mem:///" + className.replace('.', '/') + kind.extension), kind) {
+        @Override
+        public OutputStream openOutputStream() {
+          return baos;
+        }
+      };
+    }
+
+    Map<String, String> generatedSources() {
+      return sources;
+    }
+  }
+
+  private CompileTestHarness() {}
+}

--- a/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessorTest.java
+++ b/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessorTest.java
@@ -120,4 +120,34 @@ class ExternalTypeProcessorTest {
     int got = (int) m.invoke(null, instance);
     assertEquals(42, got);
   }
+
+  @Test
+  void rejectsAnnotationOnClass() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put("com.example.NotAnInterface", ""
+        + "package com.example;\n"
+        + "import org.openjdk.btrace.core.extensions.ExternalType;\n"
+        + "@ExternalType(\"com.example.app.Real\")\n"
+        + "public class NotAnInterface {}\n");
+
+    CompileTestHarness.Result r = CompileTestHarness.compile(sources);
+    assertFalse(r.success, "expected compile to fail");
+    assertTrue(r.errors().contains("@ExternalType can only be applied to interfaces"),
+        r.errors());
+  }
+
+  @Test
+  void rejectsEmptyValue() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put("com.example.Empty", ""
+        + "package com.example;\n"
+        + "import org.openjdk.btrace.core.extensions.ExternalType;\n"
+        + "@ExternalType(\"\")\n"
+        + "public interface Empty { int x(); }\n");
+
+    CompileTestHarness.Result r = CompileTestHarness.compile(sources);
+    assertFalse(r.success, "expected compile to fail");
+    assertTrue(r.errors().contains("@ExternalType.value() must be a non-empty class name"),
+        r.errors());
+  }
 }

--- a/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessorTest.java
+++ b/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessorTest.java
@@ -150,4 +150,27 @@ class ExternalTypeProcessorTest {
     assertTrue(r.errors().contains("@ExternalType.value() must be a non-empty class name"),
         r.errors());
   }
+
+  @Test
+  void generatedAdapterHandlesParameterizedTypes() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put("com.example.Listy", ""
+        + "package com.example;\n"
+        + "import java.util.List;\n"
+        + "import org.openjdk.btrace.core.extensions.ExternalType;\n"
+        + "@ExternalType(\"com.example.app.Real\")\n"
+        + "public interface Listy {\n"
+        + "  java.util.List<java.lang.String> items();\n"
+        + "  void process(java.util.List<java.lang.String> items);\n"
+        + "}\n");
+
+    CompileTestHarness.Result r = CompileTestHarness.compile(sources);
+    assertTrue(r.success, "compile failed; generated source likely has a bad type literal. errors:\n"
+        + r.errors());
+    String adapter = r.generatedSources.get("com.example.Listy$Ext");
+    assertNotNull(adapter);
+    // Raw type must appear in the MethodType literal (no angle brackets).
+    assertTrue(adapter.contains("MethodType.methodType(java.util.List.class"), adapter);
+    assertFalse(adapter.contains("java.util.List<java.lang.String>.class"), adapter);
+  }
 }

--- a/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessorTest.java
+++ b/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessorTest.java
@@ -1,0 +1,28 @@
+package org.openjdk.btrace.extension.processor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExternalTypeProcessorTest {
+
+  @Test
+  void generatesAdapterForAnnotatedInterface() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put("com.example.JobStart", ""
+        + "package com.example;\n"
+        + "import org.openjdk.btrace.core.extensions.ExternalType;\n"
+        + "@ExternalType(\"com.example.app.Real\")\n"
+        + "public interface JobStart {\n"
+        + "  int jobId();\n"
+        + "}\n");
+
+    CompileTestHarness.Result r = CompileTestHarness.compile(sources);
+    assertTrue(r.success, "compile failed:\n" + r.errors());
+    assertTrue(r.generatedSources.containsKey("com.example.JobStart$Ext"),
+        "expected adapter com.example.JobStart$Ext; generated: " + r.generatedSources.keySet());
+  }
+}

--- a/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessorTest.java
+++ b/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessorTest.java
@@ -48,4 +48,24 @@ class ExternalTypeProcessorTest {
     assertTrue(adapter.contains("public static long time("), adapter);
     assertTrue(adapter.contains("public static java.lang.Object create("), adapter);
   }
+
+  @Test
+  void virtualDispatcherUsesLazyMethodHandle() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put("com.example.JobStart", ""
+        + "package com.example;\n"
+        + "import org.openjdk.btrace.core.extensions.ExternalType;\n"
+        + "@ExternalType(\"com.example.app.Real\")\n"
+        + "public interface JobStart {\n"
+        + "  int jobId();\n"
+        + "}\n");
+
+    CompileTestHarness.Result r = CompileTestHarness.compile(sources);
+    assertTrue(r.success, r.errors());
+    String adapter = r.generatedSources.get("com.example.JobStart$Ext");
+    assertTrue(adapter.contains("private static volatile java.lang.invoke.MethodHandle"), adapter);
+    assertTrue(adapter.contains("findVirtual"), adapter);
+    assertTrue(adapter.contains("self.getClass().getClassLoader()"), adapter);
+    assertTrue(adapter.contains("(int)"), adapter);
+  }
 }

--- a/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessorTest.java
+++ b/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessorTest.java
@@ -68,4 +68,25 @@ class ExternalTypeProcessorTest {
     assertTrue(adapter.contains("self.getClass().getClassLoader()"), adapter);
     assertTrue(adapter.contains("(int)"), adapter);
   }
+
+  @Test
+  void staticDispatcherUsesTccl() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put("com.example.SparkUtils", ""
+        + "package com.example;\n"
+        + "import org.openjdk.btrace.core.extensions.ExternalType;\n"
+        + "@ExternalType(\"com.example.app.SparkUtils\")\n"
+        + "public interface SparkUtils {\n"
+        + "  @ExternalType.Static\n"
+        + "  java.lang.String version();\n"
+        + "}\n");
+
+    CompileTestHarness.Result r = CompileTestHarness.compile(sources);
+    assertTrue(r.success, r.errors());
+    String adapter = r.generatedSources.get("com.example.SparkUtils$Ext");
+    assertTrue(adapter.contains("findStatic"), adapter);
+    assertTrue(adapter.contains("Thread.currentThread().getContextClassLoader()"), adapter);
+    assertFalse(adapter.contains("java.lang.Object self"),
+        "static dispatcher must not take a receiver parameter: " + adapter);
+  }
 }

--- a/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessorTest.java
+++ b/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessorTest.java
@@ -25,4 +25,27 @@ class ExternalTypeProcessorTest {
     assertTrue(r.generatedSources.containsKey("com.example.JobStart$Ext"),
         "expected adapter com.example.JobStart$Ext; generated: " + r.generatedSources.keySet());
   }
+
+  @Test
+  void generatedAdapterContainsDispatchersForEachMethod() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put("com.example.JobStart", ""
+        + "package com.example;\n"
+        + "import org.openjdk.btrace.core.extensions.ExternalType;\n"
+        + "@ExternalType(\"com.example.app.Real\")\n"
+        + "public interface JobStart {\n"
+        + "  int jobId();\n"
+        + "  long time();\n"
+        + "  @ExternalType.Static\n"
+        + "  Object create(String name);\n"
+        + "}\n");
+
+    CompileTestHarness.Result r = CompileTestHarness.compile(sources);
+    assertTrue(r.success, r.errors());
+    String adapter = r.generatedSources.get("com.example.JobStart$Ext");
+    assertNotNull(adapter);
+    assertTrue(adapter.contains("public static int jobId("), adapter);
+    assertTrue(adapter.contains("public static long time("), adapter);
+    assertTrue(adapter.contains("public static java.lang.Object create("), adapter);
+  }
 }

--- a/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessorTest.java
+++ b/btrace-extension-processor/src/test/java/org/openjdk/btrace/extension/processor/ExternalTypeProcessorTest.java
@@ -89,4 +89,35 @@ class ExternalTypeProcessorTest {
     assertFalse(adapter.contains("java.lang.Object self"),
         "static dispatcher must not take a receiver parameter: " + adapter);
   }
+
+  @Test
+  void generatedAdapterInvokesRealMethod() throws Exception {
+    // The "external" class is just a regular class in the compile unit.
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put("com.example.target.Counter", ""
+        + "package com.example.target;\n"
+        + "public class Counter {\n"
+        + "  private final int v;\n"
+        + "  public Counter(int v) { this.v = v; }\n"
+        + "  public int value() { return v; }\n"
+        + "}\n");
+    sources.put("com.example.adapter.CounterApi", ""
+        + "package com.example.adapter;\n"
+        + "import org.openjdk.btrace.core.extensions.ExternalType;\n"
+        + "@ExternalType(\"com.example.target.Counter\")\n"
+        + "public interface CounterApi {\n"
+        + "  int value();\n"
+        + "}\n");
+
+    CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(r.success, r.errors());
+
+    Class<?> counter = r.loader.loadClass("com.example.target.Counter");
+    Object instance = counter.getConstructor(int.class).newInstance(42);
+
+    Class<?> adapter = r.loader.loadClass("com.example.adapter.CounterApi$Ext");
+    java.lang.reflect.Method m = adapter.getMethod("value", Object.class);
+    int got = (int) m.invoke(null, instance);
+    assertEquals(42, got);
+  }
 }

--- a/btrace-extensions/examples/btrace-spark/src/api/java/org/example/btrace/spark/api/SparkListenerJobStartType.java
+++ b/btrace-extensions/examples/btrace-spark/src/api/java/org/example/btrace/spark/api/SparkListenerJobStartType.java
@@ -1,0 +1,16 @@
+package org.example.btrace.spark.api;
+
+import org.openjdk.btrace.core.extensions.ExternalType;
+
+/**
+ * Build-time contract for {@code org.apache.spark.scheduler.SparkListenerJobStart}.
+ *
+ * <p>The annotation processor generates {@code SparkListenerJobStartType$Ext} in this same package
+ * with lazy-resolving static dispatchers for each declared method.
+ */
+@ExternalType("org.apache.spark.scheduler.SparkListenerJobStart")
+public interface SparkListenerJobStartType {
+  int jobId();
+
+  long time();
+}

--- a/btrace-extensions/examples/btrace-spark/src/impl/java/org/example/btrace/spark/impl/SparkApiImpl.java
+++ b/btrace-extensions/examples/btrace-spark/src/impl/java/org/example/btrace/spark/impl/SparkApiImpl.java
@@ -1,6 +1,7 @@
 package org.example.btrace.spark.impl;
 
 import org.example.btrace.spark.api.SparkApi;
+import org.example.btrace.spark.api.SparkListenerJobStartType$Ext;
 import org.openjdk.btrace.core.extensions.Extension;
 import org.openjdk.btrace.extension.util.ClassLoadingUtil;
 import org.openjdk.btrace.extension.util.MethodHandleCache;
@@ -16,30 +17,13 @@ public final class SparkApiImpl extends Extension implements SparkApi {
   @Override
   public void onJobStart(Object jobStartEvent) {
     if (jobStartEvent == null) return;
-    ClassLoadingUtil.withDefiningLoader(
-        jobStartEvent,
-        () -> {
-          try {
-            Class<?> evtCls = ClassLoadingUtil.loadFromContext(
-                "org.apache.spark.scheduler.SparkListenerJobStart", jobStartEvent);
-            MethodHandle getJobId = mh.findVirtual(evtCls, "jobId", int.class);
-            int jobId = (int) getJobId.invoke(jobStartEvent);
-            // Demonstrate multiple cached lookups (if method exists)
-            // For illustration purposes; real implementations should catch Lookup errors
-            // and log a single warning rather than per-event.
-            try {
-              MethodHandle submissionTime = mh.findVirtual(evtCls, "time", long.class);
-              long ts = (long) submissionTime.invoke(jobStartEvent);
-              // Example: println("Spark job "+jobId+" at "+ts)
-            } catch (MethodHandleCache.LookupRuntimeException ignored) {
-              // optional method; ignore if absent
-            }
-            // TODO: emit to BTrace runtime (left minimal for example)
-          } catch (Throwable ignored) {
-            // example: swallow; real impl should log via BTrace runtime logger
-          }
-          return null;
-        });
+    try {
+      int jobId = SparkListenerJobStartType$Ext.jobId(jobStartEvent);
+      long ts = SparkListenerJobStartType$Ext.time(jobStartEvent);
+      // Example: println("Spark job "+jobId+" at "+ts)
+    } catch (Throwable ignored) {
+      // example: swallow; real impl should log via BTrace runtime logger
+    }
   }
 
   @Override

--- a/btrace-gradle-plugin/README.md
+++ b/btrace-gradle-plugin/README.md
@@ -15,6 +15,7 @@ Build and package BTrace extensions with sane defaults.
 - Scans implementation bytecode to infer minimal required permissions
 - Writes extension metadata into the API JAR manifest
 - Produces three artifacts: API JAR, Impl JAR (shadowed), and distributable ZIP
+- Auto-registers the `@ExternalType` annotation processor on the api source set (generates typed, lazy-resolution adapters for application types — see `docs/architecture/provided-style-extensions.md`)
 
 ### Apply the Plugin
 

--- a/btrace-gradle-plugin/src/main/groovy/org/openjdk/btrace/gradle/BTraceExtensionPlugin.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/org/openjdk/btrace/gradle/BTraceExtensionPlugin.groovy
@@ -77,6 +77,17 @@ class BTraceExtensionPlugin implements Plugin<Project> {
             implCompileOnly.extendsFrom compileOnly
         }
 
+        // Auto-register @ExternalType annotation processor on the api source set.
+        // In-tree builds reference the sibling subproject directly; external consumers resolve
+        // the published artifact by version.
+        def processorProject = project.rootProject.findProject(':btrace-extension-processor')
+        if (processorProject != null) {
+            project.dependencies.add('apiAnnotationProcessor', processorProject)
+        } else {
+            project.dependencies.add('apiAnnotationProcessor',
+                "org.openjdk.btrace:btrace-extension-processor:${project.version}")
+        }
+
         // Configure duplicate handling for resource tasks
         project.tasks.withType(Copy).configureEach {
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Welcome to the BTrace documentation! BTrace is a safe, dynamic tracing tool for 
 
 ## Quick Start
 
-**New to BTrace?** Start here → [Getting Started Guide](gettingStarted.md)
+**New to BTrace?** Start here → [Getting Started Guide](GettingStarted.md)
 
 Get up and running in 5 minutes with installation, your first script, and common usage patterns.
 
@@ -12,36 +12,36 @@ Get up and running in 5 minutes with installation, your first script, and common
 
 | Document | Description | Target Audience |
 |----------|-------------|-----------------|
-| **[Getting Started](gettingStarted.md)** | Installation, first script, deployment modes, common pitfalls | New users, quick start |
-| **[Oneliner Guide](onelinerGuide.md)** | DTrace-style oneliners for quick debugging without scripts | Quick debugging, ops/SRE |
-| **[Quick Reference](quickReference.md)** | Annotations, patterns, CLI commands, built-in functions | Experienced users, quick lookup |
-| **[BTrace Tutorial](btraceTutorial.md)** | Comprehensive lessons covering all features | All users, in-depth learning |
-| **[Troubleshooting Guide](troubleshooting.md)** | Common errors, debugging, performance, compatibility | Problem-solving, debugging |
-| **[FAQ](faq.md)** | Common questions, best practices, comparisons | All users, decision-making |
+| **[Getting Started](GettingStarted.md)** | Installation, first script, deployment modes, common pitfalls | New users, quick start |
+| **[Oneliner Guide](OnelinerGuide.md)** | DTrace-style oneliners for quick debugging without scripts | Quick debugging, ops/SRE |
+| **[Quick Reference](QuickReference.md)** | Annotations, patterns, CLI commands, built-in functions | Experienced users, quick lookup |
+| **[BTrace Tutorial](BTraceTutorial.md)** | Comprehensive lessons covering all features | All users, in-depth learning |
+| **[Troubleshooting Guide](Troubleshooting.md)** | Common errors, debugging, performance, compatibility | Problem-solving, debugging |
+| **[FAQ](FAQ.md)** | Common questions, best practices, comparisons | All users, decision-making |
 
 ## Learning Paths
 
 ### I'm New to BTrace
-1. Read [Getting Started Guide](gettingStarted.md) (10 minutes)
+1. Read [Getting Started Guide](GettingStarted.md) (10 minutes)
 2. Try the 5-minute quick start example
-3. Learn [Oneliner syntax](onelinerGuide.md) for quick debugging (5 minutes)
-4. Explore [BTrace Tutorial](btraceTutorial.md) lessons 1-3
-5. Keep [Quick Reference](quickReference.md) handy
+3. Learn [Oneliner syntax](OnelinerGuide.md) for quick debugging (5 minutes)
+4. Explore [BTrace Tutorial](BTraceTutorial.md) lessons 1-3
+5. Keep [Quick Reference](QuickReference.md) handy
 
-Tip: Want latency histograms fast? See [Quick Start: Histogram Metrics Extension](gettingStarted.md#quick-start-histogram-metrics-extension) and the tutorial section [Using the Histogram Metrics Extension](btraceTutorial.md#using-the-histogram-metrics-extension-btrace-metrics).
+Tip: Want latency histograms fast? See [Quick Start: Histogram Metrics Extension](GettingStarted.md#quick-start-histogram-metrics-extension) and the tutorial section [Using the Histogram Metrics Extension](BTraceTutorial.md#using-the-histogram-metrics-extension-btrace-metrics).
 
 ### I Need to Solve a Problem
-1. Check [Troubleshooting Guide](troubleshooting.md) for your error
-2. Search [FAQ](faq.md) for similar issues
-3. Review [Getting Started](gettingStarted.md) common pitfalls
+1. Check [Troubleshooting Guide](Troubleshooting.md) for your error
+2. Search [FAQ](FAQ.md) for similar issues
+3. Review [Getting Started](GettingStarted.md) common pitfalls
 4. Ask on [Slack](http://btrace.slack.com/) or [Gitter](https://gitter.im/btraceio/btrace)
 
 ### I Need a Quick Lookup
-- **Quick Debug?** → [Oneliner Guide](onelinerGuide.md) for DTrace-style one-line commands
-- **Annotations?** → [Quick Reference: Core Annotations](quickReference.md#core-annotations)
-- **CLI Commands?** → [Quick Reference: CLI Commands](quickReference.md#cli-commands)
-- **Common Patterns?** → [Quick Reference: Common Patterns](quickReference.md#common-patterns)
-- **Built-in Functions?** → [Quick Reference: Built-in Functions](quickReference.md#built-in-functions)
+- **Quick Debug?** → [Oneliner Guide](OnelinerGuide.md) for DTrace-style one-line commands
+- **Annotations?** → [Quick Reference: Core Annotations](QuickReference.md#core-annotations)
+- **CLI Commands?** → [Quick Reference: CLI Commands](QuickReference.md#cli-commands)
+- **Common Patterns?** → [Quick Reference: Common Patterns](QuickReference.md#common-patterns)
+- **Built-in Functions?** → [Quick Reference: Built-in Functions](QuickReference.md#built-in-functions)
 
 ### I Want Advanced Features
 1. **JFR Integration** → [Getting Started: JFR Integration](GettingStarted.md#advanced-jfr-integration), [Tutorial Lesson 5](BTraceTutorial.md)
@@ -56,7 +56,7 @@ Tip: Want latency histograms fast? See [Quick Start: Histogram Metrics Extension
 
 ### Core Features
 - **Method Tracing** → [Tutorial Lesson 1](BTraceTutorial.md), [Quick Reference: @OnMethod](QuickReference.md#onmethod)
-- **Timing & Duration** → [Quick Reference: @Duration](QuickReference.md#parameter-annotations), [Pattern: Method Timing](QuickReference.md#pattern-1-method-entrye xit-timing)
+- **Timing & Duration** → [Quick Reference: @Duration](QuickReference.md#parameter-annotations), [Pattern: Method Timing](QuickReference.md#pattern-1-method-entryexit-timing)
 - **Exception Tracking** → [Quick Reference: Kind.ERROR](QuickReference.md#location-kinds), [Pattern: Exception Tracking](QuickReference.md#pattern-3-exception-tracking)
 - **Field Access** → [Quick Reference: Kind.FIELD_GET/SET](QuickReference.md#location-kinds)
 
@@ -145,4 +145,4 @@ Found an issue with the documentation? Please:
 
 ---
 
-**Ready to get started?** → [Getting Started Guide](gettingStarted.md)
+**Ready to get started?** → [Getting Started Guide](GettingStarted.md)

--- a/docs/architecture/provided-style-extensions.md
+++ b/docs/architecture/provided-style-extensions.md
@@ -66,6 +66,61 @@ public final class SparkApiImpl implements SparkApi {
 }
 ```
 
+## External Type Adapters (Recommended)
+
+Writing reflective adapters by hand with `ClassLoadingUtil` + `MethodHandleCache` works but has three ergonomic costs: string method names aren't refactor-safe, eager `static final MethodHandle` fields fail extension init if the target class isn't yet visible, and every reflective call expands into 5+ lines of try/catch and cache plumbing.
+
+The `@ExternalType` annotation + build-time annotation processor removes all three.
+
+### How it works
+
+Declare an interface in your extension's `api` source set marked with `@ExternalType("fully.qualified.AppType")`. The BTrace extension Gradle plugin auto-registers the annotation processor, which generates a companion `<InterfaceSimpleName>$Ext` class in the same package with typed `public static` dispatchers for each method.
+
+```java
+package com.example.spark.api;
+
+import org.openjdk.btrace.core.extensions.ExternalType;
+
+@ExternalType("org.apache.spark.scheduler.SparkListenerJobStart")
+public interface JobStart {
+  int jobId();
+  long time();
+}
+```
+
+The generated `JobStart$Ext` can then be called directly from the impl:
+
+```java
+int id = JobStart$Ext.jobId(event);
+long ts = JobStart$Ext.time(event);
+```
+
+### What the generated code does
+
+Each dispatcher uses a per-method `volatile MethodHandle` field with lazy resolution: on first call the method looks up the target class via `self.getClass().getClassLoader()` (virtual methods) or `Thread.currentThread().getContextClassLoader()` (static methods, see below), then calls `MethodHandles.publicLookup().findVirtual` / `findStatic`. Subsequent calls reuse the cached handle — once warm, the `volatile` read + `MethodHandle.invoke` is JIT-inlineable.
+
+If the external class isn't yet loaded when the dispatcher is first called, the resolver throws; the `volatile` field stays `null`, so the next call retries. No eager init, no `ExceptionInInitializerError` at extension load.
+
+### Rules
+
+- **Target:** `ElementType.TYPE`, interface only. The processor rejects classes with a compile error.
+- **Annotation value:** non-empty fully-qualified class name. Empty string is a compile error.
+- **Method return and parameter types:** anything resolvable at build time is fine. Types you can't put on the extension's compile classpath (app-private types, classes that only exist at runtime) must be typed as `Object`.
+- **Static methods:** annotate with `@ExternalType.Static` on the interface method — the generated dispatcher calls `findStatic` and uses TCCL for class loading.
+- **Default methods and static interface methods:** skipped (they already have bodies).
+
+### Scope limits (v1)
+
+Not handled by the processor; use `ClassLoadingUtil` / `MethodHandleCache` directly for:
+
+- Field access (read/write)
+- Constructors (`new ExternalType(...)`)
+- `instanceof` / `checkcast` on external types
+- Chained `@ExternalType` references (an interface method whose return type is itself `@ExternalType`-annotated)
+- Method visibility other than `public` — only `publicLookup` is used
+
+If you hit any of these, the hand-written pattern in the "Impl Sketch" section above still works alongside `@ExternalType`-based adapters in the same impl class.
+
 ## Role Detection & Config
 
 - Detect driver/executor via system properties or presence of marker classes using TCCL.

--- a/integration-tests/src/test/java/tests/RuntimeTest.java
+++ b/integration-tests/src/test/java/tests/RuntimeTest.java
@@ -795,14 +795,6 @@ public abstract class RuntimeTest {
       Thread.currentThread().interrupt();
     }
 
-    // Allow time for traced app to produce additional output after "ready:"
-    // BTrace INFO logs during agent init can exhaust stdoutLatch before app work begins
-    try {
-      Thread.sleep(1000L);
-    } catch (InterruptedException ie) {
-      Thread.currentThread().interrupt();
-    }
-
     if (startJfr && pidStringRef.get() != null) {
       // Give the periodic event at least one interval to fire before dumping
       try {


### PR DESCRIPTION
> **Stacked on top of #791.** This PR targets the `jb/configurations` branch so it shows only the incremental diff. Once #791 merges, this can be rebased onto `develop`.

## Rationale

Provided-style extension impls (introduced in #791) currently reach into application types via hand-written `MethodHandleCache` adapters. That works but has three ergonomic costs:

- **String method names.** `mh.findVirtual(cls, "jobId", int.class)` is not refactor-safe and IDE tooling can't check it.
- **Eager-resolution foot-gun.** `static final MethodHandle` fields fail extension init if the target class isn't yet visible on TCCL.
- **Boilerplate per call site.** Every reflective access expands into 5+ lines of `try/catch`, type wiring, and cache plumbing.

## Solution

`@ExternalType("com.example.app.Real")` on an interface + a build-time annotation processor → generated `$Ext` adapter with typed static dispatchers, per-method lazy `volatile MethodHandle` resolution, and no cache lookup on the warm path.

## Quick Start

Declare the interface in the extension's `api` source set:

```java
@ExternalType("org.apache.spark.scheduler.SparkListenerJobStart")
public interface JobStart {
  int jobId();
  long time();
}
```

Use the generated adapter from the impl:

```java
int id = JobStart$Ext.jobId(event);
long ts = JobStart$Ext.time(event);
```

The `org.openjdk.btrace.extension` Gradle plugin auto-registers the processor on the `api` source set — no extra wiring needed.

See the migrated `btrace-spark` example (`btrace-extensions/examples/btrace-spark/src/impl/java/.../SparkApiImpl.java`) for a before/after in a real extension.

## Scope

**In v1:**
- Virtual + static method adapters (`@ExternalType.Static` for statics)
- Primitive and reference return / parameter types
- Lazy resolution via receiver defining loader (virtual) or TCCL (static)
- Generic types erased to raw forms for `MethodType` literals
- Compile-time validation (non-interface targets, empty value → clear error)

**Not in v1** (use `ClassLoadingUtil` / `MethodHandleCache` directly):
- Field access
- Constructors
- `instanceof` / `checkcast` on external types
- Chained `@ExternalType` references
- Non-public method visibility

## Test Plan

- [x] Unit: annotation retention + `@Static` targeting (`ExternalTypeAnnotationTest`)
- [x] Unit: processor detects annotated interfaces (`ExternalTypeProcessorTest.generatesAdapterForAnnotatedInterface`)
- [x] Unit: method dispatcher signatures (`generatedAdapterContainsDispatchersForEachMethod`)
- [x] Unit: virtual dispatcher shape (`virtualDispatcherUsesLazyMethodHandle`)
- [x] Unit: static dispatcher uses TCCL (`staticDispatcherUsesTccl`)
- [x] Runtime smoke: compile + load + invoke generated adapter (`generatedAdapterInvokesRealMethod`)
- [x] Unit: validation errors for invalid targets (`rejectsAnnotationOnClass`, `rejectsEmptyValue`)
- [x] Unit: parameterized types produce raw type literals (`generatedAdapterHandlesParameterizedTypes`)
- [x] Integration: in-tree Spark example migrated from `MethodHandleCache` to `@ExternalType` — builds end-to-end through the Gradle plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/831)
<!-- Reviewable:end -->
