### PR TITLE
fix(ci): correct SDKMAN env var names in GitHub Actions workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -760,8 +760,8 @@ jobs:
 
       - name: Announce to SDKMan
         env:
-          SDKMAN_API_KEY: ${{ secrets.SDKMAN_KEY }}
-          SDKMAN_API_TOKEN: ${{ secrets.SDKMAN_TOKEN }}
+          SDKMAN_KEY: ${{ secrets.SDKMAN_KEY }}
+          SDKMAN_TOKEN: ${{ secrets.SDKMAN_TOKEN }}
         run: |
           ./gradlew :btrace-dist:sdkMajorRelease --no-daemon
 

--- a/.github/workflows/sdkman-set-default.yml
+++ b/.github/workflows/sdkman-set-default.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Set SDKMan default version
         env:
-          SDKMAN_API_KEY: ${{ secrets.SDKMAN_KEY }}
-          SDKMAN_API_TOKEN: ${{ secrets.SDKMAN_TOKEN }}
+          SDKMAN_KEY: ${{ secrets.SDKMAN_KEY }}
+          SDKMAN_TOKEN: ${{ secrets.SDKMAN_TOKEN }}
         run: |
           echo "Setting SDKMan default for btrace to ${{ inputs.version }}..."
           ./gradlew :btrace-dist:sdkDefaultVersion --no-daemon


### PR DESCRIPTION
## Summary

- Fixes `sdkDefaultVersion` failing with `consumerKey has no value available` in the `Set SDKMan Default Version` workflow and `release.yml`.

**Root cause:** PR #850 introduced `SDKMAN_API_KEY`/`SDKMAN_API_TOKEN` as env var names, but `btrace-dist/build.gradle` reads `SDKMAN_KEY`/`SDKMAN_TOKEN`:

```groovy
consumerKey = project.hasProperty("sdkman.key") ? project.property("sdkman.key") : System.getenv('SDKMAN_KEY')
consumerToken = project.hasProperty("sdkman.token") ? project.property("sdkman.token") : System.getenv('SDKMAN_TOKEN')
```

**Fix:** Rename the env vars in both workflow files to match what Gradle reads.

## Test plan
- [ ] Merge and re-run the `Set SDKMan Default Version` workflow with `version: 2.2.6`
- [ ] Verify `sdk install btrace` returns 2.2.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/852)
<!-- Reviewable:end -->
