### PR TITLE
[3.0] Add acquisition-path and first-trace smoke tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -560,7 +560,7 @@ jobs:
   # ============================================================
   finalize-tag:
     name: Finalize Release Tag
-    needs: [prepare-release, wait-for-maven]
+    needs: [prepare-release, release-smoke]
     runs-on: ubuntu-latest
     if: ${{ inputs.dry_run != true }}
     steps:
@@ -634,9 +634,9 @@ jobs:
           VERSION="${{ inputs.release_version }}"
           sed -i "s/project.version = '.*'/project.version = '${VERSION}'/" common.gradle
 
-      - name: Build distribution packages
+      - name: Build distribution packages from a clean tree
         run: |
-          ./gradlew :btrace-dist:build --no-daemon
+          ./gradlew clean :btrace-dist:build --no-daemon
 
       - name: List artifacts
         run: |
@@ -654,6 +654,101 @@ jobs:
             btrace-dist/build/distributions/btrace-v${{ inputs.release_version }}-sdkman-bin.zip
             btrace-dist/build/distributions/*.deb
             btrace-dist/build/distributions/*.rpm
+
+  # ============================================================
+  # Job 6b: Acquisition paths and first-trace release smoke tests
+  # ============================================================
+  release-smoke:
+    name: Release Acquisition and First Trace
+    needs: [prepare-release, wait-for-maven, update-jbang-catalog, build-distributions]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    if: ${{ inputs.dry_run != true }}
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        with:
+          java-version: 21
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+
+      - name: Download release distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-distributions
+          path: release-distributions
+
+      - name: Extract binary distribution
+        run: |
+          mkdir -p release-candidate
+          unzip -q "release-distributions/btrace-v${RELEASE_VERSION}-bin.zip" -d release-candidate
+
+      - name: Build fat agent from the release commit
+        run: |
+          ./gradlew clean :btrace-dist:fatAgentJar :btrace-dist:explodeExtensions --no-daemon
+
+      - name: Download Maven release metadata
+        run: |
+          mkdir -p release-metadata
+          curl --fail --show-error --silent --retry 6 --retry-delay 10 \
+            "https://repo1.maven.org/maven2/io/btrace/btrace/${RELEASE_VERSION}/btrace-${RELEASE_VERSION}.pom" \
+            --output release-metadata/btrace.pom
+
+      - name: Build release container from the candidate distribution
+        run: |
+          mkdir -p release-container/btrace
+          cp -R release-candidate/. release-container/btrace/
+          cp docker/docker-entrypoint.sh release-container/
+          docker build \
+            --build-arg "BTRACE_VERSION=${RELEASE_VERSION}" \
+            --tag "btrace-release-smoke:${RELEASE_VERSION}" \
+            --file docker/Dockerfile \
+            release-container
+
+      - name: Verify archive, Maven, manifest, version, and container metadata
+        run: |
+          scripts/verify-release-artifacts.sh \
+            --distribution release-candidate \
+            --sdkman-archive "release-distributions/btrace-v${RELEASE_VERSION}-sdkman-bin.zip" \
+            --maven-pom release-metadata/btrace.pom \
+            --container-image "btrace-release-smoke:${RELEASE_VERSION}" \
+            --version "${RELEASE_VERSION}"
+
+      - name: Run built-distribution smoke matrix
+        run: |
+          TMPDIR="${RUNNER_TEMP}" scripts/release-smoke.sh \
+            --distribution release-candidate \
+            --fat-agent btrace-dist/build/resources/main/v${RELEASE_VERSION}/libs/btrace-agent-fat.jar \
+            --version "${RELEASE_VERSION}" \
+            --keep-work
+
+      - name: Verify Maven coordinate and JBang catalog alias
+        run: |
+          curl -Ls https://sh.jbang.dev | bash -s - app setup
+          export PATH="$HOME/.jbang/bin:$PATH"
+          jbang "io.btrace:btrace:${RELEASE_VERSION}" --version | tee jbang-coordinate.log
+          grep -F "${RELEASE_VERSION}" jbang-coordinate.log
+          jbang catalog add --name btraceio \
+            https://raw.githubusercontent.com/btraceio/jbang-catalog/main/jbang-catalog.json
+          jbang btrace@btraceio --version | tee jbang-catalog.log
+          grep -F "${RELEASE_VERSION}" jbang-catalog.log
+
+      - name: Upload release-smoke diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-smoke-diagnostics
+          if-no-files-found: ignore
+          path: |
+            ${{ runner.temp }}/btrace-release-smoke.*/logs
+            jbang-*.log
 
   # ============================================================
   # Job 7: Create GitHub Release

