### PR TITLE
docs: define BTrace 3.0 prepared-mode policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ jbang btrace <PID> <script.java>
 # ~/.m2/repository/io/btrace/btrace/<version>/btrace-<version>.jar
 ```
 
+For launch-time use, review the [startup-mode security boundary](docs/GettingStarted.md#startup-modes-and-the-30-security-boundary). Use `noServer=true` for startup scripts that do not need later client connections; BTrace 3.0 does not support an unauthenticated remote prepared-mode endpoint.
+
 See [Getting Started Guide](docs/GettingStarted.md#jbang-installation-recommended-for-quick-start) for complete JBang documentation and examples.
 
 #### Binary Distribution

--- a/docs/BTraceTutorial.md
+++ b/docs/BTraceTutorial.md
@@ -136,6 +136,11 @@ The agent takes a list of comma separated arguments.
 
 The scripts to be run must have already been compiled to bytecode (a *.class* file) by __btracec__.
 
+For a launch-time script that needs no later client connection, set `noServer=true`. BTrace 3.0
+does not treat an unauthenticated startup command server as prepared mode; prepared mode requires
+authentication and loopback-only binding. Until that path is available in a tested release, use
+startup-script mode with `noServer=true` or dynamic attach where JVM policy permits it.
+
 ###### Using `btracer'
 
 `btracer [opts] <pre-compiled-btrace.class> <vm-arg> <application-args>`

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -353,7 +353,7 @@ btrace -v 12345 MyTrace.java arg1 arg2
 Start a Java application with BTrace agent and a pre-compiled script:
 
 ```bash
-java -javaagent:btrace.jar=script=<script.class>[,arg1=value1]... YourApp
+java -javaagent:btrace.jar=script=<script.class>,noServer=true[,arg1=value1]... YourApp
 ```
 
 **When to use:**
@@ -367,8 +367,27 @@ java -javaagent:btrace.jar=script=<script.class>[,arg1=value1]... YourApp
 btracec MyTrace.java
 
 # Then run with agent
-java -javaagent:/path/to/btrace.jar=script=MyTrace.class MyApp
+java -javaagent:/path/to/btrace.jar=script=MyTrace.class,noServer=true MyApp
 ```
+
+#### Startup modes and the 3.0 security boundary
+
+BTrace 3.0 distinguishes launch-time startup scripts from prepared mode:
+
+- **Startup-script mode** runs reviewed probes supplied at launch. Use `noServer=true` when no
+  later client connection is needed:
+
+  ```bash
+  java -javaagent:/path/to/btrace.jar=script=MyTrace.class,noServer=true MyApp
+  ```
+
+- **Prepared mode** is required to start an authenticated, loopback-only control endpoint for
+  later probe submission. The 3.0.0 policy permits neither unauthenticated commands nor
+  non-loopback binding.
+
+Prepared mode remains a 3.0.0 release gate. Until the authenticated path is available in a tested
+release, use startup-script mode with `noServer=true`, or use dynamic attach where the target JVM's
+policy permits it. Do not expose a startup command server as a remote diagnostic endpoint.
 
 ### 4. Launcher Mode (btracer)
 

--- a/docs/QuickReference.md
+++ b/docs/QuickReference.md
@@ -532,23 +532,24 @@ btracep MyTrace.class
 ### Java Agent Mode
 Start app with BTrace agent directly.
 ```bash
-java -javaagent:/path/to/btrace.jar=script=<script.class>[,arg=value]... YourApp
+java -javaagent:/path/to/btrace.jar=script=<script.class>,noServer=true[,arg=value]... YourApp
 ```
 
 **Agent Parameters:**
 - `script=<path>` - BTrace script class file
 - `scriptdir=<dir>` - Directory to load scripts from
 - `port=<port>` - Communication port
-- `noServer=true` - Don't start command server
+- `noServer=true` - Don't start the command server; use for startup scripts that need no later
+  client connection
 - `bootClassPath=<path>` - Additional boot classpath
 
 **Examples:**
 ```bash
