### PR TITLE
docs: add JDK compatibility matrix

### DIFF
--- a/docs/JDKCompatibility.md
+++ b/docs/JDKCompatibility.md
@@ -10,16 +10,16 @@ and push to `develop`:
 
 | JDK Version | SDKMan Identifier | Distribution | Status |
 |-------------|-------------------|--------------|--------|
-| 8 | `8.0.492-tem` | Eclipse Temurin | Supported |
-| 11 | `11.0.31-tem` | Eclipse Temurin | Supported — minimum build JDK |
-| 17 | `17.0.19-tem` | Eclipse Temurin | Supported |
-| 21 | `21.0.11-tem` | Eclipse Temurin | Supported |
-| 25 | `25.0.3-tem` | Eclipse Temurin | Supported |
+| 8 | `8.0.492-tem` | Eclipse Temurin | Supported (LTS) |
+| 11 | `11.0.31-tem` | Eclipse Temurin | Supported (LTS) — minimum build JDK |
+| 17 | `17.0.19-tem` | Eclipse Temurin | Supported (LTS) |
+| 21 | `21.0.11-tem` | Eclipse Temurin | Supported (LTS) |
+| 25 | `25.0.3-tem` | Eclipse Temurin | Supported (LTS) |
 | 27 (EA) | `27.ea.20-open` | OpenJDK Early Access | Experimental — tracked for future readiness |
 
-Version identifiers are updated automatically each Monday via
-[`.github/workflows/update-jdk-versions.yml`](./../.github/workflows/update-jdk-versions.yml)
-using the SDKMan API.
+Version identifiers are checked every Monday via
+[`.github/workflows/update-jdk-versions.yml`](../.github/workflows/update-jdk-versions.yml)
+using the SDKMan API; a pull request is opened automatically when a newer version is available.
 
 ## Distribution Support Policy
 