--- a/btrace-agent/src/main/java/io/btrace/instr/BTraceProbeNode.java
+++ b/btrace-agent/src/main/java/io/btrace/instr/BTraceProbeNode.java
@@ -528,6 +528,7 @@ public final class BTraceProbeNode extends ClassNode implements BTraceProbe {
       }
     } catch (VerifierException e) {
       verifierException = e;
+      log.debug("BTrace class verification failed", e);
     } finally {
       if (debug.isDumpClasses() && name != null) {
         debug.dumpClass(name, getBytecode(false));

--- a/btrace-compiler/src/main/java/io/btrace/compiler/CompilerHelper.java
+++ b/btrace-compiler/src/main/java/io/btrace/compiler/CompilerHelper.java
@@ -29,7 +29,6 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -39,6 +38,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.stream.Stream;
 import javax.annotation.processing.Processor;
 import javax.tools.Diagnostic;
 import javax.tools.Diagnostic.Kind;
@@ -63,8 +63,8 @@ class CompilerHelper {
   }
 
   /**
-   * Extends the classpath with JARs from extension directories. Scans in order:
-   * BTRACE_HOME/libs/ext/, ~/.btrace/ext/, $BTRACE_EXT_PATH
+   * Extends the classpath with JARs from extension directories. Scans the canonical 3.0 paths,
+   * legacy paths, and {@code BTRACE_EXT_PATH}, in that order.
    *
    * @param classPath original classpath (may be null)
    * @return extended classpath including extension JARs
@@ -72,17 +72,25 @@ class CompilerHelper {
   private String extendClassPathWithExtensions(String classPath) {
     List<String> extensionJars = new ArrayList<>();
 
-    // 1. Built-in extensions: BTRACE_HOME/libs/ext/
+    // 1. Built-in extensions. The distribution explodes each extension into its own directory.
     String btraceHome = getBTraceHome();
     if (btraceHome != null) {
-      Path builtinExtPath = Paths.get(btraceHome, "libs", "ext");
+      Path builtinExtPath = Paths.get(btraceHome, "extensions");
+      addExtensionJars(builtinExtPath, extensionJars);
+
+      // Legacy pre-3.0 location.
+      builtinExtPath = Paths.get(btraceHome, "libs", "ext");
       addExtensionJars(builtinExtPath, extensionJars);
     }
 
-    // 2. User extensions: ~/.btrace/ext/
+    // 2. User extensions.
     String userHome = System.getProperty("user.home");
     if (userHome != null) {
-      Path userExtPath = Paths.get(userHome, ".btrace", "ext");
+      Path userExtPath = Paths.get(userHome, ".btrace", "extensions");
+      addExtensionJars(userExtPath, extensionJars);
+
+      // Legacy pre-3.0 location.
+      userExtPath = Paths.get(userHome, ".btrace", "ext");
       addExtensionJars(userExtPath, extensionJars);
     }
 
@@ -160,10 +168,13 @@ class CompilerHelper {
       return;
     }
 
-    try (DirectoryStream<Path> stream = Files.newDirectoryStream(directory, "*.jar")) {
-      for (Path jar : stream) {
-        jars.add(jar.toAbsolutePath().toString());
-      }
+    try (Stream<Path> stream = Files.walk(directory)) {
+      stream
+          .filter(Files::isRegularFile)
+          .filter(path -> path.getFileName().toString().endsWith(".jar"))
+          .map(path -> path.toAbsolutePath().normalize().toString())
+          .sorted()
+          .forEach(jars::add);
     } catch (IOException ignored) {
       // Directory not accessible, skip silently
     }

--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -226,14 +226,18 @@ task prepareClientClassdata(type: Copy) {
         include 'io/btrace/client/**/*.class'
         include 'io/btrace/extcli/**/*.class'
         include 'io/btrace/compiler/**/*.class'
+        // btracec emits persisted probe packs through InstrPackGenerator. Keep its implementation
+        // and non-bootstrap dependencies visible to the client masked classloader.
+        include 'io/btrace/instr/**/*.class'
+        include 'io/btrace/runtime/**/*.class'
+        include 'io/btrace/extension/**/*.class'
         include 'io/btrace/libs/org/objectweb/asm/**/*.class'
         include 'io/btrace/libs/org/jctools/**/*.class'
         include 'io/btrace/libs/org/slf4j/**/*.class'
         include 'com/googlecode/lanterna/**/*.class'
-        // Exclude classes that are in bootstrap or shared
+        // Core classes are supplied by the bootstrap/shared sections. Runtime and extension
+        // classes are intentionally retained here for the compiler-side probe-pack generator.
         exclude 'io/btrace/core/**'
-        exclude 'io/btrace/runtime/**'
-        exclude 'io/btrace/extension/**'
         exclude 'META-INF/**'
         rename { name -> name.endsWith('.class') ? name.replace('.class', '.classdata') : name }
     }
@@ -573,7 +577,9 @@ task buildZip(type: Zip) {
 }
 
 task buildSdkmanZip(type: Zip) {
-    from "${distBase}"
+    // SDKMAN installs the extracted archive as the candidate home. Keep bin/ and libs/ at the
+    // archive root; an extra v<version>/ directory makes the installed candidate unusable.
+    from "${distTarget}"
     include "**/*"
 
     archiveBaseName.set('btrace')
@@ -631,6 +637,8 @@ buildDeb {
 }
 
 copyDtraceLib.dependsOn project(':btrace-dtrace').build
+fatAgentJar.mustRunAfter copyDtraceLib
+buildSdkmanZip.mustRunAfter fatAgentJar
 shadowJar.dependsOn btraceJar, copyDtraceLib, copyExtensions
 buildTgz.dependsOn btraceJar, fixPermissions, copyDtraceLib, processResources, explodeExtensions
 buildZip.dependsOn btraceJar, fixPermissions, copyDtraceLib, processResources, explodeExtensions
@@ -638,6 +646,19 @@ buildSdkmanZip.dependsOn btraceJar, fixPermissions, copyDtraceLib, processResour
 buildDeb.dependsOn btraceJar, fixPermissions, copyDtraceLib, processResources, explodeExtensions
 buildRpm.dependsOn btraceJar, fixPermissions, copyDtraceLib, processResources, explodeExtensions
 build.dependsOn buildSdkmanZip, buildZip, buildTgz, buildDeb, buildRpm
+
+task releaseSmoke(type: Exec) {
+    group = 'Verification'
+    description = 'Run acquisition and first-trace smoke tests against the built distribution'
+    dependsOn btraceJar, fatAgentJar, fixPermissions, explodeExtensions
+
+    workingDir rootProject.projectDir
+    commandLine 'bash',
+            rootProject.file('scripts/release-smoke.sh'),
+            '--distribution', distTarget,
+            '--fat-agent', new File(libsDir, 'btrace-agent-fat.jar'),
+            '--version', project.version
+}
 
 // Docker build tasks
 task buildDockerContext(type: Copy, dependsOn: [btraceJar, copyDtraceLib, processResources, fixPermissions]) {

--- a/btrace-dist/src/main/resources/bin/btrace
+++ b/btrace-dist/src/main/resources/bin/btrace
@@ -60,7 +60,7 @@ if [ -f "${CLIENT_JAR}" ]; then
       echo "Unable to locate tools.jar. Please, make sure JAVA_HOME points to a valid JDK installation"
       exit 1
     fi
-    ${JAVA_HOME}/bin/java ${JAVA_ARGS} -cp ${CLIENT_JAR}:${TOOLS_JAR}:/usr/share/lib/java/dtrace.jar io.btrace.boot.Loader $*
+    "${JAVA_HOME}/bin/java" ${JAVA_ARGS} -cp "${CLIENT_JAR}:${TOOLS_JAR}:/usr/share/lib/java/dtrace.jar" io.btrace.boot.Loader "$@"
   else
     echo "Please set a valid JAVA_HOME before running this script"
     exit 1

--- a/btrace-dist/src/main/resources/bin/btracec
+++ b/btrace-dist/src/main/resources/bin/btracec
@@ -20,7 +20,7 @@ CLIENT_JAR="${BTRACE_HOME}/libs/btrace.jar"
 if [ -f "${CLIENT_JAR}" ]; then
   if [ -d "${JAVA_HOME}" ]; then
     if [ "$1" = "--version" ]; then
-      ${JAVA_HOME}/bin/java ${JAVA_ARGS} -cp ${CLIENT_JAR} io.btrace.boot.Loader --version
+      "${JAVA_HOME}/bin/java" ${JAVA_ARGS} -cp "${CLIENT_JAR}" io.btrace.boot.Loader --version
       exit 0
     fi
     TOOLS_JAR="$JAVA_HOME/lib/tools.jar"
@@ -51,7 +51,7 @@ if [ -f "${CLIENT_JAR}" ]; then
       exit 1
     fi
 
-    ${JAVA_HOME}/bin/java ${JAVA_ARGS} -Dbtrace.client.main=io.btrace.compiler.Compiler -cp ${CLIENT_JAR}:${TOOLS_JAR} io.btrace.boot.Loader $*
+    "${JAVA_HOME}/bin/java" ${JAVA_ARGS} -Dbtrace.client.main=io.btrace.compiler.Compiler -cp "${CLIENT_JAR}:${TOOLS_JAR}" io.btrace.boot.Loader "$@"
   else
     echo "Please set a valid JAVA_HOME before running this script"
     exit 1

--- a/btrace-dist/src/main/resources/bin/btracep
+++ b/btrace-dist/src/main/resources/bin/btracep
@@ -54,7 +54,7 @@ if [ -f "${CLIENT_JAR}" ]; then
       exit 1
     fi
 
-    ${JAVA_HOME}/bin/java ${JAVA_ARGS} -Dbtrace.client.main=io.btrace.client.ProbePrinter -cp ${CLIENT_JAR}:${TOOLS_JAR} io.btrace.boot.Loader $*
+    "${JAVA_HOME}/bin/java" ${JAVA_ARGS} -Dbtrace.client.main=io.btrace.client.ProbePrinter -cp "${CLIENT_JAR}:${TOOLS_JAR}" io.btrace.boot.Loader "$@"
   else
     echo "Please set a valid JAVA_HOME before running this script"
     exit 1

--- a/btrace-extensions/examples/btrace-hadoop/build.gradle
+++ b/btrace-extensions/examples/btrace-hadoop/build.gradle
@@ -15,7 +15,6 @@ btraceExtension {
     id = 'btrace-hadoop-example'
     name = 'BTrace Hadoop Example'
     description = 'Example provided-style extension for Apache Hadoop'
-    services = ['org.example.btrace.hadoop.api.HadoopApi']
 }
 
 dependencies {

--- a/btrace-extensions/examples/btrace-hadoop/src/main/java/org/example/btrace/hadoop/api/HadoopApi.java
+++ b/btrace-extensions/examples/btrace-hadoop/src/main/java/org/example/btrace/hadoop/api/HadoopApi.java
@@ -16,10 +16,13 @@
  */
 package org.example.btrace.hadoop.api;
 
+import io.btrace.core.extensions.ServiceDescriptor;
+
 /**
  * Hadoop example API exposed to BTrace probes. Uses Object hand-off to avoid bootstrap coupling to
  * application types.
  */
+@ServiceDescriptor
 public interface HadoopApi {
   void onOpen(Object fileSystem, Object path);
 

--- a/btrace-extensions/examples/btrace-hadoop/src/main/resources/META-INF/services/org.example.btrace.hadoop.api.HadoopApi
+++ b/btrace-extensions/examples/btrace-hadoop/src/main/resources/META-INF/services/org.example.btrace.hadoop.api.HadoopApi
@@ -1,0 +1,1 @@
+org.example.btrace.hadoop.impl.HadoopApiImpl

--- a/btrace-gradle-plugin/README.md
+++ b/btrace-gradle-plugin/README.md
@@ -256,8 +256,9 @@ The fat agent JAR contains:
 btrace-agent-fat.jar
 ├── META-INF/
 │   ├── MANIFEST.MF
-│   │   ├── Premain-Class: io.btrace.agent.Main
-│   │   ├── Agent-Class: io.btrace.agent.Main
+│   │   ├── Premain-Class: io.btrace.boot.Loader
+│   │   ├── Agent-Class: io.btrace.boot.Loader
+│   │   ├── BTrace-Agent-Main: io.btrace.agent.Main
 │   │   ├── Boot-Class-Path: btrace-agent-fat.jar
 │   │   └── BTrace-Embedded-Extensions: ext1,ext2,ext3
 │   └── btrace-extensions/

--- a/btrace-gradle-plugin/README.md
+++ b/btrace-gradle-plugin/README.md
@@ -232,8 +232,8 @@ plugins {
 btraceFatAgent {
     baseName = 'my-custom-agent'
 
-    // Reference base BTrace JAR (required for standalone builds)
-    agentJarTask = 'btraceJar'  // or provide path
+    // Task producing the masked BTrace JAR (required for standalone builds)
+    agentJarTask = 'btraceJar'
 
     embedExtensions {
         maven('io.btrace:btrace-metrics:3.0.0')
@@ -272,6 +272,9 @@ btrace-agent-fat.jar
 ├── org/example/ext/api/...         # Extension API classes (.class)
 └── org/example/ext/impl/...        # Extension impl classes (.classdata)
 ```
+
+`fatAgentJar` validates this masked-JAR structure after assembly and fails if the loader, masked
+agent entry point, or mandatory loader manifest attributes are missing.
 
 ### Using the Fat Agent
 

--- a/btrace-gradle-plugin/build.gradle
+++ b/btrace-gradle-plugin/build.gradle
@@ -34,6 +34,10 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    // Gradle 9 TestKit launches nested builds and requires a Java 17+ runtime.
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 gradlePlugin {

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentExtension.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentExtension.groovy
@@ -28,8 +28,6 @@ import org.gradle.api.file.FileCollection
  * </pre>
  */
 class BTraceFatAgentExtension {
-    static final String DEFAULT_REGISTRY_URL = 'https://btraceio.github.io/btrace-extensions/registry/extensions.json'
-
     private final Project project
     private final List<ExtensionSource> extensionSources = []
     private final ProbeBundleSpec probeBundle
@@ -58,16 +56,9 @@ class BTraceFatAgentExtension {
     /** Property name for filtering extensions when autoDiscover is true */
     String filterProperty = 'embedExtensions'
 
-    /** Extension registry URL for resolving registry("id") sources. */
-    String registryUrl = System.getProperty('btrace.extensions.registry', DEFAULT_REGISTRY_URL)
-
-    /** Local cache file for the extension registry document. */
-    File registryCacheFile
-
     BTraceFatAgentExtension(Project project) {
         this.project = project
         this.outputDir = project.layout.buildDirectory.dir('libs').get().asFile
-        this.registryCacheFile = project.layout.buildDirectory.file('registry/extensions.json').get().asFile
         this.probeBundle = new ProbeBundleSpec(project)
     }
 

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentExtension.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentExtension.groovy
@@ -44,10 +44,10 @@ class BTraceFatAgentExtension {
     /** Package relocations (from -> to) */
     Map<String, String> relocations = [:]
 
-    /** Reference to agent JAR task (required for standalone builds) */
+    /** Reference to the task producing the masked BTrace JAR (normally btraceJar). */
     Object agentJarTask
 
-    /** Reference to boot JAR task (required for standalone builds) */
+    /** Legacy reference to a separate boot JAR task. Prefer a single masked btraceJar. */
     Object bootJarTask
 
     /** Whether to auto-discover extensions from subprojects (default: false) */

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentExtension.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentExtension.groovy
@@ -1,6 +1,9 @@
 package io.btrace.gradle
 
+import java.util.jar.JarFile
+
 import org.gradle.api.Action
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 
@@ -484,6 +487,55 @@ class ResolvedExtension {
     Properties metadata = new Properties()
     Project sourceProject  // non-null if from project source
     List<File> probes = []
+
+    /**
+     * Completes distribution metadata from the canonical API JAR manifest. Manifest values are
+     * authoritative, so stale extension ZIP properties cannot weaken the embedded permission
+     * policy. Project sources receive the same metadata as published extensions.
+     */
+    void hydrateFromApiManifest() {
+        if (apiJar == null || !apiJar.isFile()) {
+            throw new GradleException(
+                "[fat-agent] Cannot embed extension '${id}': API JAR is missing, so permission metadata cannot be transferred")
+        }
+
+        def attributeToProperty = [
+            'BTrace-Extension-Id': 'id',
+            'BTrace-Extension-Version': 'version',
+            'BTrace-Extension-Name': 'name',
+            'BTrace-Extension-Description': 'description',
+            'BTrace-API-Version': 'btrace.api.version',
+            'BTrace-Java-Version': 'java.version',
+            'BTrace-Extension-Services': 'services',
+            'BTrace-Extension-Requires': 'requires.extensions',
+            'BTrace-Extension-Permissions': 'permissions',
+            'BTrace-Extension-Exports': 'exports'
+        ]
+
+        try {
+            new JarFile(apiJar).withCloseable { jar ->
+                def attributes = jar.manifest?.mainAttributes
+                def permissions = attributes?.getValue('BTrace-Extension-Permissions')
+                if (permissions == null) {
+                    throw new GradleException(
+                        "[fat-agent] Cannot embed extension '${id}': ${apiJar.name} is missing BTrace-Extension-Permissions; refusing to default permissions to an empty set")
+                }
+                attributeToProperty.each { manifestName, propertyName ->
+                    def value = attributes.getValue(manifestName)
+                    if (value != null) metadata.setProperty(propertyName, value)
+                }
+            }
+        } catch (GradleException e) {
+            throw e
+        } catch (Exception e) {
+            throw new GradleException(
+                "[fat-agent] Cannot read extension metadata for '${id}' from ${apiJar}: ${e.message}",
+                e)
+        }
+
+        id = metadata.getProperty('id', id)
+        version = metadata.getProperty('version', version)
+    }
 
     @Override
     String toString() {

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy
@@ -36,6 +36,11 @@ import java.util.jar.JarFile
  * via {@code ClassDataLoader}).
  */
 class BTraceFatAgentPlugin implements Plugin<Project> {
+    private static final String LOADER_CLASS = 'io.btrace.boot.Loader'
+    private static final String AGENT_MAIN_CLASS = 'io.btrace.agent.Main'
+    private static final String LOADER_ENTRY = 'io/btrace/boot/Loader.class'
+    private static final String MASKED_AGENT_MAIN_ENTRY =
+        'META-INF/btrace/agent/io/btrace/agent/Main.classdata'
 
     @Override
     void apply(Project project) {
@@ -228,6 +233,10 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
                     manifest.attributes.putAll(extension.manifestAttributes)
                 }
             }
+
+            doLast {
+                validateMaskedFatAgent(archiveFile.get().asFile)
+            }
         }
 
         // Wire up dependencies after ALL projects are evaluated (important for auto-discovery)
@@ -305,6 +314,46 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
             throw new GradleException(
                 "[fat-agent] Invalid bundled probe binary name: '${binaryName}'")
         }
+    }
+
+    private static void validateMaskedFatAgent(File fatJar) {
+        new JarFile(fatJar).withCloseable { jar ->
+            def attributes = jar.manifest?.mainAttributes
+            if (attributes == null) {
+                throw invalidFatAgent(fatJar, 'missing META-INF/MANIFEST.MF')
+            }
+
+            requireJarEntry(jar, fatJar, LOADER_ENTRY)
+            requireJarEntry(jar, fatJar, MASKED_AGENT_MAIN_ENTRY)
+            requireManifestAttribute(attributes, fatJar, 'Premain-Class', LOADER_CLASS)
+            requireManifestAttribute(attributes, fatJar, 'Agent-Class', LOADER_CLASS)
+            requireManifestAttribute(attributes, fatJar, 'Main-Class', LOADER_CLASS)
+            requireManifestAttribute(
+                attributes, fatJar, 'BTrace-Agent-Main', AGENT_MAIN_CLASS)
+            requireManifestAttribute(
+                attributes, fatJar, 'Boot-Class-Path', fatJar.name)
+        }
+    }
+
+    private static void requireJarEntry(JarFile jar, File fatJar, String entry) {
+        if (jar.getJarEntry(entry) == null) {
+            throw invalidFatAgent(fatJar, "missing ${entry}")
+        }
+    }
+
+    private static void requireManifestAttribute(
+        def attributes, File fatJar, String name, String expected) {
+        def actual = attributes.getValue(name)
+        if (actual != expected) {
+            throw invalidFatAgent(
+                fatJar, "manifest ${name} must be '${expected}' but was '${actual}'")
+        }
+    }
+
+    private static GradleException invalidFatAgent(File fatJar, String problem) {
+        return new GradleException(
+            "[fat-agent] Invalid masked BTrace fat JAR ${fatJar}: ${problem}. " +
+                "Configure agentJarTask to reference the btraceJar task.")
     }
 
     /**

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy
@@ -192,10 +192,9 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
 
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
-            // Configure output directory
-            doFirst {
-                destinationDirectory.set(extension.outputDir)
-            }
+            // Declare the output during task configuration so Gradle can track it. The extension
+            // remains lazy because consumers commonly set outputDir after applying the plugin.
+            destinationDirectory.set(project.layout.dir(project.provider { extension.outputDir }))
 
             // Include staged extension content
             from(stagingDir) {
@@ -205,11 +204,15 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
             // Configure manifest
             manifest {
                 attributes(
-                    'Premain-Class': 'io.btrace.agent.Main',
-                    'Agent-Class': 'io.btrace.agent.Main',
+                    'Premain-Class': 'io.btrace.boot.Loader',
+                    'Agent-Class': 'io.btrace.boot.Loader',
+                    'Main-Class': 'io.btrace.boot.Loader',
                     'Can-Redefine-Classes': 'true',
                     'Can-Retransform-Classes': 'true',
-                    'Boot-Class-Path': "${extension.baseName}.jar"
+                    'Boot-Class-Path': "${extension.baseName}.jar",
+                    'BTrace-Version': project.version,
+                    'BTrace-Agent-Main': 'io.btrace.agent.Main',
+                    'BTrace-Client-Main': 'io.btrace.client.Main'
                 )
             }
 
@@ -277,6 +280,7 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
             try {
                 def ext = source.resolve()
                 if (ext != null) {
+                    ext.hydrateFromApiManifest()
                     resolved << ext
                     project.logger.info("[fat-agent] Resolved extension: ${ext}")
                 }
@@ -307,8 +311,6 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
      * Stage a resolved extension to the staging directory.
      */
     private void stageExtension(Project project, File stagingDir, ResolvedExtension ext) {
-        def manifestMetadata = readApiManifestMetadata(ext)
-
         // Stage API classes as .class files (for bootstrap)
         if (ext.apiJar?.exists()) {
             project.copy {
@@ -327,6 +329,17 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
                 include '**/*.class'
                 rename '(.+)\\.class', '$1.classdata'
             }
+            def declaredServices = (ext.metadata?.getProperty('services') ?: '')
+                .split(',')
+                .collect { it.trim() }
+                .findAll { !it.isEmpty() }
+            if (!declaredServices.isEmpty()) {
+                project.copy {
+                    from project.zipTree(ext.implJar)
+                    into stagingDir
+                    include declaredServices.collect { "META-INF/services/${it}" }
+                }
+            }
             project.logger.info("[fat-agent] Staged impl (as .classdata) from: ${ext.implJar.name}")
         }
 
@@ -334,56 +347,46 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
         def extMetaDir = new File(stagingDir, "META-INF/btrace-extensions/${ext.id}")
         extMetaDir.mkdirs()
 
+        def properties = new LinkedHashMap<String, String>()
+        properties.id = ext.id
+        properties.version = ext.version
+        properties.name = ext.metadata?.getProperty('name') ?: ext.id
+        properties.description = ext.metadata?.getProperty('description') ?: ''
+        ['btrace.api.version', 'java.version', 'services', 'requires.extensions', 'permissions',
+         'exports', 'configurator', 'probes'].each { key ->
+            def value = ext.metadata?.getProperty(key)
+            if (value != null) properties[key] = value
+        }
+
+        def escapeProperty = { String value ->
+            def escaped = new StringBuilder()
+            value.toCharArray().eachWithIndex { char character, int index ->
+                switch (character) {
+                    case '\\': escaped.append('\\\\'); break
+                    case '\t': escaped.append('\\t'); break
+                    case '\n': escaped.append('\\n'); break
+                    case '\r': escaped.append('\\r'); break
+                    case '\f': escaped.append('\\f'); break
+                    case ' ': escaped.append(index == 0 ? '\\ ' : ' '); break
+                    default:
+                        int codePoint = (int) character
+                        if (codePoint < 0x20 || codePoint > 0x7e) {
+                            escaped.append(String.format('\\u%04x', codePoint))
+                        } else {
+                            escaped.append(character)
+                        }
+                }
+            }
+            escaped.toString()
+        }
         def propsFile = new File(extMetaDir, 'extension.properties')
-        propsFile.text = """\
-id=${ext.id}
-version=${ext.version}
-name=${manifestMetadata.name}
-description=${manifestMetadata.description}
-btrace.api.version=${manifestMetadata.btraceApiVersion}
-java.version=${manifestMetadata.javaVersion}
-services=${manifestMetadata.services}
-requires.extensions=${manifestMetadata.requiresExtensions}
-permissions=${manifestMetadata.permissions}
-"""
+        propsFile.withWriter('ISO-8859-1') { writer ->
+            properties.each { key, value ->
+                writer.write("${key}=${escapeProperty(value)}\n")
+            }
+        }
 
         project.logger.info("[fat-agent] Created extension.properties for ${ext.id}")
-    }
-
-    /**
-     * Reads metadata from the API JAR that a filesystem repository would use. Permission metadata
-     * is mandatory: silently replacing a missing attribute with an empty set would let embedded
-     * packaging bypass the privileged-extension policy.
-     */
-    private Map<String, String> readApiManifestMetadata(ResolvedExtension ext) {
-        if (ext.apiJar == null || !ext.apiJar.isFile()) {
-            throw new GradleException(
-                "[fat-agent] Cannot embed extension '${ext.id}': API JAR is missing, so permission metadata cannot be transferred")
-        }
-
-        try (JarFile apiJar = new JarFile(ext.apiJar)) {
-            def attrs = apiJar.manifest?.mainAttributes
-            def permissions = attrs?.getValue('BTrace-Extension-Permissions')
-            if (permissions == null) {
-                throw new GradleException(
-                    "[fat-agent] Cannot embed extension '${ext.id}': ${ext.apiJar.name} is missing BTrace-Extension-Permissions; refusing to default permissions to an empty set")
-            }
-            return [
-                name: attrs.getValue('BTrace-Extension-Name') ?: ext.metadata?.getProperty('name') ?: ext.id,
-                description: attrs.getValue('BTrace-Extension-Description') ?: ext.metadata?.getProperty('description') ?: '',
-                btraceApiVersion: attrs.getValue('BTrace-API-Version') ?: '3.0+',
-                javaVersion: attrs.getValue('BTrace-Java-Version') ?: '8+',
-                services: attrs.getValue('BTrace-Extension-Services') ?: '',
-                requiresExtensions: attrs.getValue('BTrace-Extension-Requires') ?: '',
-                permissions: permissions
-            ]
-        } catch (GradleException e) {
-            throw e
-        } catch (Exception e) {
-            throw new GradleException(
-                "[fat-agent] Cannot read permission metadata for extension '${ext.id}' from ${ext.apiJar}: ${e.message}",
-                e)
-        }
     }
 
     /**

--- a/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceFatAgentPluginTest.java
+++ b/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceFatAgentPluginTest.java
@@ -234,6 +234,7 @@ class BTraceFatAgentPluginTest {
     @Test
     @DisplayName("Fat agent packages nested bundled probe binary names")
     void packagesNestedBundledProbe() throws IOException {
+        writeMinimalMaskedAgentFixture();
         Path probe = projectDir.resolve("probes/com/example/NestedProbe.class");
         Files.createDirectories(probe.getParent());
         Files.write(probe, new byte[] {0, 1, 2, 3});
@@ -241,6 +242,7 @@ class BTraceFatAgentPluginTest {
                 buildFile,
                 "plugins { id 'io.btrace.fat-agent' }\n"
                         + "btraceFatAgent {\n"
+                        + "  agentJarTask = 'jar'\n"
                         + "  bundledProbes {\n"
                         + "    from 'probes'\n"
                         + "    include 'com.example.NestedProbe'\n"
@@ -309,20 +311,25 @@ class BTraceFatAgentPluginTest {
     @Test
     @DisplayName("Launched fat agent executes and tears down a nested bundled probe")
     void launchedFatAgentExecutesAndTearsDownBundledProbe() throws Exception {
-        Path agentSource = projectDir.resolve("src/main/java/io/btrace/agent/Main.java");
+        Path agentSource = projectDir.resolve("src/main/java/io/btrace/boot/Loader.java");
         Path appSource = projectDir.resolve("src/main/java/demo/App.java");
         Path probeSource = projectDir.resolve("probe-src/com/example/NestedProbe.java");
+        Path maskedAgentMain =
+                projectDir.resolve(
+                        "src/main/resources/META-INF/btrace/agent/io/btrace/agent/Main.classdata");
         Files.createDirectories(agentSource.getParent());
         Files.createDirectories(appSource.getParent());
         Files.createDirectories(probeSource.getParent());
+        Files.createDirectories(maskedAgentMain.getParent());
+        Files.write(maskedAgentMain, new byte[] {0});
         Files.writeString(
                 agentSource,
-                "package io.btrace.agent;\n"
+                "package io.btrace.boot;\n"
                         + "import java.io.InputStream;\n"
-                        + "public final class Main {\n"
+                        + "public final class Loader {\n"
                         + "  public static void premain(String name) throws Exception {\n"
                         + "    String path = \"META-INF/btrace-probes/\" + name.replace('.', '/') + \".class\";\n"
-                        + "    ClassLoader loader = Main.class.getClassLoader();\n"
+                        + "    ClassLoader loader = Loader.class.getClassLoader();\n"
                         + "    try (InputStream in = loader != null ? loader.getResourceAsStream(path) : ClassLoader.getSystemResourceAsStream(path)) {\n"
                         + "      if (in == null) throw new IllegalStateException(\"missing \" + path);\n"
                         + "      Class<?> probe = new ProbeLoader().define(in.readAllBytes());\n"
@@ -365,8 +372,6 @@ class BTraceFatAgentPluginTest {
                         + "tasks.named('stageProbes') { dependsOn 'compileBundledProbe' }\n"
                         + "btraceFatAgent {\n"
                         + "  agentJarTask = 'jar'\n"
-                        + "  manifestAttributes['Premain-Class'] = 'io.btrace.agent.Main'\n"
-                        + "  manifestAttributes['Agent-Class'] = 'io.btrace.agent.Main'\n"
                         + "  bundledProbes {\n"
                         + "    from layout.buildDirectory.dir('compiled-probes').get().asFile\n"
                         + "    include 'com.example.NestedProbe'\n"
@@ -397,6 +402,50 @@ class BTraceFatAgentPluginTest {
         assertTrue(output.contains("BUNDLED_PROBE_EXECUTED"), output);
         assertTrue(output.contains("APP_RAN"), output);
         assertTrue(output.contains("BUNDLED_PROBE_TORN_DOWN"), output);
+    }
+
+    @Test
+    @DisplayName("Conventional agent JARs fail the masked fat-agent contract")
+    void conventionalAgentJarFailsClearly() throws IOException {
+        Path agentSource = projectDir.resolve("src/main/java/io/btrace/agent/Main.java");
+        Files.createDirectories(agentSource.getParent());
+        Files.writeString(
+                agentSource,
+                "package io.btrace.agent; public final class Main {}\n",
+                StandardCharsets.UTF_8);
+        writeFile(
+                buildFile,
+                "plugins { id 'io.btrace.fat-agent' }\n"
+                        + "btraceFatAgent { agentJarTask = 'jar' }\n");
+
+        BuildResult result = createRunner().withArguments("fatAgentJar").buildAndFail();
+
+        assertTrue(result.getOutput().contains("Invalid masked BTrace fat JAR"));
+        assertTrue(result.getOutput().contains("missing io/btrace/boot/Loader.class"));
+        assertTrue(result.getOutput().contains("reference the btraceJar task"));
+    }
+
+    @Test
+    @DisplayName("Fat agents require the masked agent section")
+    void fatAgentWithoutMaskedAgentMainFailsClearly() throws IOException {
+        Path loaderSource = projectDir.resolve("src/main/java/io/btrace/boot/Loader.java");
+        Files.createDirectories(loaderSource.getParent());
+        Files.writeString(
+                loaderSource,
+                "package io.btrace.boot; public final class Loader {}\n",
+                StandardCharsets.UTF_8);
+        writeFile(
+                buildFile,
+                "plugins { id 'io.btrace.fat-agent' }\n"
+                        + "btraceFatAgent { agentJarTask = 'jar' }\n");
+
+        BuildResult result = createRunner().withArguments("fatAgentJar").buildAndFail();
+
+        assertTrue(result.getOutput().contains("Invalid masked BTrace fat JAR"));
+        assertTrue(
+                result.getOutput()
+                        .contains(
+                                "missing META-INF/btrace/agent/io/btrace/agent/Main.classdata"));
     }
 
     @Test
@@ -640,6 +689,20 @@ class BTraceFatAgentPluginTest {
                         + "'\n"
                         + "  }\n"
                         + "}\n");
+    }
+
+    private void writeMinimalMaskedAgentFixture() throws IOException {
+        Path loaderSource = projectDir.resolve("src/main/java/io/btrace/boot/Loader.java");
+        Path maskedAgentMain =
+                projectDir.resolve(
+                        "src/main/resources/META-INF/btrace/agent/io/btrace/agent/Main.classdata");
+        Files.createDirectories(loaderSource.getParent());
+        Files.createDirectories(maskedAgentMain.getParent());
+        Files.writeString(
+                loaderSource,
+                "package io.btrace.boot; public final class Loader {}\n",
+                StandardCharsets.UTF_8);
+        Files.write(maskedAgentMain, new byte[] {0});
     }
 
     private Path writeExtensionFixture(String permissions) throws IOException {

--- a/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceFatAgentPluginTest.java
+++ b/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceFatAgentPluginTest.java
@@ -34,6 +34,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
+import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import org.gradle.testkit.runner.BuildResult;
@@ -582,6 +583,45 @@ class BTraceFatAgentPluginTest {
     }
 
     @Test
+    @DisplayName("Extension API manifest metadata is retained when staging")
+    void extensionApiManifestMetadataRetained() throws IOException {
+        Path extensionDir = projectDir.resolve("sample-extension");
+        Files.createDirectories(extensionDir);
+        createExtensionApiJar(extensionDir.resolve("sample-api.jar"));
+        createExtensionImplJar(extensionDir.resolve("sample-impl.jar"));
+
+        writeFile(buildFile,
+            "plugins {\n" +
+            "    id 'io.btrace.fat-agent'\n" +
+            "}\n" +
+            "\n" +
+            "btraceFatAgent {\n" +
+            "    autoDiscover = false\n" +
+            "    embedExtensions {\n" +
+            "        file('sample-extension')\n" +
+            "    }\n" +
+            "}\n"
+        );
+
+        BuildResult result = createRunner()
+            .withArguments("stageExtensions")
+            .build();
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":stageExtensions").getOutcome());
+        String properties = Files.readString(
+            projectDir.resolve(
+                "build/fat-agent-staging/META-INF/btrace-extensions/sample/extension.properties"));
+        assertTrue(properties.contains("services=com.example.SampleService"));
+        assertTrue(properties.contains("permissions=THREADS"));
+        assertTrue(properties.contains("btrace.api.version=3.0+"));
+        assertEquals(
+            "com.example.SampleServiceImpl",
+            Files.readString(
+                projectDir.resolve(
+                    "build/fat-agent-staging/META-INF/services/com.example.SampleService")));
+    }
+
+    @Test
     @DisplayName("Registry source fails clearly for unknown extension id")
     void registrySourceFailsForUnknownId() throws IOException {
         Path registry = projectDir.resolve("extensions.json");
@@ -659,6 +699,31 @@ class BTraceFatAgentPluginTest {
             // The manifest is the only content needed by this packaging fixture.
         }
         return extensionDir;
+    }
+
+    private void createExtensionApiJar(Path jarPath) throws IOException {
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attributes.putValue("BTrace-Extension-Id", "sample");
+        attributes.putValue("BTrace-Extension-Version", "1.2.3");
+        attributes.putValue("BTrace-Extension-Name", "Sample extension");
+        attributes.putValue("BTrace-API-Version", "3.0+");
+        attributes.putValue("BTrace-Java-Version", "8+");
+        attributes.putValue("BTrace-Extension-Services", "com.example.SampleService");
+        attributes.putValue("BTrace-Extension-Permissions", "THREADS");
+        try (JarOutputStream ignored =
+            new JarOutputStream(Files.newOutputStream(jarPath), manifest)) {
+            // The staging regression only needs canonical manifest metadata.
+        }
+    }
+
+    private void createExtensionImplJar(Path jarPath) throws IOException {
+        try (JarOutputStream jar = new JarOutputStream(Files.newOutputStream(jarPath))) {
+            jar.putNextEntry(new JarEntry("META-INF/services/com.example.SampleService"));
+            jar.write("com.example.SampleServiceImpl".getBytes(StandardCharsets.UTF_8));
+            jar.closeEntry();
+        }
     }
 
     private void writeFile(File file, String content) throws IOException {

--- a/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceFatAgentPluginTest.java
+++ b/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceFatAgentPluginTest.java
@@ -33,8 +33,8 @@ import java.nio.file.Path;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.Attributes;
-import java.util.jar.JarFile;
 import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import org.gradle.testkit.runner.BuildResult;
@@ -619,38 +619,6 @@ class BTraceFatAgentPluginTest {
             Files.readString(
                 projectDir.resolve(
                     "build/fat-agent-staging/META-INF/services/com.example.SampleService")));
-    }
-
-    @Test
-    @DisplayName("Registry source fails clearly for unknown extension id")
-    void registrySourceFailsForUnknownId() throws IOException {
-        Path registry = projectDir.resolve("extensions.json");
-        Files.writeString(
-            registry,
-            "{\n" +
-            "  \"schema_version\": 1,\n" +
-            "  \"extensions\": []\n" +
-            "}\n",
-            StandardCharsets.UTF_8);
-
-        writeFile(buildFile,
-            "plugins {\n" +
-            "    id 'io.btrace.fat-agent'\n" +
-            "}\n" +
-            "\n" +
-            "btraceFatAgent {\n" +
-            "    registryUrl = '" + registry.toUri().toString() + "'\n" +
-            "    embedExtensions {\n" +
-            "        registry('missing-ext')\n" +
-            "    }\n" +
-            "}\n"
-        );
-
-        BuildResult result = createRunner()
-            .withArguments("stageExtensions")
-            .buildAndFail();
-
-        assertTrue(result.getOutput().contains("Unknown extension id: missing-ext"));
     }
 
     private GradleRunner createRunner() {

--- a/docs/architecture/MaskedJarArchitecture.md
+++ b/docs/architecture/MaskedJarArchitecture.md
@@ -41,6 +41,12 @@ btrace.jar (~2.9 MB)
 
 **Masked classes** (~1600+): Agent, client, and shared classes are stored as `.classdata` files under `META-INF/btrace/`. The JVM's class loading ignores these files entirely. They are loaded on demand by `MaskedClassLoader`.
 
+The client section also contains the instrumentation/runtime implementation used by `btracec` to
+turn compiled scripts into persisted probe packs. The `io.btrace.core.PackGenerator` service
+descriptor is visible from the masked JAR root, so its `io.btrace.instr.InstrPackGenerator`
+provider and non-bootstrap dependencies must be loadable by the client masked classloader as well
+as by the agent classloader.
+
 ### Manifest
 
 ```

--- a/docs/architecture/fat-agent-plugin.md
+++ b/docs/architecture/fat-agent-plugin.md
@@ -187,8 +187,9 @@ The fat agent JAR manifest includes:
 
 | Attribute | Description |
 |-----------|-------------|
-| `Premain-Class` | `io.btrace.agent.Main` |
-| `Agent-Class` | `io.btrace.agent.Main` |
+| `Premain-Class` | `io.btrace.boot.Loader` |
+| `Agent-Class` | `io.btrace.boot.Loader` |
+| `BTrace-Agent-Main` | `io.btrace.agent.Main` |
 | `Can-Redefine-Classes` | `true` |
 | `Can-Retransform-Classes` | `true` |
 | `Boot-Class-Path` | `btrace-agent-fat.jar` (self-reference) |

--- a/docs/architecture/fat-agent-plugin.md
+++ b/docs/architecture/fat-agent-plugin.md
@@ -195,6 +195,11 @@ The fat agent JAR manifest includes:
 | `Boot-Class-Path` | `btrace-agent-fat.jar` (self-reference) |
 | `BTrace-Embedded-Extensions` | Comma-separated list of extension IDs |
 
+After assembly, the plugin verifies that the JAR contains `io/btrace/boot/Loader.class`, the masked
+`META-INF/btrace/agent/io/btrace/agent/Main.classdata` entry, and the mandatory loader manifest
+attributes. A conventional agent JAR is not a valid base input; `agentJarTask` must reference the
+task producing the masked BTrace JAR (normally `btraceJar`).
+
 ## Runtime Behavior
 
 ### Extension Loading

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -46,11 +46,18 @@ The release workflow performs these steps:
 6. **⏸️ MANUAL CHECKPOINT**: You must release artifacts via Central Portal
 7. **Wait for Maven Central**: Polls until artifacts are available (30 min timeout)
 8. **Build Distributions**: Creates tar.gz, zip, deb, rpm packages
-9. **GitHub Release**: Creates release with artifacts and changelog
-10. **SDKMan Update**: Announces new version to SDKMan
-11. **JBang**: Automatic - uses Maven Central artifacts
-12. **Version Bumps**: Updates develop and release branch to next snapshots
-13. **Milestones**: Creates/closes milestone, associates merged PRs
+9. **Release Smoke**: Exercises acquisition, first-trace, prepared, migration, extension, protocol,
+   archive, container, version, and license paths against the release candidate
+10. **GitHub Release**: Creates release with artifacts and changelog
+11. **SDKMan Update**: Announces new version to SDKMan
+12. **JBang**: Verifies both the Maven coordinate and catalog alias
+13. **Version Bumps**: Updates develop and release branch to next snapshots
+14. **Milestones**: Creates/closes milestone, associates merged PRs
+
+The final tag and GitHub release depend on the release-smoke job. Failures upload the individual
+target, client, compiler, migration, and doctor logs so packaging and readiness failures can be
+diagnosed without rerunning the release. The gate reads artifact availability only; it never uses
+download counts or network analytics.
 
 ### Manual Release Step
 
@@ -86,6 +93,15 @@ DRY_RUN=true ./scripts/release.sh minor
 ```
 
 Or use the GitHub Actions UI to trigger with `dry_run: true`.
+
+To run the live portion locally after building from a clean checkout:
+
+```bash
+./gradlew clean :btrace-dist:btraceJar :btrace-dist:fatAgentJar :btrace-dist:explodeExtensions
+./gradlew :btrace-dist:releaseSmoke
+```
+
+The smoke task requires JDK 11+, Bash, Python 3, and a local JVM that permits Attach API access.
 
 ## Maven Central
 
@@ -137,8 +153,7 @@ For major releases, `sdkMajorRelease` is used; for minor/patch, `sdkMinorRelease
 
 ## JBang
 
-JBang automatically picks up new versions from Maven Central. No manual action required.
-Once Maven Central has the artifacts, users can run:
+Once Maven Central has the artifact and the catalog is updated, users can run:
 
 ```bash
 jbang catalog add --name btraceio https://raw.githubusercontent.com/btraceio/jbang-catalog/main/jbang-catalog.json
@@ -147,6 +162,8 @@ jbang btrace@btraceio <PID> script.java
 
 Release checklist for JBang:
 - The release workflow updates `btraceio/jbang-catalog` automatically when `JBANG_CATALOG_PAT` is configured.
+- The release-smoke gate executes both `jbang io.btrace:btrace:<version> --version` and the
+  `btrace@btraceio` catalog alias before the final release tag is created.
 - If the workflow cannot push, update `btrace.java` in `btraceio/jbang-catalog` to the new major/minor version.
 
 ## Rollback Procedure

--- a/docs/tutorials/demo/legacy/SlowChargeProbe.java
+++ b/docs/tutorials/demo/legacy/SlowChargeProbe.java
@@ -9,13 +9,18 @@ package demo;
 import org.openjdk.btrace.core.annotations.BTrace;
 import org.openjdk.btrace.core.annotations.OnMethod;
 import org.openjdk.btrace.core.annotations.Duration;
+import org.openjdk.btrace.core.annotations.Kind;
+import org.openjdk.btrace.core.annotations.Location;
 import org.openjdk.btrace.core.annotations.Return;
 import static org.openjdk.btrace.core.BTraceUtils.println;
 import static org.openjdk.btrace.core.BTraceUtils.str;
 
 @BTrace
 public class SlowChargeProbe {
-  @OnMethod(clazz = "demo.OrderService", method = "chargeCard")
+  @OnMethod(
+      clazz = "demo.OrderService",
+      method = "chargeCard",
+      location = @Location(Kind.RETURN))
   public static void onCharge(@Duration long duration, @Return Object result) {
     if (duration > 200_000_000L) {
       println("slow chargeCard: " + str(duration / 1_000_000) + " ms");

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+DIST=""
+FAT_AGENT=""
+VERSION=""
+KEEP_WORK=false
+WORK=""
+TARGET_PID=""
+CLIENT_PID=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/release-smoke.sh --distribution <dir> --fat-agent <jar> --version <version> [--keep-work]
+
+Runs the release-candidate smoke matrix against an already built distribution. The test requires
+JDK 11+, Bash, Python 3, and a local Attach API-capable JVM. It performs no analytics or download
+count queries.
+EOF
+}
+
+while (($#)); do
+  case "$1" in
+    --distribution)
+      DIST=$2
+      shift 2
+      ;;
+    --fat-agent)
+      FAT_AGENT=$2
+      shift 2
+      ;;
+    --version)
+      VERSION=$2
+      shift 2
+      ;;
+    --keep-work)
+      KEEP_WORK=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+fail() {
+  echo "release smoke FAILED: $*" >&2
+  if [[ -n "$WORK" && -d "$WORK/logs" ]]; then
+    for log in "$WORK"/logs/*.log; do
+      [[ -f "$log" ]] || continue
+      echo "===== $log =====" >&2
+      tail -n 200 "$log" >&2
+    done
+  fi
+  exit 1
+}
+
+stop_process() {
+  local pid=${1:-}
+  [[ -n "$pid" ]] || return 0
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    for _ in {1..20}; do
+      kill -0 "$pid" 2>/dev/null || break
+      sleep 0.1
+    done
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+  wait "$pid" 2>/dev/null || true
+}
+
+cleanup() {
+  stop_process "$CLIENT_PID"
+  stop_process "$TARGET_PID"
+  if [[ -n "$WORK" && -d "$WORK" ]]; then
+    if [[ "$KEEP_WORK" == true ]]; then
+      echo "release smoke work directory: $WORK"
+    else
+      rm -rf "$WORK"
+    fi
+  fi
+}
+trap cleanup EXIT
+
+[[ -n "$DIST" && -d "$DIST" ]] || fail "--distribution must name an extracted distribution"
+[[ -n "$FAT_AGENT" && -f "$FAT_AGENT" ]] || fail "--fat-agent must name a built fat-agent JAR"
+[[ -n "$VERSION" ]] || fail "--version is required"
+[[ -n "${JAVA_HOME:-}" && -x "$JAVA_HOME/bin/java" ]] || fail "JAVA_HOME must point to a JDK"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required for socket assertions"
+
+DIST=$(cd "$DIST" && pwd)
+FAT_AGENT=$(cd "$(dirname "$FAT_AGENT")" && pwd)/$(basename "$FAT_AGENT")
+BTRACE="$DIST/bin/btrace"
+BTRACEC="$DIST/bin/btracec"
+MASKED_JAR="$DIST/libs/btrace.jar"
+[[ -x "$BTRACE" ]] || fail "missing executable $BTRACE"
+[[ -x "$BTRACEC" ]] || fail "missing executable $BTRACEC"
+[[ -f "$MASKED_JAR" ]] || fail "missing masked JAR $MASKED_JAR"
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/btrace-release-smoke.XXXXXX")
+mkdir -p "$WORK/logs" "$WORK/classes"
+cp "$ROOT/docs/tutorials/demo/DemoApp.java" "$WORK/DemoApp.java"
+cp "$ROOT/docs/tutorials/demo/OrderTiming.java" "$WORK/OrderTiming.java"
+cp "$ROOT/docs/tutorials/demo/legacy/SlowChargeProbe.java" "$WORK/SlowChargeProbe.java"
+cp "$ROOT/scripts/release-smoke/"*.java "$WORK/"
+
+wait_for_text() {
+  local file=$1
+  local text=$2
+  local timeout_seconds=${3:-45}
+  local deadline=$((SECONDS + timeout_seconds))
+  while ((SECONDS < deadline)); do
+    grep -F "$text" "$file" >/dev/null 2>&1 && return 0
+    sleep 0.2
+  done
+  return 1
+}
+
+start_patient() {
+  local label=$1
+  shift
+  stop_process "$TARGET_PID"
+  TARGET_PID=""
+  local log="$WORK/logs/${label}-target.log"
+  "$JAVA_HOME/bin/java" "$@" "$WORK/DemoApp.java" >"$log" 2>&1 &
+  TARGET_PID=$!
+  wait_for_text "$log" "[demo] order service running" 30 || fail "$label target did not become ready"
+}
+
+run_doctor() {
+  local label=$1
+  local expected_exit=$2
+  local expected_text=$3
+  local log="$WORK/logs/${label}-doctor.log"
+  local exit_code=0
+  for attempt in 1 2; do
+    set +e
+    BTRACE_HOME="$DIST" JAVA_HOME="$JAVA_HOME" "$BTRACE" doctor "$TARGET_PID" >"$log" 2>&1
+    exit_code=$?
+    set -e
+    [[ "$exit_code" -ne 3 || "$expected_exit" -eq 3 ]] && break
+    sleep 1
+  done
+  [[ "$exit_code" -eq "$expected_exit" ]] || fail "$label doctor exit $exit_code, expected $expected_exit"
+  grep -F "$expected_text" "$log" >/dev/null || fail "$label doctor output did not contain: $expected_text"
+}
+
+start_trace() {
+  local label=$1
+  local expected_text=$2
+  local java_tool_options=$3
+  shift 3
+  local log="$WORK/logs/${label}-client.log"
+  stop_process "$CLIENT_PID"
+  CLIENT_PID=""
+  (
+    cd "$WORK"
+    BTRACE_HOME="$DIST" JAVA_HOME="$JAVA_HOME" JAVA_TOOL_OPTIONS="$java_tool_options" \
+      "$BTRACE" "$@"
+  ) >"$log" 2>&1 &
+  CLIENT_PID=$!
+  wait_for_text "$log" "$expected_text" 60 || fail "$label did not produce: $expected_text"
+}
+
+finish_trace() {
+  stop_process "$CLIENT_PID"
+  CLIENT_PID=""
+  sleep 1
+}
+
+echo "[smoke] distribution metadata"
+version_output=$(BTRACE_HOME="$DIST" JAVA_HOME="$JAVA_HOME" "$BTRACE" --version 2>&1) \
+  || fail "btrace --version failed: $version_output"
+[[ "$version_output" == *"$VERSION"* ]] || fail "btrace --version did not contain $VERSION: $version_output"
+manifest=$(unzip -p "$MASKED_JAR" META-INF/MANIFEST.MF) \
+  || fail "could not read the masked JAR manifest"
+for entry in \
+  "Main-Class: io.btrace.boot.Loader" \
+  "Premain-Class: io.btrace.boot.Loader" \
+  "Agent-Class: io.btrace.boot.Loader" \
+  "BTrace-Version: $VERSION"; do
+  [[ "$manifest" == *"$entry"* ]] || fail "masked JAR manifest missing $entry"
+done
+
+echo "[smoke] documented dynamic oneliner, source script, and doctor"
+start_patient dynamic
+run_doctor before-attach 2 "PREPARATION_REQUIRED"
+start_trace documented-oneliner "processOrder" "" -n \
+  'OrderService::processOrder @return { print method, time }' "$TARGET_PID"
+run_doctor after-attach 0 "READY"
+finish_trace
+start_trace documented-source "worker=" "" "$TARGET_PID" OrderTiming.java
+finish_trace
+stop_process "$TARGET_PID"
+TARGET_PID=""
+
+echo "[smoke] authenticated prepared mode"
+start_patient prepared "-javaagent:$MASKED_JAR=port=0"
+run_doctor prepared 0 "READY"
+grep -F "Authentication: required" "$WORK/logs/prepared-doctor.log" >/dev/null \
+  || fail "prepared mode did not require authentication"
+start_trace prepared-source "worker=" "" "$TARGET_PID" OrderTiming.java
+finish_trace
+stop_process "$TARGET_PID"
+TARGET_PID=""
+
+echo "[smoke] startup script with noServer=true"
+(
+  cd "$WORK"
+  BTRACE_HOME="$DIST" JAVA_HOME="$JAVA_HOME" "$BTRACEC" -d "$WORK/classes" StartupProbe.java
+) >"$WORK/logs/startup-compile.log" 2>&1 || fail "startup probe compilation failed"
+startup_class="$WORK/classes/StartupProbe.class"
+[[ -f "$startup_class" ]] || fail "btracec did not produce StartupProbe.class"
+closed_port=$(python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)
+start_patient no-server \
+  "-javaagent:$MASKED_JAR=script=$startup_class,noServer=true,port=$closed_port,stdout=true"
+wait_for_text "$WORK/logs/no-server-target.log" "release-smoke: startup probe" 45 \
+  || fail "startup probe did not run"
+run_doctor no-server 2 "PREPARATION_REQUIRED"
+python3 - "$closed_port" <<'PY' || fail "noServer=true opened the configured command socket"
+import socket
+import sys
+s = socket.socket()
+s.settimeout(0.5)
+try:
+    s.connect(("127.0.0.1", int(sys.argv[1])))
+except OSError:
+    raise SystemExit(0)
+finally:
+    s.close()
+raise SystemExit(1)
+PY
+stop_process "$TARGET_PID"
+TARGET_PID=""
+
+echo "[smoke] 2.x source migration and distribution compiler"
+"$ROOT/scripts/migrate-btrace-script.sh" "$WORK/SlowChargeProbe.java" \
+  >"$WORK/logs/migration.log" 2>&1 || fail "source migration helper failed"
+if grep -F "org.openjdk.btrace" "$WORK/SlowChargeProbe.java" >/dev/null; then
+  fail "source migration left legacy package references"
+fi
+(
+  cd "$WORK"
+  BTRACE_HOME="$DIST" JAVA_HOME="$JAVA_HOME" "$BTRACEC" -d "$WORK/classes" SlowChargeProbe.java
+) >"$WORK/logs/migration-compile.log" 2>&1 || fail "migrated source did not compile"
+
+echo "[smoke] forced V1, forced V2, and automatic negotiation"
+for mode in v1 v2 auto; do
+  case "$mode" in
+    v1) protocol_options="-Dbtrace.comm.protocol=1 -Dbtrace.comm.autoNegotiate=false -Dbtrace.comm.forceVersion=true" ;;
+    v2) protocol_options="-Dbtrace.comm.protocol=2 -Dbtrace.comm.autoNegotiate=false -Dbtrace.comm.forceVersion=true" ;;
+    auto) protocol_options="-Dbtrace.comm.protocol=2 -Dbtrace.comm.autoNegotiate=true -Dbtrace.comm.forceVersion=false" ;;
+  esac
+  read -r -a target_options <<<"$protocol_options"
+  start_patient "protocol-$mode" "${target_options[@]}"
+  start_trace "protocol-$mode" "worker=" "$protocol_options" "$TARGET_PID" OrderTiming.java
+  finish_trace
+  stop_process "$TARGET_PID"
+  TARGET_PID=""
+done
+
+echo "[smoke] embedded non-privileged and privileged extensions"
+cat >"$WORK/permissions.properties" <<'EOF'
+allowExtensions=btrace-hadoop-example
+allowPrivileged=false
+EOF
+start_patient embedded-non-privileged \
+  "-Dbtrace.permissions=$WORK/permissions.properties" \
+  "-javaagent:$FAT_AGENT=port=0,debug=true"
+run_doctor embedded-non-privileged 0 "READY"
+start_trace embedded-non-privileged "release-smoke: non-privileged extension" "" \
+  "$TARGET_PID" NonPrivilegedExtensionProbe.java
+finish_trace
+stop_process "$TARGET_PID"
+TARGET_PID=""
+
+cat >"$WORK/permissions.properties" <<'EOF'
+allowExtensions=btrace-metrics
+allowPrivileged=true
+EOF
+start_patient embedded-privileged \
+  "-Dbtrace.permissions=$WORK/permissions.properties" \
+  "-javaagent:$FAT_AGENT=port=0,debug=true"
+run_doctor embedded-privileged 0 "READY"
+start_trace embedded-privileged "release-smoke: privileged extension" "" \
+  "$TARGET_PID" PrivilegedExtensionProbe.java
+finish_trace
+stop_process "$TARGET_PID"
+TARGET_PID=""
+
+echo "release smoke PASSED"

--- a/scripts/release-smoke/NonPrivilegedExtensionProbe.java
+++ b/scripts/release-smoke/NonPrivilegedExtensionProbe.java
@@ -1,0 +1,17 @@
+import static io.btrace.core.BTraceUtils.println;
+
+import io.btrace.core.annotations.BTrace;
+import io.btrace.core.annotations.Injected;
+import io.btrace.core.annotations.OnMethod;
+import org.example.btrace.hadoop.api.HadoopApi;
+
+@BTrace
+public class NonPrivilegedExtensionProbe {
+  @Injected private static HadoopApi hadoop;
+
+  @OnMethod(clazz = "OrderService", method = "processOrder")
+  public static void onOrder() {
+    hadoop.onOpen(null, null);
+    println("release-smoke: non-privileged extension");
+  }
+}

--- a/scripts/release-smoke/PrivilegedExtensionProbe.java
+++ b/scripts/release-smoke/PrivilegedExtensionProbe.java
@@ -1,0 +1,17 @@
+import static io.btrace.core.BTraceUtils.println;
+
+import io.btrace.core.annotations.BTrace;
+import io.btrace.core.annotations.Injected;
+import io.btrace.core.annotations.OnMethod;
+import io.btrace.metrics.MetricsService;
+
+@BTrace
+public class PrivilegedExtensionProbe {
+  @Injected private static MetricsService metrics;
+
+  @OnMethod(clazz = "OrderService", method = "processOrder")
+  public static void onOrder() {
+    metrics.histogram("release-smoke").record(1);
+    println("release-smoke: privileged extension");
+  }
+}

--- a/scripts/release-smoke/StartupProbe.java
+++ b/scripts/release-smoke/StartupProbe.java
@@ -1,0 +1,14 @@
+import static io.btrace.core.BTraceUtils.println;
+
+import io.btrace.core.annotations.BTrace;
+import io.btrace.core.annotations.Kind;
+import io.btrace.core.annotations.Location;
+import io.btrace.core.annotations.OnMethod;
+
+@BTrace
+public class StartupProbe {
+  @OnMethod(clazz = "OrderService", method = "processOrder", location = @Location(Kind.RETURN))
+  public static void onReturn() {
+    println("release-smoke: startup probe");
+  }
+}

--- a/scripts/verify-release-artifacts.sh
+++ b/scripts/verify-release-artifacts.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIST=""
+SDKMAN_ARCHIVE=""
+MAVEN_POM=""
+VERSION=""
+CONTAINER_IMAGE=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/verify-release-artifacts.sh --distribution <dir> --sdkman-archive <zip>
+       --maven-pom <file> --version <version> [--container-image <tag>]
+
+Verifies release artifact layout and metadata without consulting download counts or analytics.
+EOF
+}
+
+while (($#)); do
+  case "$1" in
+    --distribution)
+      DIST=$2
+      shift 2
+      ;;
+    --sdkman-archive)
+      SDKMAN_ARCHIVE=$2
+      shift 2
+      ;;
+    --maven-pom)
+      MAVEN_POM=$2
+      shift 2
+      ;;
+    --version)
+      VERSION=$2
+      shift 2
+      ;;
+    --container-image)
+      CONTAINER_IMAGE=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+fail() {
+  echo "release artifact verification FAILED: $*" >&2
+  exit 1
+}
+
+[[ -n "$DIST" && -d "$DIST" ]] || fail "--distribution must name an extracted distribution"
+[[ -n "$SDKMAN_ARCHIVE" && -f "$SDKMAN_ARCHIVE" ]] || fail "--sdkman-archive must name a ZIP"
+[[ -n "$MAVEN_POM" && -f "$MAVEN_POM" ]] || fail "--maven-pom must name a POM file"
+[[ -n "$VERSION" ]] || fail "--version is required"
+[[ -n "${JAVA_HOME:-}" && -x "$JAVA_HOME/bin/java" ]] || fail "JAVA_HOME must point to a JDK"
+
+masked_jar="$DIST/libs/btrace.jar"
+[[ -f "$masked_jar" ]] || fail "distribution does not contain libs/btrace.jar"
+[[ -x "$DIST/bin/btrace" ]] || fail "distribution does not contain executable bin/btrace"
+
+version_output=$(BTRACE_HOME="$DIST" "$DIST/bin/btrace" --version 2>&1) \
+  || fail "btrace --version failed: $version_output"
+[[ "$version_output" == *"$VERSION"* ]] || fail "btrace --version did not contain $VERSION: $version_output"
+
+manifest=$(unzip -p "$masked_jar" META-INF/MANIFEST.MF) \
+  || fail "could not read the masked JAR manifest"
+for entry in \
+  "Main-Class: io.btrace.boot.Loader" \
+  "Premain-Class: io.btrace.boot.Loader" \
+  "Agent-Class: io.btrace.boot.Loader" \
+  "BTrace-Version: $VERSION"; do
+  [[ "$manifest" == *"$entry"* ]] || fail "masked JAR manifest missing $entry"
+done
+
+sdkman_entries=$(unzip -Z1 "$SDKMAN_ARCHIVE") \
+  || fail "could not list the SDKMAN archive"
+for entry in bin/btrace bin/btracec libs/btrace.jar; do
+  grep -Fx "$entry" <<<"$sdkman_entries" >/dev/null \
+    || fail "SDKMAN archive is not installable at its root; missing $entry"
+done
+if grep -E "^v${VERSION}/(bin|libs)/" <<<"$sdkman_entries" >/dev/null; then
+  fail "SDKMAN archive contains an extra v$VERSION directory"
+fi
+
+grep -F "<name>The Apache License, Version 2.0</name>" "$MAVEN_POM" >/dev/null \
+  || fail "Maven POM is missing the Apache 2.0 license name"
+grep -F "<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>" "$MAVEN_POM" >/dev/null \
+  || fail "Maven POM is missing the Apache 2.0 license URL"
+
+if [[ -n "$CONTAINER_IMAGE" ]]; then
+  command -v docker >/dev/null 2>&1 || fail "docker is required for --container-image"
+  image_license=$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.licenses" }}' "$CONTAINER_IMAGE") \
+    || fail "could not inspect the container OCI license"
+  [[ "$image_license" == "Apache-2.0" ]] || fail "container OCI license is $image_license"
+  image_version=$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' "$CONTAINER_IMAGE") \
+    || fail "could not inspect the container OCI version"
+  [[ "$image_version" == "$VERSION" ]] || fail "container OCI version is $image_version"
+  docker run --rm --entrypoint /bin/sh "$CONTAINER_IMAGE" -c \
+    'test -f /opt/btrace/libs/btrace.jar && test ! -f /opt/btrace/libs/btrace-agent.jar' \
+    || fail "container does not contain the intended masked JAR layout"
+fi
+
+echo "release artifact verification PASSED"


### PR DESCRIPTION
Closes #880.

## Summary

- add a clean-built distribution smoke matrix for documented oneliners, source probes, doctor, authenticated prepared mode, no-server startup, migration, V1/V2/auto negotiation, and embedded extensions
- verify SDKMAN, Maven, masked/fat-agent, version, license, and container metadata and gate final release tagging on the checks
- fix packaging defects exposed by the gate: launcher argument quoting, client masked dependencies, SDKMAN layout, fat-agent metadata/service staging, extension discovery, and the legacy migration fixture
- enforce the masked fat-agent contract after assembly: require `io.btrace.boot.Loader`, the masked agent entry point, and the mandatory loader manifest attributes, with a clear failure for conventional agent JAR inputs
- remove obsolete fat-agent registry DSL state and its stale `registry()` test

## Verification

- clean masked/fat-agent/distribution/POM build plus repository-wide `spotlessCheck`: 231 tasks, passed
- all 22 `BTraceFatAgentPluginTest` tests: passed with Gradle TestKit running on Java 17
- real `:btrace-dist:fatAgentJar` assembly: passed; output contains `io/btrace/boot/Loader.class` and `META-INF/btrace/agent/io/btrace/agent/Main.classdata`
- release artifact verifier: passed
- full live release smoke matrix: passed
- Bash syntax, workflow YAML parse, and `git diff --check`: passed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/903)
<!-- Reviewable:end -->
