### PR TITLE
feat(client): add read-only doctor command

### DIFF
--- a/btrace-client/src/main/java/io/btrace/client/Client.java
+++ b/btrace-client/src/main/java/io/btrace/client/Client.java
@@ -63,6 +63,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -871,6 +872,9 @@ public class Client {
             }
             continue;
           }
+          if (isDynamicAgentLoadingRestricted(ale)) {
+            throw dynamicAgentLoadFailure(pid, agentPath, ale);
+          }
           throw ale;
         }
       }
@@ -885,12 +889,14 @@ public class Client {
         configureConnection(loadedAgentProperties);
       }
     } catch (RuntimeException | IOException re) {
-      System.err.println("[DEBUG] IOException/RuntimeException during attach:");
-      re.printStackTrace();
+      if (log.isDebugEnabled()) {
+        log.debug("Attach failed for PID {}", pid, re);
+      }
       throw re;
     } catch (Exception exp) {
-      System.err.println("[DEBUG] Exception during attach:");
-      exp.printStackTrace();
+      if (log.isDebugEnabled()) {
+        log.debug("Attach failed for PID {}", pid, exp);
+      }
       throw new IOException("Failed to attach to PID " + pid, exp);
     } finally {
       if (vm != null) {
@@ -900,6 +906,35 @@ public class Client {
         }
       }
     }