@@ -32,7 +32,9 @@ If you discover a distribution-specific issue, please [open a GitHub issue](#rep
 ## Minimum Java Version
 
 BTrace compiles with `sourceCompatibility = 8` and `targetCompatibility = 8`, targeting the widest
-possible deployment base. The build toolchain requires JDK 11 or later.
+possible deployment base. The build toolchain auto-provisions a JDK 11 compiler via Gradle
+toolchains; the CI pipeline runs with JDK 24. A local build requires JDK 11 or later available
+to Gradle (installed locally or auto-provisioned).
 
 ## Reporting Compatibility Issues
 

--- a/docs/JDKCompatibility.md
+++ b/docs/JDKCompatibility.md
@@ -1,0 +1,61 @@
+# JDK Compatibility
+
+BTrace is tested against a range of JDK versions and distributions to ensure compatibility
+across diverse runtime environments.
+
+## Tested Versions
+
+The CI pipeline runs integration tests against the following JDK versions on every pull request
+and push to `develop`:
+
+| JDK Version | SDKMan Identifier | Distribution | Status |
+|-------------|-------------------|--------------|--------|
+| 8 | `8.0.492-tem` | Eclipse Temurin | Supported |
+| 11 | `11.0.31-tem` | Eclipse Temurin | Supported — minimum build JDK |
+| 17 | `17.0.19-tem` | Eclipse Temurin | Supported |
+| 21 | `21.0.11-tem` | Eclipse Temurin | Supported |
+| 25 | `25.0.3-tem` | Eclipse Temurin | Supported |
+| 27 (EA) | `27.ea.20-open` | OpenJDK Early Access | Experimental — tracked for future readiness |
+
+Version identifiers are updated automatically each Monday via
+[`.github/workflows/update-jdk-versions.yml`](./../.github/workflows/update-jdk-versions.yml)
+using the SDKMan API.
+
+## Distribution Support Policy
+
+CI validates BTrace against **Eclipse Temurin** as the primary distribution. Other distributions
+(Amazon Corretto, Azul Zulu, GraalVM CE, Eclipse OpenJ9, Oracle JDK, etc.) are expected to work
+when they conform to the Java SE specification, but they are not formally tested in the CI pipeline.
+
+If you discover a distribution-specific issue, please [open a GitHub issue](#reporting-compatibility-issues).
+
+## Minimum Java Version
+
+BTrace compiles with `sourceCompatibility = 8` and `targetCompatibility = 8`, targeting the widest
+possible deployment base. The build toolchain requires JDK 11 or later.
+
+## Reporting Compatibility Issues
+
+| Situation | Where to report |
+|-----------|-----------------|
+| A specific JDK version or distribution breaks BTrace | [Open a GitHub issue](https://github.com/btraceio/btrace/issues) with the `compatibility` label |
+| General question about JDK version support | [GitHub Discussions](https://github.com/btraceio/btrace/discussions) |
+| You have a fix | Open a pull request — see [Contributing](../CONTRIBUTING.md) |
+
+Please include:
+- JDK version and distribution (e.g., `GraalVM CE 21.0.3`)
+- BTrace version
+- Minimal reproduction: the BTrace script + target app + command used
+- Full error output
+
+## External Compatibility Validation
+
+Community members are welcome to validate BTrace against additional JDK distributions and versions
+not covered by the CI matrix. If you find an issue:
+
+1. Search [existing issues](https://github.com/btraceio/btrace/issues) before opening a new one.
+2. Open an issue with the `compatibility` label and the details listed above.
+3. If you can provide a targeted fix, a pull request is strongly preferred over a long-running fork.
+
+Long-lived compatibility forks are discouraged: they diverge from upstream quickly and often become
+impossible to reconcile. Instead, contribute focused patches upstream so all users benefit.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Get up and running in 5 minutes with installation, your first script, and common
 | **[Troubleshooting Guide](Troubleshooting.md)** | Common errors, debugging, performance, compatibility | Problem-solving, debugging |
 | **[FAQ](FAQ.md)** | Common questions, best practices, comparisons | All users, decision-making |
 | **[MCP Server](MCPServer.md)** | Using BTrace from AI clients via the Model Context Protocol | AI-assisted debugging, LLM integrations |
+| **[JDK Compatibility](JDKCompatibility.md)** | Tested JDK versions and distributions, external contribution guide | Contributors, ops teams, compatibility testers |
 | **[Extension Registry](ExtensionRegistry.md)** | JSON catalog and GitHub workflow for discovering published extensions | Extension authors, platform maintainers |
 
 ## Learning Paths
@@ -151,7 +152,7 @@ BTrace is an open-source project welcoming contributions. To contribute:
 ## Version Information
 
 - **Current Version**: Check [GitHub Releases](https://github.com/btraceio/btrace/releases/latest)
-- **Java Compatibility**: Java 8-25
+- **Java Compatibility**: Java 8–27 EA — see [JDK Compatibility](JDKCompatibility.md) for the full matrix
 - **License**: GPLv2 with Classpath Exception
 
 ## Documentation Feedback


### PR DESCRIPTION
## Summary
- Creates `docs/JDKCompatibility.md`: tested JDK versions (8–27 EA), distribution support policy (Temurin primary), minimum version requirements (build JDK 11/CI JDK 24), issue-reporting guide, and external contributor guidance that discourages long-lived forks
- Updates `docs/README.md`: adds the new doc to the documentation table and fixes the stale "Java 8-25" version claim to "Java 8–27 EA" with a cross-link

Closes #849

## Test Plan
- [ ] Verify `docs/JDKCompatibility.md` renders correctly on GitHub (table formatting, heading hierarchy, links resolve)
- [ ] Verify `docs/README.md` table and version info display correctly
- [ ] Confirm SDKMan identifiers in the matrix match the current `matrix.java` list in `.github/workflows/continuous.yml`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/851)
<!-- Reviewable:end -->
