### PR TITLE
Revert junit-jupiter v6 bump in JDK8-pinned modules

### DIFF
--- a/btrace-agent/build.gradle
+++ b/btrace-agent/build.gradle
@@ -17,10 +17,10 @@ compileTestJava {
 // JDK 17+ to compile against, so pin this module's test dependency to the last JDK
 // 8-compatible release instead of the repo-wide catalog version.
 configurations.testCompileClasspath {
-    resolutionStrategy.force 'org.junit.jupiter:junit-jupiter:6.1.2'
+    resolutionStrategy.force 'org.junit.jupiter:junit-jupiter:5.14.4'
 }
 configurations.testRuntimeClasspath {
-    resolutionStrategy.force 'org.junit.jupiter:junit-jupiter:6.1.2'
+    resolutionStrategy.force 'org.junit.jupiter:junit-jupiter:5.14.4'
 }
 
 sourceSets {

--- a/btrace-gradle-plugin/build.gradle
+++ b/btrace-gradle-plugin/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     // Testing — version pinned here to match the root project's version catalog (settings.gradle).
     // Note: this is an included build and cannot access the root project's 'libs' version catalog.
     testImplementation gradleTestKit()
-    testImplementation 'org.junit.jupiter:junit-jupiter:6.1.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -22,10 +22,10 @@ compileTestJava {
 // so pin this module's test dependency to the last JDK 8-compatible release instead of
 // the repo-wide catalog version.
 configurations.testCompileClasspath {
-    resolutionStrategy.force 'org.junit.jupiter:junit-jupiter:6.1.2'
+    resolutionStrategy.force 'org.junit.jupiter:junit-jupiter:5.14.4'
 }
 configurations.testRuntimeClasspath {
-    resolutionStrategy.force 'org.junit.jupiter:junit-jupiter:6.1.2'
+    resolutionStrategy.force 'org.junit.jupiter:junit-jupiter:5.14.4'
 }
 
 task buildEventsJar(type: Jar) {


### PR DESCRIPTION
## Summary
- PR #871 (Renovate) rewrote three explicit `resolutionStrategy.force` pins on `org.junit.jupiter:junit-jupiter` (btrace-agent, btrace-gradle-plugin, integration-tests) from JDK8-compatible versions (5.14.4 / 5.11.4) to v6.1.2.
- Those pins exist specifically because these modules' test sourcesets target JDK8, and junit-jupiter 6.x requires JDK17+ to compile against — the comments right above each pin explain this. Renovate isn't aware of that constraint and blindly bumped the pinned version anyway.
- This has broken `develop`'s `build` job since the merge (`Could not resolve org.junit.jupiter:junit-jupiter:6.1.1 ... only compatible with JVM runtime version 17 or newer`), and it merged in the first place because `develop` has no required status checks configured, so Renovate's automerge never actually waited for CI.

## Fix
Straight revert of #871 — restores the three pins to their JDK8-compatible versions. Verified `:btrace-agent:compileTestJava` and `:integration-tests:compileTestJava` both succeed locally.

## Test plan
- [x] `./gradlew :btrace-agent:compileTestJava :integration-tests:compileTestJava` — BUILD SUCCESSFUL
- [ ] CI green on this PR

Separately, I'm adding required status checks to `develop`'s branch protection so this class of break can't merge again regardless of Renovate's automerge settings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/902)
<!-- Reviewable:end -->