-# Basic agent mode
-java -javaagent:btrace.jar=script=MyTrace.class MyApp
+# Startup script with no command endpoint
+java -javaagent:btrace.jar=script=MyTrace.class,noServer=true MyApp
 
-# With custom port
-java -javaagent:btrace.jar=script=MyTrace.class,port=2020 MyApp
+# With debug logging and no command endpoint
+java -javaagent:btrace.jar=script=MyTrace.class,noServer=true,debug=true MyApp
 ```
 
 ### Wire Protocol

--- a/internal/plans/2026-07-11-v3.0.0-release-plan.md
+++ b/internal/plans/2026-07-11-v3.0.0-release-plan.md
@@ -22,6 +22,24 @@ Note the honest framing: nothing in 3.0.0 *requires* 17 (the code tiers are 8 / 
 | 0.6 | jbang flags + `--grant/--deny/--grantAll` | Either implement the documented flags or fix the docs (gap analysis §3.19–20). Recommendation: fix docs for 3.0.0, implement in 3.1 if demand exists |
 | 0.7 | Docker base images | Keep JDK-11-based images working (they must still attach to old JVMs) but refresh tags to 3.0.0 and re-verify variants |
 
+### Trust-boundary decisions confirmed for 3.0.0
+
+The security and compatibility decisions for prepared mode are accepted in
+[`internal/specs/3.0.0-prepared-mode-security-policy.md`](../specs/3.0.0-prepared-mode-security-policy.md).
+They are release gates, not implementation suggestions:
+
+| Decision | 3.0.0 policy |
+| --- | --- |
+| Telemetry | Disabled by default; explicit `telemetry=true` opt-in only |
+| Prepared mode | Authenticated before every operational command; loopback-only by default |
+| Remote command server | Unsupported in 3.0.0; non-loopback binding fails closed |
+| 2.2.x compatibility | Retained for compatible dynamic attach; old clients are rejected by authenticated prepared mode without a downgrade |
+| Maven fat agent | Supported only if the published-artifact and launched-JVM gates in #879 pass; otherwise fail the goal explicitly and remove 3.0.0 claims |
+
+If authenticated prepared mode misses the release, premain must not expose an unauthenticated
+standby server. The release falls back to startup-script mode with `noServer=true`, removes
+prepared-mode claims, and defers prepared mode to a later release.
+
 ## Phase 1 — Implement the Java < 17 deprecation warning (code)
 1. **Shared helper** in `btrace-core` (compiled at source 8): parse `java.specification.version` ("1.8" → 8, else integer prefix); expose `int javaFeatureVersion()` and `boolean isDeprecatedJavaVersion()` (< 17). Guard with a `static AtomicBoolean warned` for once-only semantics per JVM.
 2. **Agent-side warning (primary)**: in `io.btrace.agent.Main.main(String, Instrumentation)` right after the `Main.inst != null` idempotence guard (`btrace-agent/src/main/java/io/btrace/agent/Main.java:168-175`) — fires exactly once per target JVM regardless of premain/agentmain/fat-agent path. Emit to stderr AND the client message channel if a client is connected. Suggested text:
@@ -79,6 +97,19 @@ Ordered by severity; §-references are to the gap analysis.
 5. **Docs link check**: run a markdown link checker over `README.md`, `docs/**`, `docker/README.md`, plugin READMEs (catches §3.11–15 regressions); grep-gates in CI or the release checklist: no `org.openjdk.btrace` outside migration-guide/shim contexts, no `GPL` outside NOTICE history, no `2\.[23]\.[0-9]` version strings in docs, no `/Users/` paths.
 6. **Doc-vs-code property audit**: grep all documented sysprops (`btrace.comm.*`, `btrace.feature.manifestLibs`, `btrace.permissions`, `btrace.suppressJavaDeprecationWarning`, `btrace.verify.*`, `btrace.validation.*`, `btrace.oneliner.dump`) against `System.getProperty` call sites.
 7. **RC flow**: cut `v3.0.0_RC` via `.github/workflows/release.yml`, verify: Maven Central staging artifacts under `io.btrace:*` with Apache-2.0 POM license, SDKMAN default-version update (#850 fix), jbang catalog bump (external `btraceio/jbang-catalog`), Docker images `3.0.0[-alpine|-distroless]`, `btrace --version` output, GitHub auto release notes.
+
+### Trust-boundary release checklist
+
+- [ ] Default agent startup invokes no telemetry transport code.
+- [ ] Startup-script mode with `noServer=true` opens no command socket.
+- [ ] Prepared mode binds to loopback by default and rejects non-loopback configuration.
+- [ ] V1 and V2 operational commands are rejected before successful authentication.
+- [ ] Authentication failures and debug logging do not disclose credentials.
+- [ ] A 2.2.x client remains compatible with dynamic 3.0 attach where supported and is rejected
+  by authenticated prepared mode without a downgrade.
+- [ ] Maven fat-agent claims remain only if its published-artifact and launched-JVM tests pass.
+- [ ] If any prepared-mode security gate fails, apply the documented startup-script fallback and
+  remove prepared-mode claims before the release candidate proceeds.
 
 ## Phase 5 — Release-notes skeleton (3.0.0 announcement)
 1. Headline: new package `io.btrace`, Apache 2.0, single masked `btrace.jar`, extension framework, flat DSL, oneliners, MCP/AI tooling, protocol V2, ClassFile-API future-proofing.

--- a/internal/specs/3.0.0-prepared-mode-security-policy.md
+++ b/internal/specs/3.0.0-prepared-mode-security-policy.md
@@ -1,0 +1,96 @@
+# BTrace 3.0.0 Prepared-Mode Security and Compatibility Policy
+
+Date: 2026-07-13
+
+Status: accepted release policy
+
+Related issues: [#872](https://github.com/btraceio/btrace/issues/872),
+[#873](https://github.com/btraceio/btrace/issues/873),
+[#874](https://github.com/btraceio/btrace/issues/874), and
+[#879](https://github.com/btraceio/btrace/issues/879)
+
+## Decision
+
+BTrace 3.0.0 will distinguish three operating modes:
+
+- **Dynamic mode** attaches to a running JVM through the Attach API. Existing V1/V2
+  compatibility is retained where the peer supports it.
+- **Prepared mode** loads BTrace at JVM startup and accepts later probe submissions. It must
+  authenticate every connection before accepting an operational command and bind to a loopback
+  address by default.
+- **Startup-script mode** loads one or more reviewed probes at JVM startup with `noServer=true`.
+  It opens no command socket and is the fallback when authenticated prepared mode is unavailable.
+
+An unauthenticated startup command server is not an acceptable prepared-mode implementation,
+even when it binds only to loopback.
+
+## Security policy
+
+1. Agent telemetry is disabled by default. An operator must explicitly set `telemetry=true`
+   before the agent creates a telemetry thread or performs telemetry-related DNS or network I/O.
+2. Prepared mode binds to an address returned by `InetAddress.getLoopbackAddress()` by default.
+   It does not bind wildcard interfaces.
+3. Non-loopback command-server binding is unsupported in 3.0.0 and must fail closed. A later
+   release may define authenticated remote operation and mTLS separately.
+4. Prepared mode requires credentials that are not supplied in process arguments or emitted in
+   normal or debug logs. Authentication precedes settings, probe, reconnect, list, event, and exit
+   commands.
+5. Failure to create owner-protected local credential material or to establish the required
+   authentication boundary aborts prepared-mode startup. It must not downgrade to an
+   unauthenticated listener.
+
+## Compatibility policy
+
+| Client | Agent and mode | Required behavior |
+| --- | --- | --- |
+| 3.0 client | 2.2.x dynamically attached agent | Use the existing compatible V1/V2 path. Do not describe an unauthenticated startup listener as secure prepared mode. |
+| 2.2.x client | 3.0 dynamically attached agent | Retain the existing compatible protocol path where practical. Dynamic attachment does not enable a prepared-mode authentication bypass. |
+| 2.2.x client | 3.0 authenticated prepared agent | Reject the connection before any operational command. Report that the client lacks prepared-mode authentication when the protocol permits a clear error. Never downgrade authentication. |
+| 3.0 client | 3.0 authenticated prepared agent | Authenticate before protocol operations, then negotiate and operate over a supported V1 or V2 path. |
+
+Authentication is a security boundary, not a protocol-version preference. Compatibility may fail
+closed at that boundary in a new major release.
+
+## Maven fat-agent release policy
+
+The decision is to ship the Maven `fat-agent` goal in 3.0.0 only if
+[#879](https://github.com/btraceio/btrace/issues/879) proves all of the following against
+published-style artifacts:
+
+- the consumer build completes;
+- implementation classes and metadata load from the produced JAR;
+- an extension service executes in a launched JVM; and
+- missing content fails the build clearly.
+
+Failure of any gate at the 3.0.0 release candidate automatically selects withdrawal: the goal must
+fail with an explicit unsupported message and all 3.0.0 Maven fat-agent claims and examples must
+be removed. This is not a release-time waiver decision. The tested Gradle path may ship
+independently.
+
+## Prepared-mode fallback
+
+If authenticated prepared mode does not pass its security and compatibility gates by the 3.0.0
+release candidate:
+
+1. premain opens no command server by default, and startup-script examples explicitly set
+   `noServer=true`;
+2. 3.0.0 documentation and release notes do not advertise prepared or standby mode;
+3. documentation recommends `-javaagent:...=script=...,noServer=true` for launch-time tracing and
+   dynamic attach only where JVM policy permits it; and
+4. authenticated prepared mode moves to a later release. No unauthenticated compatibility escape
+   hatch is permitted.
+
+## Release gates
+
+The 3.0.0 release checklist must demonstrate:
+
+- default startup performs no telemetry transport work;
+- startup-script mode with `noServer=true` opens no command socket;
+- prepared mode binds only to loopback by default;
+- no operational V1 or V2 command succeeds before authentication;
+- missing, malformed, and incorrect credentials fail closed without logging secrets;
+- the compatibility cases above produce the required success or rejection; and
+- Maven fat-agent documentation is present only when its launched-JVM gates pass.
+
+Any exception requires an explicit release decision. Security gates cannot be waived solely to
+preserve a compatibility or launch claim.


### PR DESCRIPTION
## Summary

- record the BTrace 3.0 prepared-mode security and client compatibility decisions
- add deterministic release gates and fail-closed fallbacks to the 3.0 release plan
- update user-facing startup examples to use `noServer=true` until authenticated prepared mode is available

## Why

Issue #872 gates the remaining 3.0 code-readiness work, but the repository did not contain a canonical decision for telemetry consent, prepared-mode binding and authentication, legacy-client behavior, remote control, or Maven fat-agent release eligibility. Without that policy, later implementations could preserve compatibility by silently weakening the security boundary.

The accepted policy makes telemetry opt-in, requires authentication and loopback binding for prepared mode, defers remote control, rejects legacy clients that cannot authenticate, and automatically withdraws Maven fat-agent support if its end-to-end gates fail.

## User impact

Launch-time documentation now distinguishes startup-script mode from prepared mode. Startup-script examples that need no later client connection explicitly disable the command server, avoiding accidental exposure of the current unauthenticated endpoint.

## Validation

- `GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew spotlessCheck`
- `git diff --check`
- adversarial acceptance review covering downgrade behavior, unsafe examples, release-waiver ambiguity, and fail-closed fallback behavior

Closes #872

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/893)
<!-- Reviewable:end -->