+  }
+
+  static boolean isDynamicAgentLoadingRestricted(Throwable failure) {
+    for (Throwable current = failure; current != null; current = current.getCause()) {
+      String message = current.getMessage();
+      if (message == null) {
+        continue;
+      }
+      String normalized = message.toLowerCase(Locale.ROOT);
+      if (normalized.contains("dynamic agent loading is not enabled")
+          || normalized.contains("dynamic agent loading is disabled")
+          || normalized.contains("use -xx:+enabledynamicagentloading")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static IOException dynamicAgentLoadFailure(
+      String pid, String agentPath, AgentLoadException failure) {
+    String message =
+        "Dynamic agent loading was rejected for PID "
+            + pid
+            + ".\nFor the next deployment, relaunch with -XX:+EnableDynamicAgentLoading, or use "
+            + "reviewed prepared mode with -javaagent:"
+            + agentPath
+            + "=port=0.\nBTrace did not inspect the target VM flag state; this guidance is based "
+            + "on the agent-load rejection.";
+    return new IOException(message, failure);
   }
 
   void discoverPreparedAgent(String pid) throws IOException {

--- a/btrace-client/src/main/java/io/btrace/client/Doctor.java
+++ b/btrace-client/src/main/java/io/btrace/client/Doctor.java
@@ -59,20 +59,24 @@ final class Doctor {
         output.println(report.toJson());
       } else {
         error.println(parsed.error);
-        error.println("Usage: btrace doctor <pid> [--json]");
+        error.println("Usage: btrace doctor <pid> [--json] [-v]");
       }
       output.flush();
       error.flush();
       return EXIT_UNEXPECTED_FAILURE;
     }
 
-    Report report = inspect(parsed.pid, attacher);
+    Report report = inspect(parsed.pid, attacher, parsed.verbose ? error : null);
     output.println(parsed.json ? report.toJson() : report.toHuman());
     output.flush();
     return report.status.exitCode;
   }
 
   static Report inspect(String pid, Attacher attacher) {
+    return inspect(pid, attacher, null);
+  }
+
+  private static Report inspect(String pid, Attacher attacher, PrintWriter verboseError) {
     boolean attachApiAvailable = attacher.isAvailable();
     if (!attachApiAvailable) {
       return Report.inaccessible(pid, false, "Attach API is unavailable in this BTrace runtime.");
@@ -84,6 +88,10 @@ final class Doctor {
     } catch (AttachNotSupportedException | IOException | SecurityException inaccessible) {
       return Report.inaccessible(pid, true, safeMessage(inaccessible));
     } catch (Exception | LinkageError unexpected) {
+      if (verboseError != null) {
+        unexpected.printStackTrace(verboseError);
+        verboseError.flush();
+      }
       return Report.unexpected(pid, true, safeMessage(unexpected));
     }
   }
@@ -410,7 +418,8 @@ final class Doctor {
           null,
           null,
           detail,
-          Collections.singletonList("Rerun with -v and report the unexpected failure."));
+          Collections.singletonList(
+              "Rerun with btrace doctor <pid> -v and report the unexpected failure."));
     }
 
     String toHuman() {
@@ -553,33 +562,48 @@ final class Doctor {
   private static final class ParsedArguments {
     final String pid;
     final boolean json;
+    final boolean verbose;
     final String error;
 
-    private ParsedArguments(String pid, boolean json, String error) {
+    private ParsedArguments(String pid, boolean json, boolean verbose, String error) {
       this.pid = pid;
       this.json = json;
+      this.verbose = verbose;
       this.error = error;
     }
 
     static ParsedArguments parse(String[] args) {
       boolean json = false;
+      for (String argument : args) {
+        if ("--json".equals(argument)) {
+          json = true;
+        }
+      }
+
+      boolean jsonSeen = false;
+      boolean verbose = false;
       String pid = null;
       for (String argument : args) {
         if ("--json".equals(argument)) {
-          if (json) {
-            return new ParsedArguments(pid, true, "--json may be specified only once.");
+          if (jsonSeen) {
+            return new ParsedArguments(pid, true, verbose, "--json may be specified only once.");
           }
-          json = true;
+          jsonSeen = true;
+        } else if ("-v".equals(argument)) {
+          if (verbose) {
+            return new ParsedArguments(pid, json, true, "-v may be specified only once.");
+          }
+          verbose = true;
         } else if (pid == null) {
           pid = argument;
         } else {
-          return new ParsedArguments(pid, json, "doctor accepts exactly one PID.");
+          return new ParsedArguments(pid, json, verbose, "doctor accepts exactly one PID.");
         }
       }
       if (pid == null || !pid.matches("[1-9][0-9]*")) {
-        return new ParsedArguments(pid, json, "doctor requires a positive numeric PID.");
+        return new ParsedArguments(pid, json, verbose, "doctor requires a positive numeric PID.");
       }
-      return new ParsedArguments(pid, json, null);
+      return new ParsedArguments(pid, json, verbose, null);
     }
   }
 

--- a/btrace-client/src/main/java/io/btrace/client/Doctor.java
+++ b/btrace-client/src/main/java/io/btrace/client/Doctor.java
@@ -1,0 +1,613 @@
+/*
+ * Copyright (c) 2008, 2024, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.btrace.client;
+
+import com.sun.tools.attach.AttachNotSupportedException;
+import com.sun.tools.attach.VirtualMachine;
+import io.btrace.core.comm.ConnectionAuthenticator;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+/** Read-only target readiness diagnostics for {@code btrace doctor}. */
+final class Doctor {
+  static final int EXIT_READY = 0;
+  static final int EXIT_PREPARATION_REQUIRED = 2;
+  static final int EXIT_INACCESSIBLE = 3;
+  static final int EXIT_UNEXPECTED_FAILURE = 4;
+
+  private static final String DYNAMIC_LOADING_OBSERVATION = "not_tested";
+  private static final String DYNAMIC_REMEDIATION =
+      "Relaunch with -XX:+EnableDynamicAgentLoading before using dynamic attach.";
+  private static final String PREPARED_REMEDIATION =
+      "Relaunch with -javaagent:/path/to/btrace.jar=port=0 for reviewed prepared mode.";
+
+  private Doctor() {}
+
+  static int run(String[] args, PrintWriter output, PrintWriter error) {
+    return run(args, output, error, new VirtualMachineAttacher());
+  }
+
+  static int run(String[] args, PrintWriter output, PrintWriter error, Attacher attacher) {
+    ParsedArguments parsed = ParsedArguments.parse(args);
+    if (parsed.error != null) {
+      if (parsed.json) {
+        Report report = Report.unexpected(parsed.pid, attacher.isAvailable(), parsed.error);
+        output.println(report.toJson());
+      } else {
+        error.println(parsed.error);
+        error.println("Usage: btrace doctor <pid> [--json]");
+      }
+      output.flush();
+      error.flush();
+      return EXIT_UNEXPECTED_FAILURE;
+    }
+
+    Report report = inspect(parsed.pid, attacher);
+    output.println(parsed.json ? report.toJson() : report.toHuman());
+    output.flush();
+    return report.status.exitCode;
+  }
+
+  static Report inspect(String pid, Attacher attacher) {
+    boolean attachApiAvailable = attacher.isAvailable();
+    if (!attachApiAvailable) {
+      return Report.inaccessible(pid, false, "Attach API is unavailable in this BTrace runtime.");
+    }
+
+    try (Target target = attacher.attach(pid)) {
+      Properties properties = target.getSystemProperties();
+      return inspectProperties(pid, properties);
+    } catch (AttachNotSupportedException | IOException | SecurityException inaccessible) {
+      return Report.inaccessible(pid, true, safeMessage(inaccessible));
+    } catch (Exception | LinkageError unexpected) {
+      return Report.unexpected(pid, true, safeMessage(unexpected));
+    }
+  }
+
+  private static Report inspectProperties(String pid, Properties properties) {
+    String javaVersion = safeText(properties.getProperty("java.version"));
+    String javaVendor =
+        safeText(properties.getProperty("java.vendor", properties.getProperty("java.vm.vendor")));
+    String portValue = trimToNull(properties.getProperty("btrace.port"));
+    if (portValue == null) {
+      return Report.preparationRequired(
+          pid,
+          javaVersion,
+          javaVendor,
+          false,
+          null,
+          null,
+          null,
+          null,
+          "No BTrace control endpoint is published.");
+    }
+
+    int port;
+    try {
+      port = Integer.parseInt(portValue);
+    } catch (NumberFormatException invalid) {
+      return Report.preparationRequired(
+          pid,
+          javaVersion,
+          javaVendor,
+          true,
+          null,
+          null,
+          null,
+          null,
+          "The published BTrace port is invalid.");
+    }
+    if (port < 1 || port > 65535) {
+      return Report.preparationRequired(
+          pid,
+          javaVersion,
+          javaVendor,
+          true,
+          null,
+          null,
+          null,
+          null,
+          "The published BTrace port is invalid.");
+    }
+
+    String address = trimToNull(properties.getProperty("btrace.address"));
+    if (address != null && !isNumericLoopback(address)) {
+      return Report.preparationRequired(
+          pid,
+          javaVersion,
+          javaVendor,
+          true,
+          address,
+          port,
+          null,
+          null,
+          "The published BTrace address is not loopback.");
+    }
+
+    String authenticationValue = trimToNull(properties.getProperty("btrace.auth.required"));
+    if (authenticationValue != null
+        && !"true".equalsIgnoreCase(authenticationValue)
+        && !"false".equalsIgnoreCase(authenticationValue)) {
+      return Report.preparationRequired(
+          pid,
+          javaVersion,
+          javaVendor,
+          true,
+          address,
+          port,
+          null,
+          null,
+          "The BTrace authentication metadata is invalid.");
+    }
+
+    boolean authenticationRequired = Boolean.parseBoolean(authenticationValue);
+    String tokenFile = trimToNull(properties.getProperty("btrace.auth.tokenFile"));
+    Boolean credentialReadable = null;
+    if (authenticationRequired) {
+      credentialReadable = isUsableCredentialFile(tokenFile);
+      if (!credentialReadable) {
+        return Report.preparationRequired(
+            pid,
+            javaVersion,
+            javaVendor,
+            true,
+            address,
+            port,
+            true,
+            false,
+            "The prepared-mode credential file is missing or unreadable.");
+      }
+    }
+
+    return Report.ready(
+        pid, javaVersion, javaVendor, address, port, authenticationRequired, credentialReadable);
+  }
+
+  private static boolean isNumericLoopback(String address) {
+    if (!address.matches("[0-9a-fA-F:.%]+")) {
+      return false;
+    }
+    try {
+      return InetAddress.getByName(address).isLoopbackAddress();
+    } catch (IOException invalid) {
+      return false;
+    }
+  }
+
+  private static boolean isUsableCredentialFile(String tokenFile) {
+    if (tokenFile == null) {
+      return false;
+    }
+    try {
+      Path path = Paths.get(tokenFile).toAbsolutePath().normalize();
+      if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS) || !Files.isReadable(path)) {
+        return false;
+      }
+      byte[] token = ConnectionAuthenticator.readToken(path);
+      Arrays.fill(token, (byte) 0);
+      return true;
+    } catch (IOException | RuntimeException invalid) {
+      return false;
+    }
+  }
+
+  private static String safeMessage(Throwable failure) {
+    String message = safeText(failure.getMessage());
+    if (message == null) {
+      return failure.getClass().getSimpleName();
+    }
+    return message;
+  }
+
+  private static String safeText(String value) {
+    String text = trimToNull(value);
+    if (text == null) {
+      return null;
+    }
+    StringBuilder safe = new StringBuilder(text.length());
+    for (int i = 0; i < text.length(); i++) {
+      char character = text.charAt(i);
+      safe.append(Character.isISOControl(character) ? ' ' : character);
+    }
+    return safe.toString();
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  interface Attacher {
+    boolean isAvailable();
+
+    Target attach(String pid) throws Exception;
+  }
+
+  interface Target extends AutoCloseable {
+    Properties getSystemProperties() throws IOException;
+
+    @Override
+    void close() throws IOException;
+  }
+
+  enum Status {
+    READY("ready", EXIT_READY),
+    PREPARATION_REQUIRED("preparation_required", EXIT_PREPARATION_REQUIRED),
+    INACCESSIBLE("inaccessible", EXIT_INACCESSIBLE),
+    UNEXPECTED_FAILURE("unexpected_failure", EXIT_UNEXPECTED_FAILURE);
+
+    final String jsonName;
+    final int exitCode;
+
+    Status(String jsonName, int exitCode) {
+      this.jsonName = jsonName;
+      this.exitCode = exitCode;
+    }
+  }
+
+  static final class Report {
+    final String pid;
+    final Status status;
+    final boolean attachApiAvailable;
+    final boolean targetAccessible;
+    final String javaVersion;
+    final String javaVendor;
+    final boolean endpointPublished;
+    final boolean endpointReady;
+    final String address;
+    final Integer port;
+    final Boolean authenticationRequired;
+    final Boolean credentialReadable;
+    final String detail;
+    final List<String> remediation;
+
+    private Report(
+        String pid,
+        Status status,
+        boolean attachApiAvailable,
+        boolean targetAccessible,
+        String javaVersion,
+        String javaVendor,
+        boolean endpointPublished,
+        boolean endpointReady,
+        String address,
+        Integer port,
+        Boolean authenticationRequired,
+        Boolean credentialReadable,
+        String detail,
+        List<String> remediation) {
+      this.pid = pid;
+      this.status = status;
+      this.attachApiAvailable = attachApiAvailable;
+      this.targetAccessible = targetAccessible;
+      this.javaVersion = javaVersion;
+      this.javaVendor = javaVendor;
+      this.endpointPublished = endpointPublished;
+      this.endpointReady = endpointReady;
+      this.address = address;
+      this.port = port;
+      this.authenticationRequired = authenticationRequired;
+      this.credentialReadable = credentialReadable;
+      this.detail = detail;
+      this.remediation = remediation;
+    }
+
+    static Report ready(
+        String pid,
+        String javaVersion,
+        String javaVendor,
+        String address,
+        int port,
+        boolean authenticationRequired,
+        Boolean credentialReadable) {
+      return new Report(
+          pid,
+          Status.READY,
+          true,
+          true,
+          javaVersion,
+          javaVendor,
+          true,
+          true,
+          address,
+          port,
+          authenticationRequired,
+          credentialReadable,
+          "A BTrace control endpoint is ready.",
+          Collections.emptyList());
+    }
+
+    static Report preparationRequired(
+        String pid,
+        String javaVersion,
+        String javaVendor,
+        boolean endpointPublished,
+        String address,
+        Integer port,
+        Boolean authenticationRequired,
+        Boolean credentialReadable,
+        String detail) {
+      List<String> remediation = new ArrayList<>();
+      remediation.add(DYNAMIC_REMEDIATION);
+      remediation.add(PREPARED_REMEDIATION);
+      return new Report(
+          pid,
+          Status.PREPARATION_REQUIRED,
+          true,
+          true,
+          javaVersion,
+          javaVendor,
+          endpointPublished,
+          false,
+          address,
+          port,
+          authenticationRequired,
+          credentialReadable,
+          detail,
+          remediation);
+    }
+
+    static Report inaccessible(String pid, boolean attachApiAvailable, String detail) {
+      List<String> remediation = new ArrayList<>();
+      remediation.add("Run as an OS user permitted to attach to the target JVM.");
+      remediation.add(PREPARED_REMEDIATION);
+      return new Report(
+          pid,
+          Status.INACCESSIBLE,
+          attachApiAvailable,
+          false,
+          null,
+          null,
+          false,
+          false,
+          null,
+          null,
+          null,
+          null,
+          detail,
+          remediation);
+    }
+
+    static Report unexpected(String pid, boolean attachApiAvailable, String detail) {
+      return new Report(
+          pid,
+          Status.UNEXPECTED_FAILURE,
+          attachApiAvailable,
+          false,
+          null,
+          null,
+          false,
+          false,
+          null,
+          null,
+          null,
+          null,
+          detail,
+          Collections.singletonList("Rerun with -v and report the unexpected failure."));
+    }
+
+    String toHuman() {
+      StringBuilder text = new StringBuilder();
+      text.append("BTrace doctor for PID ").append(pid).append('\n');
+      text.append("Status: ")
+          .append(status.name())
+          .append(" (exit ")
+          .append(status.exitCode)
+          .append(")\n");
+      text.append("Target JDK: ")
+          .append(javaVersion != null ? javaVersion : "unknown")
+          .append(" (")
+          .append(javaVendor != null ? javaVendor : "unknown vendor")
+          .append(")\n");
+      text.append("Attach API: ")
+          .append(attachApiAvailable ? "available" : "unavailable")
+          .append('\n');
+      text.append("Target attach: ")
+          .append(targetAccessible ? "accessible" : "inaccessible")
+          .append('\n');
+      text.append("Dynamic agent loading: not tested (doctor never loads an agent)\n");
+      if (endpointReady) {
+        text.append("BTrace endpoint: ready at ")
+            .append(address != null ? address : "localhost")
+            .append(':')
+            .append(port)
+            .append('\n');
+        text.append("Authentication: ")
+            .append(Boolean.TRUE.equals(authenticationRequired) ? "required" : "not required");
+        if (credentialReadable != null) {
+          text.append("; credential file ").append(credentialReadable ? "readable" : "unreadable");
+        }
+        text.append('\n');
+      } else {
+        text.append("BTrace endpoint: not ready\n");
+      }
+      text.append("Detail: ").append(detail).append('\n');
+      text.append("Observation: doctor did not inspect the target VM flag state.\n");
+      if (!remediation.isEmpty()) {
+        text.append("Remediation:\n");
+        for (String action : remediation) {
+          text.append("- ").append(action).append('\n');
+        }
+      }
+      if (targetAccessible) {
+        text.append("Actions: read target system properties and detached; ");
+      } else {
+        text.append("Actions: target properties were not available; ");
+      }
+      text.append("no agent load or BTrace command connection was attempted.");
+      return text.toString();
+    }
+
+    String toJson() {
+      StringBuilder json = new StringBuilder();
+      json.append('{');
+      field(json, "schemaVersion", 1).append(',');
+      field(json, "pid", pid).append(',');
+      field(json, "status", status.jsonName).append(',');
+      field(json, "exitCode", status.exitCode).append(',');
+      json.append("\"target\":{");
+      field(json, "jdkVersion", javaVersion).append(',');
+      field(json, "vendor", javaVendor).append("},");
+      json.append("\"attach\":{");
+      field(json, "apiAvailable", attachApiAvailable).append(',');
+      field(json, "targetAccessible", targetAccessible).append(',');
+      field(json, "agentLoadingPermission", DYNAMIC_LOADING_OBSERVATION).append("},");
+      json.append("\"operation\":{");
+      field(json, "readOnly", true).append(',');
+      field(json, "agentLoadAttempted", false).append(',');
+      field(json, "commandConnectionOpened", false).append("},");
+      json.append("\"btrace\":{");
+      field(json, "endpointPublished", endpointPublished).append(',');
+      field(json, "ready", endpointReady).append(',');
+      field(json, "address", address).append(',');
+      field(json, "port", port).append(',');
+      field(json, "authenticationRequired", authenticationRequired).append(',');
+      field(json, "credentialReadable", credentialReadable).append("},");
+      field(json, "detail", detail).append(',');
+      json.append("\"remediation\":[");
+      for (int i = 0; i < remediation.size(); i++) {
+        if (i > 0) {
+          json.append(',');
+        }
+        string(json, remediation.get(i));
+      }
+      return json.append("]}").toString();
+    }
+
+    private static StringBuilder field(StringBuilder json, String name, Object value) {
+      string(json, name).append(':');
+      if (value == null) {
+        return json.append("null");
+      }
+      if (value instanceof Boolean || value instanceof Number) {
+        return json.append(value);
+      }
+      return string(json, String.valueOf(value));
+    }
+
+    private static StringBuilder string(StringBuilder json, String value) {
+      json.append('"');
+      for (int i = 0; i < value.length(); i++) {
+        char character = value.charAt(i);
+        switch (character) {
+          case '"':
+            json.append("\\\"");
+            break;
+          case '\\':
+            json.append("\\\\");
+            break;
+          case '\b':
+            json.append("\\b");
+            break;
+          case '\f':
+            json.append("\\f");
+            break;
+          case '\n':
+            json.append("\\n");
+            break;
+          case '\r':
+            json.append("\\r");
+            break;
+          case '\t':
+            json.append("\\t");
+            break;
+          default:
+            if (character < 0x20) {
+              json.append(String.format("\\u%04x", (int) character));
+            } else {
+              json.append(character);
+            }
+        }
+      }
+      return json.append('"');
+    }
+  }
+
+  private static final class ParsedArguments {
+    final String pid;
+    final boolean json;
+    final String error;
+
+    private ParsedArguments(String pid, boolean json, String error) {
+      this.pid = pid;
+      this.json = json;
+      this.error = error;
+    }
+
+    static ParsedArguments parse(String[] args) {
+      boolean json = false;
+      String pid = null;
+      for (String argument : args) {
+        if ("--json".equals(argument)) {
+          if (json) {
+            return new ParsedArguments(pid, true, "--json may be specified only once.");
+          }
+          json = true;
+        } else if (pid == null) {
+          pid = argument;
+        } else {
+          return new ParsedArguments(pid, json, "doctor accepts exactly one PID.");
+        }
+      }
+      if (pid == null || !pid.matches("[1-9][0-9]*")) {
+        return new ParsedArguments(pid, json, "doctor requires a positive numeric PID.");
+      }
+      return new ParsedArguments(pid, json, null);
+    }
+  }
+
+  private static final class VirtualMachineAttacher implements Attacher {
+    @Override
+    public boolean isAvailable() {
+      try {
+        Class.forName("com.sun.tools.attach.VirtualMachine", false, Doctor.class.getClassLoader());
+        return true;
+      } catch (ClassNotFoundException | LinkageError unavailable) {
+        return false;
+      }
+    }
+
+    @Override
+    public Target attach(String pid) throws Exception {
+      VirtualMachine machine = VirtualMachine.attach(pid);
+      return new Target() {
+        @Override
+        public Properties getSystemProperties() throws IOException {
+          return machine.getSystemProperties();
+        }
+
+        @Override
+        public void close() throws IOException {
+          machine.detach();
+        }
+      };
+    }
+  }
+}

--- a/btrace-client/src/main/java/io/btrace/client/Main.java
+++ b/btrace-client/src/main/java/io/btrace/client/Main.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,6 +107,18 @@ public final class Main {
   }
 
   public static void main(String[] args) throws Exception {
+    if (args.length > 0 && "doctor".equals(args[0])) {
+      int exitCode =
+          Doctor.run(
+              Arrays.copyOfRange(args, 1, args.length),
+              new PrintWriter(System.out, true),
+              new PrintWriter(System.err, true));
+      if (exitCode != Doctor.EXIT_READY) {
+        System.exit(exitCode);
+      }
+      return;
+    }
+
     int port = BTRACE_DEFAULT_PORT;
     String host = BTRACE_DEFAULT_HOST;
     String classPath = ".";

--- a/btrace-client/src/main/java/io/btrace/client/Main.java
+++ b/btrace-client/src/main/java/io/btrace/client/Main.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,10 +106,11 @@ public final class Main {
   }
 
   public static void main(String[] args) throws Exception {
-    if (args.length > 0 && "doctor".equals(args[0])) {
+    String[] doctorArguments = doctorArguments(args);
+    if (doctorArguments != null) {
       int exitCode =
           Doctor.run(
-              Arrays.copyOfRange(args, 1, args.length),
+              doctorArguments,
               new PrintWriter(System.out, true),
               new PrintWriter(System.err, true));
       if (exitCode != Doctor.EXIT_READY) {
@@ -401,6 +401,22 @@ public final class Main {
     } catch (IOException exp) {
       errorExit(exp.getMessage(), 1);
     }
+  }
+
+  static String[] doctorArguments(String[] args) {
+    int doctorIndex =
+        args.length > 0 && "doctor".equals(args[0])
+            ? 0
+            : args.length > 1 && "-v".equals(args[0]) && "doctor".equals(args[1]) ? 1 : -1;
+    if (doctorIndex < 0) {
+      return null;
+    }
+
+    String[] doctorArguments = new String[args.length - 1];
+    System.arraycopy(args, 0, doctorArguments, 0, doctorIndex);
+    System.arraycopy(
+        args, doctorIndex + 1, doctorArguments, doctorIndex, args.length - doctorIndex - 1);
+    return doctorArguments;
   }
 
   private static CommandListener createCommandListener(Client client) {

--- a/btrace-client/src/test/java/io/btrace/client/ClientTest.java
+++ b/btrace-client/src/test/java/io/btrace/client/ClientTest.java
@@ -18,6 +18,7 @@ package io.btrace.client;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.sun.tools.attach.AgentLoadException;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -278,6 +279,35 @@ class ClientTest {
     for (byte value : token) {
       assertEquals(0, value);
     }
+  }
+
+  @Test
+  void recognizesRestrictedDynamicAgentLoadingFailure() {
+    AgentLoadException failure =
+        new AgentLoadException(
+            "Dynamic agent loading is not enabled. Use -XX:+EnableDynamicAgentLoading");
+
+    assertTrue(Client.isDynamicAgentLoadingRestricted(failure));
+    assertFalse(
+        Client.isDynamicAgentLoadingRestricted(new AgentLoadException("Agent JAR not found")));
+    assertFalse(
+        Client.isDynamicAgentLoadingRestricted(
+            new AgentLoadException(
+                "EnableDynamicAgentLoading was enabled but agent initialization failed")));
+  }
+
+  @Test
+  void restrictedDynamicAgentGuidanceUsesResolvedAgentPathWithoutClaimingFlagState() {
+    AgentLoadException cause = new AgentLoadException("Dynamic agent loading is disabled");
+
+    IOException failure =
+        Client.dynamicAgentLoadFailure("1234", "/opt/btrace/libs/btrace.jar", cause);
+
+    assertTrue(failure.getMessage().contains("PID 1234"));
+    assertTrue(failure.getMessage().contains("-XX:+EnableDynamicAgentLoading"));
+    assertTrue(failure.getMessage().contains("-javaagent:/opt/btrace/libs/btrace.jar=port=0"));
+    assertTrue(failure.getMessage().contains("did not inspect the target VM flag state"));
+    assertSame(cause, failure.getCause());
   }
 
   private static Object readField(Client client, String name) throws Exception {

--- a/btrace-client/src/test/java/io/btrace/client/DoctorTest.java
+++ b/btrace-client/src/test/java/io/btrace/client/DoctorTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2008, 2024, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.btrace.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DoctorTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void humanReadyReportUsesOnlyReadOnlyAttachOperations() throws Exception {
+    Path token = tempDir.resolve("prepared.token");
+    Files.write(token, "secret".getBytes(StandardCharsets.UTF_8));
+    Properties properties = baseProperties();
+    properties.setProperty("btrace.port", "43210");
+    properties.setProperty("btrace.address", "127.0.0.1");
+    properties.setProperty("btrace.auth.required", "true");
+    properties.setProperty("btrace.auth.tokenFile", token.toString());
+    RecordingAttacher attacher = new RecordingAttacher(properties);
+    StringWriter output = new StringWriter();
+    StringWriter error = new StringWriter();
+
+    int exitCode =
+        Doctor.run(
+            new String[] {"1234"}, new PrintWriter(output), new PrintWriter(error), attacher);
+
+    assertEquals(Doctor.EXIT_READY, exitCode);
+    assertTrue(output.toString().contains("Status: READY (exit 0)"));
+    assertTrue(output.toString().contains("Target JDK: 21.0.2 (Eclipse Adoptium)"));
+    assertTrue(output.toString().contains("Dynamic agent loading: not tested"));
+    assertTrue(output.toString().contains("BTrace endpoint: ready at 127.0.0.1:43210"));
+    assertTrue(output.toString().contains("Authentication: required; credential file readable"));
+    assertTrue(output.toString().contains("no agent load or BTrace command connection"));
+    assertEquals("", error.toString());
+    assertEquals(1, attacher.attachCount);
+    assertEquals(1, attacher.propertiesReadCount);
+    assertEquals(1, attacher.closeCount);
+  }
+
+  @Test
+  void jsonPreparationReportHasStableFactsAndExitCode() {
+    RecordingAttacher attacher = new RecordingAttacher(baseProperties());
+    StringWriter output = new StringWriter();
+
+    int exitCode =
+        Doctor.run(
+            new String[] {"--json", "1234"},
+            new PrintWriter(output),
+            new PrintWriter(new StringWriter()),
+            attacher);
+
+    assertEquals(Doctor.EXIT_PREPARATION_REQUIRED, exitCode);
+    String json = output.toString().trim();
+    assertTrue(json.startsWith("{\"schemaVersion\":1,"));
+    assertTrue(json.contains("\"status\":\"preparation_required\""));
+    assertTrue(json.contains("\"exitCode\":2"));
+    assertTrue(json.contains("\"jdkVersion\":\"21.0.2\""));
+    assertTrue(json.contains("\"apiAvailable\":true"));
+    assertTrue(json.contains("\"targetAccessible\":true"));
+    assertTrue(json.contains("\"agentLoadingPermission\":\"not_tested\""));
+    assertTrue(json.contains("\"readOnly\":true"));
+    assertTrue(json.contains("\"agentLoadAttempted\":false"));
+    assertTrue(json.contains("\"commandConnectionOpened\":false"));
+    assertTrue(json.contains("\"endpointPublished\":false"));
+    assertTrue(json.contains("-XX:+EnableDynamicAgentLoading"));
+    assertTrue(json.contains("-javaagent:/path/to/btrace.jar=port=0"));
+    assertTrue(json.endsWith("}"));
+  }
+
+  @Test
+  void unreadablePreparedCredentialRequiresPreparation() {
+    Properties properties = baseProperties();
+    properties.setProperty("btrace.port", "43210");
+    properties.setProperty("btrace.address", "::1");
+    properties.setProperty("btrace.auth.required", "true");
+    properties.setProperty("btrace.auth.tokenFile", tempDir.resolve("missing").toString());
+
+    Doctor.Report report = Doctor.inspect("1234", new RecordingAttacher(properties));
+
+    assertEquals(Doctor.Status.PREPARATION_REQUIRED, report.status);
+    assertTrue(report.endpointPublished);
+    assertFalse(report.endpointReady);
+    assertEquals(Boolean.TRUE, report.authenticationRequired);
+    assertEquals(Boolean.FALSE, report.credentialReadable);
+  }
+
+  @Test
+  void emptyPreparedCredentialRequiresPreparation() throws Exception {
+    Path token = tempDir.resolve("empty.token");
+    Files.write(token, new byte[0]);
+    Properties properties = baseProperties();
+    properties.setProperty("btrace.port", "43210");
+    properties.setProperty("btrace.address", "127.0.0.1");
+    properties.setProperty("btrace.auth.required", "true");
+    properties.setProperty("btrace.auth.tokenFile", token.toString());
+
+    Doctor.Report report = Doctor.inspect("1234", new RecordingAttacher(properties));
+
+    assertEquals(Doctor.Status.PREPARATION_REQUIRED, report.status);
+    assertEquals(Boolean.FALSE, report.credentialReadable);
+  }
+
+  @Test
+  void attachRejectionIsInaccessible() {
+    Doctor.Attacher attacher = new FailingAttacher(new IOException("permission denied"));
+    StringWriter output = new StringWriter();
+
+    int exitCode =
+        Doctor.run(
+            new String[] {"1234"},
+            new PrintWriter(output),
+            new PrintWriter(new StringWriter()),
+            attacher);
+
+    assertEquals(Doctor.EXIT_INACCESSIBLE, exitCode);
+    assertTrue(output.toString().contains("Status: INACCESSIBLE (exit 3)"));
+    assertTrue(output.toString().contains("Target attach: inaccessible"));
+    assertTrue(output.toString().contains("permission denied"));
+  }
+
+  @Test
+  void unavailableAttachApiDoesNotTryTarget() {
+    RecordingAttacher attacher = new RecordingAttacher(baseProperties());
+    attacher.available = false;
+
+    Doctor.Report report = Doctor.inspect("1234", attacher);
+
+    assertEquals(Doctor.Status.INACCESSIBLE, report.status);
+    assertFalse(report.attachApiAvailable);
+    assertEquals(0, attacher.attachCount);
+  }
+
+  @Test
+  void unexpectedAttachFailureHasDistinctExitCode() {
+    Doctor.Attacher attacher = new FailingAttacher(new IllegalStateException("broken provider"));
+
+    Doctor.Report report = Doctor.inspect("1234", attacher);
+
+    assertEquals(Doctor.Status.UNEXPECTED_FAILURE, report.status);
+    assertEquals(Doctor.EXIT_UNEXPECTED_FAILURE, report.status.exitCode);
+  }
+
+  @Test
+  void invalidPidReturnsJsonUsageFailureWithoutAttaching() {
+    RecordingAttacher attacher = new RecordingAttacher(baseProperties());
+    StringWriter output = new StringWriter();
+
+    int exitCode =
+        Doctor.run(
+            new String[] {"not-a-pid", "--json"},
+            new PrintWriter(output),
+            new PrintWriter(new StringWriter()),
+            attacher);
+
+    assertEquals(Doctor.EXIT_UNEXPECTED_FAILURE, exitCode);
+    assertTrue(output.toString().contains("\"status\":\"unexpected_failure\""));
+    assertEquals(0, attacher.attachCount);
+  }
+
+  private static Properties baseProperties() {
+    Properties properties = new Properties();
+    properties.setProperty("java.version", "21.0.2");
+    properties.setProperty("java.vendor", "Eclipse Adoptium");
+    return properties;
+  }
+
+  private static final class RecordingAttacher implements Doctor.Attacher {
+    private final Properties properties;
+    boolean available = true;
+    int attachCount;
+    int propertiesReadCount;
+    int closeCount;
+
+    RecordingAttacher(Properties properties) {
+      this.properties = properties;
+    }
+
+    @Override
+    public boolean isAvailable() {
+      return available;
+    }
+
+    @Override
+    public Doctor.Target attach(String pid) {
+      attachCount++;
+      return new Doctor.Target() {
+        @Override
+        public Properties getSystemProperties() {
+          propertiesReadCount++;
+          return properties;
+        }
+
+        @Override
+        public void close() {
+          closeCount++;
+        }
+      };
+    }
+  }
+
+  private static final class FailingAttacher implements Doctor.Attacher {
+    private final Exception failure;
+
+    FailingAttacher(Exception failure) {
+      this.failure = failure;
+    }
+
+    @Override
+    public boolean isAvailable() {
+      return true;
+    }
+
+    @Override
+    public Doctor.Target attach(String pid) throws Exception {
+      throw failure;
+    }
+  }
+}

--- a/btrace-client/src/test/java/io/btrace/client/DoctorTest.java
+++ b/btrace-client/src/test/java/io/btrace/client/DoctorTest.java
@@ -167,6 +167,21 @@ class DoctorTest {
   }
 
   @Test
+  void verboseUnexpectedFailurePrintsStackTrace() {
+    Doctor.Attacher attacher = new FailingAttacher(new IllegalStateException("broken provider"));
+    StringWriter output = new StringWriter();
+    StringWriter error = new StringWriter();
+
+    int exitCode =
+        Doctor.run(
+            new String[] {"1234", "-v"}, new PrintWriter(output), new PrintWriter(error), attacher);
+
+    assertEquals(Doctor.EXIT_UNEXPECTED_FAILURE, exitCode);
+    assertTrue(output.toString().contains("Status: UNEXPECTED_FAILURE (exit 4)"));
+    assertTrue(error.toString().contains("java.lang.IllegalStateException: broken provider"));
+  }
+
+  @Test
   void invalidPidReturnsJsonUsageFailureWithoutAttaching() {
     RecordingAttacher attacher = new RecordingAttacher(baseProperties());
     StringWriter output = new StringWriter();
@@ -180,6 +195,26 @@ class DoctorTest {
 
     assertEquals(Doctor.EXIT_UNEXPECTED_FAILURE, exitCode);
     assertTrue(output.toString().contains("\"status\":\"unexpected_failure\""));
+    assertEquals(0, attacher.attachCount);
+  }
+
+  @Test
+  void laterJsonFlagIsPreservedForInvalidExtraArgument() {
+    RecordingAttacher attacher = new RecordingAttacher(baseProperties());
+    StringWriter output = new StringWriter();
+    StringWriter error = new StringWriter();
+
+    int exitCode =
+        Doctor.run(
+            new String[] {"1234", "extra", "--json"},
+            new PrintWriter(output),
+            new PrintWriter(error),
+            attacher);
+
+    assertEquals(Doctor.EXIT_UNEXPECTED_FAILURE, exitCode);
+    assertTrue(output.toString().contains("\"status\":\"unexpected_failure\""));
+    assertTrue(output.toString().contains("doctor accepts exactly one PID"));
+    assertEquals("", error.toString());
     assertEquals(0, attacher.attachCount);
   }
 

--- a/btrace-client/src/test/java/io/btrace/client/MainTest.java
+++ b/btrace-client/src/test/java/io/btrace/client/MainTest.java
@@ -16,6 +16,7 @@
  */
 package io.btrace.client;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -32,6 +33,13 @@ class MainTest {
     assertFalse(usage.contains("--boot-jar"));
     assertFalse(usage.contains("--extract-agent"));
     assertTrue(usage.contains("--oneliner"));
-    assertTrue(usage.contains("btrace doctor <pid> [--json]"));
+    assertTrue(usage.contains("btrace doctor <pid> [--json] [-v]"));
+  }
+
+  @Test
+  void verboseFlagBeforeDoctorIsDispatchedToDoctor() {
+    assertArrayEquals(
+        new String[] {"-v", "1234", "--json"},
+        Main.doctorArguments(new String[] {"-v", "doctor", "1234", "--json"}));
   }
 }

--- a/btrace-client/src/test/java/io/btrace/client/MainTest.java
+++ b/btrace-client/src/test/java/io/btrace/client/MainTest.java
@@ -32,5 +32,6 @@ class MainTest {
     assertFalse(usage.contains("--boot-jar"));
     assertFalse(usage.contains("--extract-agent"));
     assertTrue(usage.contains("--oneliner"));
+    assertTrue(usage.contains("btrace doctor <pid> [--json]"));
   }
 }

--- a/btrace-core/src/main/resources/io/btrace/core/messages.properties
+++ b/btrace-core/src/main/resources/io/btrace/core/messages.properties
@@ -70,6 +70,7 @@ btracec.usage=\
     -trusted          Enable trusted script (eg. no checks)
 btrace.usage=\
   Usage: btrace <options> <pid> <btrace source or .class file> <btrace arguments>\n\
+  Read-only diagnostics: btrace doctor <pid> [--json]\n\
   where possible options include:\n  \
     --version             Show the version\n  \
     -v                    Run in verbose mode\n  \

--- a/btrace-core/src/main/resources/io/btrace/core/messages.properties
+++ b/btrace-core/src/main/resources/io/btrace/core/messages.properties
@@ -70,7 +70,7 @@ btracec.usage=\
     -trusted          Enable trusted script (eg. no checks)
 btrace.usage=\
   Usage: btrace <options> <pid> <btrace source or .class file> <btrace arguments>\n\
-  Read-only diagnostics: btrace doctor <pid> [--json]\n\
+  Read-only diagnostics: btrace doctor <pid> [--json] [-v]\n\
   where possible options include:\n  \
     --version             Show the version\n  \
     -v                    Run in verbose mode\n  \

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -348,6 +348,19 @@ btrace -v 12345 MyTrace.java arg1 arg2
 - `-p <port>` - Specify port for communication
 - `-o <file>` - Redirect output to file
 
+Before attaching, inspect readiness without loading an agent or opening the BTrace command socket:
+
+```bash
+btrace doctor <pid>
+btrace doctor <pid> --json
+```
+
+Doctor reads target properties through the Attach API and then detaches. It reports the target
+JDK/vendor, Attach availability, an existing BTrace endpoint, and next-deployment remediation.
+Dynamic-agent loading permission is always reported as `not_tested`, because observing it would
+require the state-changing load that doctor deliberately avoids. Exit codes are stable: `0` ready,
+`2` preparation required, `3` inaccessible, and `4` unexpected failure or invalid invocation.
+
 ### 3. Java Agent Mode (Pre-compiled Scripts)
 
 Start a Java application with BTrace agent and a pre-compiled script:

--- a/docs/QuickReference.md
+++ b/docs/QuickReference.md
@@ -421,12 +421,13 @@ btrace [options] <PID> <script.java> [script-args]
 Read-only readiness diagnostics:
 
 ```bash
-btrace doctor <pid> [--json]
+btrace doctor <pid> [--json] [-v]
 ```
 
 Doctor attaches only to read target system properties, then detaches; it never loads an agent or
 opens the BTrace command connection. It distinguishes Attach API availability from dynamic-agent
-loading permission, which is reported as `not_tested`.
+loading permission, which is reported as `not_tested`. Add `-v` to print a stack trace when an
+unexpected provider or runtime failure prevents diagnosis.
 
 | Exit | Status | Meaning |
 | ---: | --- | --- |

--- a/docs/QuickReference.md
+++ b/docs/QuickReference.md
@@ -418,6 +418,23 @@ Attach to running JVM and trace.
 btrace [options] <PID> <script.java> [script-args]
 ```
 
+Read-only readiness diagnostics:
+
+```bash
+btrace doctor <pid> [--json]
+```
+
+Doctor attaches only to read target system properties, then detaches; it never loads an agent or
+opens the BTrace command connection. It distinguishes Attach API availability from dynamic-agent
+loading permission, which is reported as `not_tested`.
+
+| Exit | Status | Meaning |
+| ---: | --- | --- |
+| 0 | ready | A usable BTrace endpoint is published. |
+| 2 | preparation required | The target is readable but has no usable endpoint. |
+| 3 | inaccessible | Attach is unavailable or denied. |
+| 4 | unexpected failure | Invocation or provider failure prevented diagnosis. |
+
 **Common Options:**
 - `--version` - Show the version
 - `-v` - Run in verbose mode

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -18,6 +18,21 @@ This guide helps you diagnose and resolve common BTrace issues.
 
 ## JVM Attachment Issues
 
+Start with the read-only diagnostic before trying to load the agent:
+
+```bash
+btrace doctor <pid>
+# Machine-readable automation output:
+btrace doctor <pid> --json
+```
+
+Doctor reports whether the Attach API is available and the target is accessible, but reports
+dynamic-agent loading permission as `not_tested`: determining that permission would require an
+agent-load attempt. If a normal BTrace attach is explicitly rejected because dynamic loading is
+disabled, BTrace prints two next-deployment choices instead of an unconditional stack trace:
+relaunch with `-XX:+EnableDynamicAgentLoading`, or configure reviewed prepared mode with
+`-javaagent:/path/to/btrace.jar=port=0`.
+
 ### Unable to attach to target VM
 
 **Error message:**

--- a/internal/specs/3.0.0-btrace-doctor.md
+++ b/internal/specs/3.0.0-btrace-doctor.md
@@ -1,0 +1,52 @@
+# BTrace 3.0.0 Doctor Command Contract
+
+Date: 2026-07-13
+
+Status: implementation contract for
+[#875](https://github.com/btraceio/btrace/issues/875)
+
+## Command and read-only boundary
+
+```text
+btrace doctor <pid> [--json]
+```
+
+Doctor opens an Attach API connection, reads target system properties, and detaches. It never
+calls `loadAgent`, opens the BTrace command socket, writes a target property, or submits a command.
+Because testing dynamic-agent permission would require attempting an agent load, the permission is
+always reported as `not_tested`. Attach API availability and target accessibility are separate
+observations.
+
+## Stable exit codes
+
+| Code | Status | Meaning |
+| ---: | --- | --- |
+| 0 | `ready` | A published BTrace endpoint has usable local connection metadata. |
+| 2 | `preparation_required` | The target is inspectable but no usable BTrace endpoint is published. |
+| 3 | `inaccessible` | The Attach API is unavailable or the target cannot be inspected. |
+| 4 | `unexpected_failure` | Arguments or an unexpected provider/runtime failure prevented diagnosis. |
+
+A ready authenticated endpoint requires a valid port, a numeric loopback address when one is
+published, valid authentication metadata, and a regular, readable, non-empty credential file. No
+socket connection is made to prove readiness.
+
+## Output contract
+
+Human output states the target JDK/vendor, Attach API availability, target accessibility, dynamic
+load permission as not tested, endpoint readiness, observed authentication state, remediation, and
+the exact operations doctor did not attempt.
+
+JSON output has `schemaVersion: 1` and stable top-level fields: `pid`, `status`, `exitCode`,
+`target`, `attach`, `operation`, `btrace`, `detail`, and `remediation`. Unknown or unobserved values
+are JSON `null`, not guesses.
+
+## Remediation
+
+When no usable endpoint is ready, doctor prints both next-deployment alternatives:
+
+- relaunch with `-XX:+EnableDynamicAgentLoading` before using dynamic attach; or
+- relaunch with `-javaagent:/path/to/btrace.jar=port=0` for reviewed prepared mode.
+
+The normal attach path recognizes explicit dynamic-agent-disabled failures and reports the resolved
+agent JAR path in the prepared-mode alternative. It states that BTrace did not inspect the target
+flag state and suppresses stack traces unless verbose logging is enabled.

--- a/internal/specs/3.0.0-btrace-doctor.md
+++ b/internal/specs/3.0.0-btrace-doctor.md
@@ -8,7 +8,7 @@ Status: implementation contract for
 ## Command and read-only boundary
 
 ```text
-btrace doctor <pid> [--json]
+btrace doctor <pid> [--json] [-v]
 ```
 
 Doctor opens an Attach API connection, reads target system properties, and detaches. It never
@@ -39,6 +39,9 @@ the exact operations doctor did not attempt.
 JSON output has `schemaVersion: 1` and stable top-level fields: `pid`, `status`, `exitCode`,
 `target`, `attach`, `operation`, `btrace`, `detail`, and `remediation`. Unknown or unobserved values
 are JSON `null`, not guesses.
+
+Verbose mode writes the stack trace for an unexpected provider or runtime failure to stderr. The
+flag may follow the doctor arguments or precede the `doctor` subcommand.
 
 ## Remediation
 


### PR DESCRIPTION
## Summary

- add btrace doctor <pid> with human and schema-versioned JSON output
- keep diagnosis read-only: Attach API property read plus detach, with no agent load or BTrace command connection
- report target JDK/vendor, Attach API availability, target accessibility, endpoint metadata, authentication readiness, and explicitly untested load permission
- define stable exit codes 0 ready, 2 preparation required, 3 inaccessible, and 4 unexpected failure
- translate explicit dynamic-agent-disabled failures into -XX:+EnableDynamicAgentLoading and resolved prepared-mode -javaagent guidance
- suppress unconditional attach stack traces while retaining verbose debug causes
- document the command, JSON contract, exit codes, and remediation

Closes #875

## Stack

This PR is stacked on #895 because doctor diagnoses the prepared endpoint and validates the credential format introduced there. Review commit fd5b6c54 for the #875-only change.

## Verification

- full :btrace-client:test suite
- repository-wide spotlessCheck
- clean :btrace-dist:btraceJar
- full :btrace-dist:build
- focused human and JSON output, stable exit code, read-only facade, inaccessible provider, unexpected failure, invalid PID, empty/missing credential, and dynamic-load classification tests
- live plain JVM: doctor returned exit 2, reported load permission as not tested, and added no BTrace properties
- live prepared JVM: human and JSON doctor returned exit 0 with the published loopback endpoint and usable credential; target output showed no command-server connection
- live JVM launched with -XX:-EnableDynamicAgentLoading: normal attach returned both next-deployment alternatives with the resolved agent JAR and no stack trace

## Adversarial review

- Attach API availability and agent-load permission are separate fields; doctor never infers the VM flag
- production doctor has no loadAgent or command-socket path
- prepared readiness validates port, numeric loopback address, authentication metadata, and a bounded non-symlink token read, then wipes the temporary token
- unknown observations are null in JSON rather than guessed
- exception and target-property control characters are sanitized, and JSON strings are escaped
- dynamic-load guidance matches explicit rejection phrases only, avoiding generic agent-load misclassification

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/896)
<!-- Reviewable:end -->
