### PR TITLE
fix: update stale org/openjdk/btrace path strings to io/btrace

### DIFF
--- a/benchmarks/agent-benchmark/build.gradle
+++ b/benchmarks/agent-benchmark/build.gradle
@@ -38,8 +38,8 @@ jmhJar {
   include 'META-INF/BenchmarkList'
   include 'META-INF/CompilerHints'
   include 'org/openjdk/jmh/**'
-  include 'org/openjdk/btrace/bench/**/*.class'
-  include 'org/openjdk/btrace/generated/**/*'
+  include 'io/btrace/bench/**/*.class'
+  include 'io/btrace/generated/**/*'
   include "joptsimple/**"
   include "org/apache/**"
   include 'jmh*'

--- a/benchmarks/runtime-benchmarks/build.gradle
+++ b/benchmarks/runtime-benchmarks/build.gradle
@@ -47,11 +47,11 @@ jmhJar {
   include 'org/jctools/**/*'
   include 'org/objectweb/asm/**'
   include 'org/openjdk/jmh/**'
-  include 'org/openjdk/btrace/bench/**/*.class'
-  include "org/openjdk/btrace/core/**"
-  include "org/openjdk/btrace/instr/**"
-  include 'org/openjdk/btrace/generated/**/*'
-  include 'org/openjdk/btrace/runtime/**'
+  include 'io/btrace/bench/**/*.class'
+  include "io/btrace/core/**"
+  include "io/btrace/instr/**"
+  include 'io/btrace/generated/**/*'
+  include 'io/btrace/runtime/**'
   // no legacy services classes to package
   include "joptsimple/**"
   include "org/apache/**"

--- a/btrace-agent/build.gradle
+++ b/btrace-agent/build.gradle
@@ -85,7 +85,7 @@ jar {
 
 // Exclude sources that rely on JDK-internal modules from Javadoc to avoid missing-package errors
 tasks.named('javadoc').configure {
-    exclude 'org/openjdk/btrace/agent/PerfReaderImpl.java'
+    exclude 'io/btrace/agent/PerfReaderImpl.java'
 }
 
 task compileTestProbes {

--- a/btrace-core/build.gradle
+++ b/btrace-core/build.gradle
@@ -57,7 +57,7 @@ jacocoTestReport {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it, include: [
-                '**/org/openjdk/btrace/core/comm/**/*.class'
+                '**/io/btrace/core/comm/**/*.class'
             ])
         }))
     }

--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -465,8 +465,8 @@ test {
  * │   └── btrace-extensions/
  * │       └── ext-id/
  * │           └── extension.properties
- * ├── org/openjdk/btrace/...           # Agent + API classes (.class)
- * └── org/openjdk/btrace/ext/impl/...  # Impl classes (.classdata)
+ * ├── io/btrace/...           # Agent + API classes (.class)
+ * └── io/btrace/ext/impl/...  # Impl classes (.classdata)
  *
  * Usage:
  *   ./gradlew :btrace-dist:fatAgentJar -PembedExtensions=btrace-spark,btrace-metrics

--- a/btrace-dtrace/build.gradle
+++ b/btrace-dtrace/build.gradle
@@ -56,7 +56,7 @@ sourceSets {
 }
 
 shadowJar {
-    include 'org/openjdk/btrace/dtrace/**/*'
+    include 'io/btrace/dtrace/**/*'
     archiveClassifier = null
 }
 

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceExtensionPlugin.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceExtensionPlugin.groovy
@@ -234,7 +234,7 @@ class BTraceExtensionPlugin implements Plugin<Project> {
                     }
                 }
                 // Enforce: at most one package-level @ExtensionDescriptor across the project
