### PR TITLE
client: fix JAVA_HOME NPE at startup and malformed cmdQueueLimit token

### DIFF
--- a/btrace-client/src/main/java/io/btrace/client/Client.java
+++ b/btrace-client/src/main/java/io/btrace/client/Client.java
@@ -803,7 +803,7 @@ public class Client {
       agentArgs += "," + Args.SYSTEM_CLASS_PATH + "=" + sysCp;
       String cmdQueueLimit = System.getProperty(BTraceRuntime.CMD_QUEUE_LIMIT_KEY, null);
       if (cmdQueueLimit != null) {
-        agentArgs += ",=" + Args.CMD_QUEUE_LIMIT + cmdQueueLimit;
+        agentArgs += "," + Args.CMD_QUEUE_LIMIT + "=" + cmdQueueLimit;
       }
       agentArgs += "," + Args.PROBE_DESC_PATH + "=" + probeDescPath;
 

--- a/btrace-client/src/main/java/io/btrace/client/Main.java
+++ b/btrace-client/src/main/java/io/btrace/client/Main.java
@@ -91,9 +91,17 @@ public final class Main {
   }
 
   private static String getJavaVersion() {
+    String javaHome = System.getenv("JAVA_HOME");
+    if (javaHome == null || javaHome.trim().isEmpty()) {
+      // Fall back to the JVM the client itself is running on; JAVA_HOME is not required to be set.
+      javaHome = System.getProperty("java.home");
+    }
+    if (javaHome == null || javaHome.trim().isEmpty()) {
+      return null;
+    }
     Properties props = new Properties();
     try {
-      props.load(Files.newInputStream(Paths.get(System.getenv("JAVA_HOME"), "release")));
+      props.load(Files.newInputStream(Paths.get(javaHome, "release")));
       return props.getProperty("JAVA_VERSION").replace("\"", "");
     } catch (IOException ignored) {
       return null;


### PR DESCRIPTION
Main.getJavaVersion() ran inside the class's static initializer and called Paths.get(System.getenv("JAVA_HOME"), "release") unguarded. When JAVA_HOME isn't set, System.getenv() returns null and Paths.get(null, ..) throws NullPointerException -- only IOException was caught, so the NPE escaped as ExceptionInInitializerError and killed the CLI before it could start. Falls back to the java.home system property (the JVM the client itself is running on) when JAVA_HOME is unset or blank, and returns null (unknown version) only if neither is available.

Separately, Client.java built the --cmdQueueLimit agent argument as ",=" + Args.CMD_QUEUE_LIMIT + cmdQueueLimit instead of the "," + KEY + "=" + value pattern every other agent arg in this method follows. The leading "=" with no key meant the agent's parser saw a junk empty-key entry rather than a CMD_QUEUE_LIMIT value, so the setting was silently dropped.

Fixes #887, #886

## What does this change do?

<!-- Summarize the user-visible or maintenance change in a few sentences. -->

## Related issue

<!-- Link an issue, discussion, design, or release-plan item. Use "N/A" if none applies. -->

Closes #

## Scope and compatibility

- [ ] I identified the affected module(s) and kept unrelated changes out of this PR.
- [ ] This preserves the supported Java/runtime compatibility tiers, or the change is documented below.
- [ ] This does not change the masked-JAR layout, class-loader boundary, or wire protocol.
- [ ] If it does, I updated the relevant architecture documentation and verification plan.

**Compatibility or migration notes:**

<!-- Mention API, CLI, probe, extension, protocol, packaging, or documentation changes. -->

## Testing

<!-- List the commands you ran and the relevant result. Follow the repository Gradle guidance. -->

- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] `spotlessCheck`
- [ ] Documentation/link or sample verification (if applicable)

**Commands and results:**

```text
# Example:
# GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :module:test
```

## Documentation and release impact

- [ ] User-facing documentation is updated, or no documentation change is needed.
- [ ] Release notes/changelog are updated, or no release-note entry is needed.
- [ ] Samples, distribution contents, or published coordinates are updated if affected.
- [ ] This change is safe to merge independently of a release, or the dependency is explained below.

**Release notes / follow-up work:**

<!-- Call out deprecations, breaking changes, follow-up PRs, or release coordination. -->

## Final checklist

- [ ] I reviewed the complete diff and removed unrelated changes.
- [ ] New or changed behavior has appropriate tests, or the reason for not adding them is explained above.
- [ ] User-facing behavior, APIs, samples, and documentation are consistent with this change.
- [ ] I did not include generated build output, local configuration, credentials, or other accidental files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/905)
<!-- Reviewable:end -->
