### PR TITLE
fix(code): close Reader in code

### DIFF
--- a/btrace-compiler/src/main/java/io/btrace/compiler/PCPP.java
+++ b/btrace-compiler/src/main/java/io/btrace/compiler/PCPP.java
@@ -778,10 +778,11 @@ public class PCPP {
         return;
       }
       // Process this file in-line
-      Reader reader = new BufferedReader(new FileReader(fullname));
-      run(reader, fullname);
-    } else {
-      // System.out.println("INACTIVE BLOCK, SKIPPING " + filename);
+      try (Reader reader = new BufferedReader(new FileReader(fullname))) {
+          run(reader, fullname);
+          } else {
+          // System.out.println("INACTIVE BLOCK, SKIPPING " + filename);
+      }
     }
   }
 


### PR DESCRIPTION
Came across this in btrace-compiler/src/main/java/io/btrace/compiler/PCPP.java while following the call chain — The resource opened there can leak if code exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path. Feel free to close if not relevant.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/853)
<!-- Reviewable:end -->