-                def extDescDesc = 'Lorg/openjdk/btrace/core/extensions/ExtensionDescriptor;'
+                def extDescDesc = 'Lio/btrace/core/extensions/ExtensionDescriptor;'
                 int extDescCount = 0
                 def scanForPkgDescriptors = { File classesDir ->
                     if (classesDir == null || !classesDir.exists()) return
@@ -277,8 +277,8 @@ class BTraceExtensionPlugin implements Plugin<Project> {
                             cr.accept(cn, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG)
                             def isInterface = (cn.access & Opcodes.ACC_INTERFACE) != 0
                             def hasMarker = false
-                            (cn.visibleAnnotations ?: []).each { hasMarker |= (it.desc == 'Lorg/openjdk/btrace/core/extensions/ServiceDescriptor;') }
-                            (cn.invisibleAnnotations ?: []).each { hasMarker |= (it.desc == 'Lorg/openjdk/btrace/core/extensions/ServiceDescriptor;') }
+                            (cn.visibleAnnotations ?: []).each { hasMarker |= (it.desc == 'Lio/btrace/core/extensions/ServiceDescriptor;') }
+                            (cn.invisibleAnnotations ?: []).each { hasMarker |= (it.desc == 'Lio/btrace/core/extensions/ServiceDescriptor;') }
                             if (hasMarker && isInterface) detected.add(fq)
                         }
                     }
@@ -354,7 +354,7 @@ class BTraceExtensionPlugin implements Plugin<Project> {
                         // Collect ServiceDescriptor.permissions
                         def collectServicePerms = { AnnotationNode an ->
                             if (an == null) return
-                            if (an.desc == 'Lorg/openjdk/btrace/core/extensions/ServiceDescriptor;') {
+                            if (an.desc == 'Lio/btrace/core/extensions/ServiceDescriptor;') {
                                 def vals = an.values ?: []
                                 for (int i = 0; i < vals.size(); i += 2) {
                                     if (vals[i] == 'permissions') {
@@ -701,7 +701,7 @@ class BTraceExtensionPlugin implements Plugin<Project> {
                                 def cn = new ClassNode()
                                 cr.accept(cn, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG)
                                 (cn.visibleAnnotations ?: []).each { an ->
-                                    if (an.desc == 'Lorg/openjdk/btrace/core/extensions/ServiceDescriptor;') {
+                                    if (an.desc == 'Lio/btrace/core/extensions/ServiceDescriptor;') {
                                         def vals = an.values ?: []
                                         for (int i = 0; i < vals.size(); i += 2) {
                                             if (vals[i] == 'permissions') {
@@ -715,7 +715,7 @@ class BTraceExtensionPlugin implements Plugin<Project> {
                                     }
                                 }
                                 (cn.invisibleAnnotations ?: []).each { an ->
-                                    if (an.desc == 'Lorg/openjdk/btrace/core/extensions/ServiceDescriptor;') {
+                                    if (an.desc == 'Lio/btrace/core/extensions/ServiceDescriptor;') {
                                         def vals = an.values ?: []
                                         for (int i = 0; i < vals.size(); i += 2) {
                                             if (vals[i] == 'permissions') {
@@ -741,7 +741,7 @@ class BTraceExtensionPlugin implements Plugin<Project> {
                                 def cr2 = new ClassReader(bytes2)
                                 def cn2 = new ClassNode(); cr2.accept(cn2, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG)
                                 (cn2.visibleAnnotations ?: []).each { an ->
-                                    if (an.desc == 'Lorg/openjdk/btrace/core/extensions/ExtensionDescriptor;') {
+                                    if (an.desc == 'Lio/btrace/core/extensions/ExtensionDescriptor;') {
                                         def vals = an.values ?: []
                                         for (int i = 0; i < vals.size(); i += 2) {
                                             if (vals[i] == 'permissions') {
@@ -755,7 +755,7 @@ class BTraceExtensionPlugin implements Plugin<Project> {
                                     }
                                 }
                                 (cn2.invisibleAnnotations ?: []).each { an ->
-                                    if (an.desc == 'Lorg/openjdk/btrace/core/extensions/ExtensionDescriptor;') {
+                                    if (an.desc == 'Lio/btrace/core/extensions/ExtensionDescriptor;') {
                                         def vals = an.values ?: []
                                         for (int i = 0; i < vals.size(); i += 2) {
                                             if (vals[i] == 'permissions') {
@@ -1099,8 +1099,8 @@ class BTraceExtensionPlugin implements Plugin<Project> {
                                 def cn = new ClassNode(); cr.accept(cn, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG)
                                 boolean isInterface = (cn.access & Opcodes.ACC_INTERFACE) != 0
                                 boolean hasMarker = false
-                                (cn.visibleAnnotations ?: []).each { hasMarker |= (it.desc == 'Lorg/openjdk/btrace/core/extensions/ServiceDescriptor;') }
-                                (cn.invisibleAnnotations ?: []).each { hasMarker |= (it.desc == 'Lorg/openjdk/btrace/core/extensions/ServiceDescriptor;') }
+                                (cn.visibleAnnotations ?: []).each { hasMarker |= (it.desc == 'Lio/btrace/core/extensions/ServiceDescriptor;') }
+                                (cn.invisibleAnnotations ?: []).each { hasMarker |= (it.desc == 'Lio/btrace/core/extensions/ServiceDescriptor;') }
                                 if (hasMarker && isInterface) services.add(fq)
                             }
                         }

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/PermissionScanner.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/PermissionScanner.groovy
@@ -156,7 +156,7 @@ final class PermissionScanner {
         if (owner.startsWith('com/sun/management/')) {
             perms.add('MEMORY_INFO')
         }
-        if (owner.startsWith('jdk/jfr/') || owner.startsWith('org/openjdk/btrace/core/jfr/')) {
+        if (owner.startsWith('jdk/jfr/') || owner.startsWith('io/btrace/core/jfr/')) {
             perms.add('JFR_EVENTS')
         }
     }

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/SingleSourceApiPartition.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/SingleSourceApiPartition.groovy
@@ -33,9 +33,9 @@ import org.objectweb.asm.tree.MethodNode
 @CompileStatic
 final class SingleSourceApiPartition {
     private static final String SERVICE_DESCRIPTOR_DESC =
-        'Lorg/openjdk/btrace/core/extensions/ServiceDescriptor;'
+        'Lio/btrace/core/extensions/ServiceDescriptor;'
     private static final String EXTERNAL_TYPE_DESC =
-        'Lorg/openjdk/btrace/core/extensions/ExternalType;'
+        'Lio/btrace/core/extensions/ExternalType;'
     private static final Pattern EXCLUDED_GENERATED =
         Pattern.compile('.*(\\$Ext|\\.btrace\\.shim\\.).*')
 


### PR DESCRIPTION
## Summary
Found while auditing `refactor/module-consolidation` (a separate, now-superseded branch that independently reached the same module layout `develop` already has): a handful of path-filter and ASM-descriptor string literals still referenced the pre-repackaging `org.openjdk.btrace` package, missed by the `org.openjdk.btrace → io.btrace` repackaging.

- `BTraceExtensionPlugin`: ASM annotation descriptors for `ServiceDescriptor`/`ExtensionDescriptor` used the old binary names, so bytecode scanning for these markers matched nothing (extension permission/API-partition logic silently no-op'd on these markers).
- `SingleSourceApiPartition`: same descriptor mismatch for `ServiceDescriptor`/`ExternalType`.
- `PermissionScanner`: JFR permission detection checked the old package prefix.
- `btrace-dist`: stale doc-comment example paths (the actual classdata masking filters were already correct).
- `btrace-agent`, `btrace-core`, `btrace-dtrace`, `benchmarks/*`: stale javadoc exclude, jacoco include filter, and shadowJar/jmhJar include filters.

## Test plan
- [x] `./gradlew test` — full suite passes
- [x] `:btrace-gradle-plugin:test` (TestKit) fails identically on unmodified `develop` in this environment (Gradle 9.5.1 vs. the module's JDK 11 toolchain → `UnsupportedJavaRuntimeException`) — confirmed pre-existing and unrelated to this change, not something this PR introduces or fixes
- [x] Verified no remaining `org/openjdk/btrace` / `org.openjdk.btrace` references in any `.gradle`/`.groovy` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/863)
<!-- Reviewable:end -->
