### PR TITLE
fix(extensions): harden pre-release packaging and metrics

### DIFF
--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -515,21 +515,23 @@ task copyExtensions(type: Copy) {
     into "${distTarget}/extensions/"
 }
 
-// Copy the btracex CLI shaded jar into libs
+def releaseExtensionProjects = [
+    ':btrace-extensions:btrace-contracts',
+    ':btrace-extensions:btrace-gpu-bridge',
+    ':btrace-extensions:btrace-llm-trace',
+    ':btrace-extensions:btrace-metrics',
+    ':btrace-extensions:btrace-rag-quality',
+    ':btrace-extensions:btrace-statsd',
+    ':btrace-extensions:btrace-utils'
+]
 
-// Discover all extension subprojects and wire copyExtensions dynamically to avoid hard-coded paths
 gradle.projectsEvaluated {
-    def extProjects = rootProject.subprojects.findAll { it.plugins.hasPlugin('io.btrace.extension') }
-    if (extProjects.isEmpty()) {
-        logger.lifecycle("[btrace-dist] No BTrace extension projects found. Skipping extension packaging.")
-    } else {
-        tasks.named('copyExtensions').configure { t ->
-            extProjects.each { sp ->
-                // Depend on packaging task and copy any *-extension.zip from its distributions folder
-                t.dependsOn("${sp.path}:packageExtension")
-                t.from(sp.layout.buildDirectory.dir('distributions')) {
-                    include "*-extension.zip"
-                }
+    tasks.named('copyExtensions').configure { t ->
+        releaseExtensionProjects.each { extensionProjectPath ->
+            def extensionProject = project(extensionProjectPath)
+            t.dependsOn("${extensionProjectPath}:packageExtension")
+            t.from(extensionProject.layout.buildDirectory.dir('distributions')) {
+                include "*-extension.zip"
             }
         }
     }
@@ -563,6 +565,10 @@ task explodeExtensions {
             }
         }
     }
+}
+
+tasks.named('test').configure {
+    dependsOn explodeExtensions
 }
 
 task buildZip(type: Zip) {

--- a/btrace-dist/src/test/java/io/btrace/dist/BTraceJarPackagingTest.java
+++ b/btrace-dist/src/test/java/io/btrace/dist/BTraceJarPackagingTest.java
@@ -22,6 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import org.junit.jupiter.api.Test;
@@ -49,5 +52,51 @@ class BTraceJarPackagingTest {
       Attributes attributes = jarFile.getManifest().getMainAttributes();
       assertEquals("io.btrace.boot.Loader", attributes.getValue("Main-Class"));
     }
+  }
+
+  @Test
+  void packagesOnlyMaintainedExtensions() {
+    Set<String> expected =
+        new HashSet<>(
+            Arrays.asList(
+                "btrace-contracts",
+                "btrace-gpu-bridge",
+                "btrace-llm-trace",
+                "btrace-metrics",
+                "btrace-rag-quality",
+                "btrace-statsd",
+                "btrace-utils"));
+    File extensionsDir = getExtensionsDir();
+
+    File[] archives = extensionsDir.listFiles(file -> file.getName().endsWith("-extension.zip"));
+    assertNotNull(archives, "Expected packaged extension archives");
+    assertEquals(expected.size(), archives.length, "Unexpected number of packaged extensions");
+    Set<String> packaged = new HashSet<>();
+    for (File archive : archives) {
+      for (String extension : expected) {
+        if (archive.getName().startsWith(extension + "-")) {
+          packaged.add(extension);
+        }
+      }
+    }
+    assertEquals(expected, packaged, "Unexpected packaged extension archives");
+
+    File[] exploded = extensionsDir.listFiles(File::isDirectory);
+    assertNotNull(exploded, "Expected exploded extension directories");
+    Set<String> explodedNames = new HashSet<>();
+    for (File extension : exploded) {
+      explodedNames.add(extension.getName());
+    }
+    assertEquals(expected, explodedNames, "Unexpected exploded extensions");
+  }
+
+  private static File getExtensionsDir() {
+    File resourcesDir = new File("build/resources/main");
+    File[] versionDirs = resourcesDir.listFiles(File::isDirectory);
+    assertNotNull(versionDirs, "Expected versioned dist directory under build/resources/main");
+    assertEquals(1, versionDirs.length, "Expected exactly one versioned dist directory");
+    File extensionsDir = new File(versionDirs[0], "extensions");
+    assertTrue(extensionsDir.isDirectory(), "Expected assembled extensions directory to exist");
+    return extensionsDir;
   }
 }

--- a/btrace-extensions/btrace-metrics/src/main/java/io/btrace/metrics/stats/StatsMetricImpl.java
+++ b/btrace-extensions/btrace-metrics/src/main/java/io/btrace/metrics/stats/StatsMetricImpl.java
@@ -18,6 +18,7 @@ package io.btrace.metrics.stats;
 
 import io.btrace.metrics.Metric;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.DoubleAdder;
 import java.util.concurrent.atomic.LongAdder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -35,7 +36,7 @@ public final class StatsMetricImpl implements StatsMetric, Metric {
   private final String name;
   private final LongAdder count = new LongAdder();
   private final LongAdder sum = new LongAdder();
-  private final LongAdder sumOfSquares = new LongAdder();
+  private final DoubleAdder sumOfSquares = new DoubleAdder();
   private final AtomicLong min = new AtomicLong(Long.MAX_VALUE);
   private final AtomicLong max = new AtomicLong(Long.MIN_VALUE);
 
@@ -51,7 +52,7 @@ public final class StatsMetricImpl implements StatsMetric, Metric {
   public void record(long value) {
     count.increment();
     sum.add(value);
-    sumOfSquares.add(value * value);
+    sumOfSquares.add((double) value * value);
 
     // Update min (CAS loop)
     long currentMin;
@@ -80,7 +81,7 @@ public final class StatsMetricImpl implements StatsMetric, Metric {
   @Nullable public StatsSnapshot snapshot() {
     long cnt = count.sum();
     long sm = sum.sum();
-    long sumSq = sumOfSquares.sum();
+    double sumSq = sumOfSquares.sum();
     long mn = min.get();
     long mx = max.get();
 
@@ -91,7 +92,7 @@ public final class StatsMetricImpl implements StatsMetric, Metric {
     double avg = (double) sm / cnt;
 
     // Variance = E[X^2] - E[X]^2
-    double variance = ((double) sumSq / cnt) - (avg * avg);
+    double variance = (sumSq / cnt) - (avg * avg);
     double stddev = Math.sqrt(Math.max(0, variance));
 
     return new StatsSnapshotImpl(name, cnt, sm, mn, mx, avg, stddev);

--- a/btrace-extensions/btrace-metrics/src/test/java/io/btrace/metrics/StatsMetricTest.java
+++ b/btrace-extensions/btrace-metrics/src/test/java/io/btrace/metrics/StatsMetricTest.java
@@ -19,13 +19,14 @@ package io.btrace.metrics;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.btrace.metrics.stats.StatsMetric;
+import io.btrace.metrics.stats.StatsMetricImpl;
 import io.btrace.metrics.stats.StatsSnapshot;
 import org.junit.jupiter.api.Test;
 
 class StatsMetricTest {
   @Test
   void accumulatesAndSnapshots() {
-    StatsMetric m = new io.btrace.metrics.stats.StatsMetricImpl("s");
+    StatsMetric m = new StatsMetricImpl("s");
     m.record(1);
     m.record(3);
     StatsSnapshot snap = m.snapshot();
@@ -34,5 +35,17 @@ class StatsMetricTest {
     assertEquals(4, snap.sum());
     assertEquals(1, snap.min());
     assertEquals(3, snap.max());
+  }
+
+  @Test
+  void computesStandardDeviationWithoutSquareOverflow() {
+    StatsMetric metric = new StatsMetricImpl("overflow");
+    metric.record(0);
+    metric.record(4_000_000_000L);
+
+    StatsSnapshot snapshot = metric.snapshot();
+
+    assertTrue(Double.isFinite(snapshot.stddev()));
+    assertEquals(2_000_000_000D, snapshot.stddev(), 0.001D);
   }
 }

--- a/btrace-extensions/btrace-statsd/build.gradle
+++ b/btrace-extensions/btrace-statsd/build.gradle
@@ -22,4 +22,9 @@ dependencies {
     apiCompileOnly project(':btrace-core')
     implImplementation project(':btrace-core')
     implementation libs.slf4j
+    testImplementation libs.junit.jupiter
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/btrace-extensions/btrace-statsd/src/main/java/io/btrace/statsd/StatsdImpl.java
+++ b/btrace-extensions/btrace-statsd/src/main/java/io/btrace/statsd/StatsdImpl.java
@@ -26,30 +26,33 @@ import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 
 public final class StatsdImpl extends Extension implements Statsd {
-  private final Object socketLock = new Object();
-  private DatagramSocket socket;
-  private InetAddress address;
-  private int port;
+  private static final class Endpoint {
+    final InetAddress address;
+    final int port;
+    final DatagramSocket socket;
+
+    Endpoint(InetAddress address, int port, DatagramSocket socket) {
+      this.address = address;
+      this.port = port;
+      this.socket = socket;
+    }
+  }
+
+  private final Object lifecycleLock = new Object();
+  private volatile Endpoint endpoint;
 
   @Override
   public void initialize(ExtensionContext context) throws ExtensionException {
     super.initialize(context);
+    Endpoint configured;
     try {
       InetAddress configuredAddress = InetAddress.getByName(SharedSettings.GLOBAL.getStatsdHost());
       int configuredPort = SharedSettings.GLOBAL.getStatsdPort();
-      DatagramSocket configuredSocket = new DatagramSocket();
-      synchronized (socketLock) {
-        closeSocket();
-        address = configuredAddress;
-        port = configuredPort;
-        socket = configuredSocket;
-      }
+      configured = new Endpoint(configuredAddress, configuredPort, new DatagramSocket());
     } catch (Throwable ignored) {
-      synchronized (socketLock) {
-        closeSocket();
-        address = null;
-      }
+      configured = null;
     }
+    swapEndpoint(configured);
   }
 
   @Override
@@ -59,6 +62,10 @@ public final class StatsdImpl extends Extension implements Statsd {
 
   @Override
   public void increment(String name, String tags) {
+    Endpoint ep = endpoint;
+    if (ep == null) {
+      return;
+    }
     try {
       StringBuilder sb = new StringBuilder();
       sb.append(name).append(":1|c");
@@ -66,13 +73,8 @@ public final class StatsdImpl extends Extension implements Statsd {
         sb.append("|#").append(tags);
       }
       byte[] data = sb.toString().getBytes(StandardCharsets.US_ASCII);
-      synchronized (socketLock) {
-        if (socket == null || socket.isClosed() || address == null) {
-          return;
-        }
-        DatagramPacket pkt = new DatagramPacket(data, data.length, address, port);
-        socket.send(pkt);
-      }
+      DatagramPacket pkt = new DatagramPacket(data, data.length, ep.address, ep.port);
+      ep.socket.send(pkt);
     } catch (Throwable ignore) {
       // Best-effort, ignore errors in script path
     }
@@ -80,16 +82,17 @@ public final class StatsdImpl extends Extension implements Statsd {
 
   @Override
   public void close() {
-    synchronized (socketLock) {
-      closeSocket();
-      address = null;
-    }
+    swapEndpoint(null);
   }
 
-  private void closeSocket() {
-    if (socket != null) {
-      socket.close();
-      socket = null;
+  private void swapEndpoint(Endpoint next) {
+    Endpoint previous;
+    synchronized (lifecycleLock) {
+      previous = endpoint;
+      endpoint = next;
+    }
+    if (previous != null) {
+      previous.socket.close();
     }
   }
 }

--- a/btrace-extensions/btrace-statsd/src/main/java/io/btrace/statsd/StatsdImpl.java
+++ b/btrace-extensions/btrace-statsd/src/main/java/io/btrace/statsd/StatsdImpl.java
@@ -18,12 +18,40 @@ package io.btrace.statsd;
 
 import io.btrace.core.SharedSettings;
 import io.btrace.core.extensions.Extension;
+import io.btrace.core.extensions.ExtensionContext;
+import io.btrace.core.extensions.ExtensionException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 
 public final class StatsdImpl extends Extension implements Statsd {
+  private final Object socketLock = new Object();
+  private DatagramSocket socket;
+  private InetAddress address;
+  private int port;
+
+  @Override
+  public void initialize(ExtensionContext context) throws ExtensionException {
+    super.initialize(context);
+    try {
+      InetAddress configuredAddress = InetAddress.getByName(SharedSettings.GLOBAL.getStatsdHost());
+      int configuredPort = SharedSettings.GLOBAL.getStatsdPort();
+      DatagramSocket configuredSocket = new DatagramSocket();
+      synchronized (socketLock) {
+        closeSocket();
+        address = configuredAddress;
+        port = configuredPort;
+        socket = configuredSocket;
+      }
+    } catch (Throwable ignored) {
+      synchronized (socketLock) {
+        closeSocket();
+        address = null;
+      }
+    }
+  }
+
   @Override
   public void increment(String name) {
     increment(name, null);
@@ -38,14 +66,30 @@ public final class StatsdImpl extends Extension implements Statsd {
         sb.append("|#").append(tags);
       }
       byte[] data = sb.toString().getBytes(StandardCharsets.US_ASCII);
-      DatagramPacket pkt = new DatagramPacket(data, data.length);
-      pkt.setAddress(InetAddress.getByName(SharedSettings.GLOBAL.getStatsdHost()));
-      pkt.setPort(SharedSettings.GLOBAL.getStatsdPort());
-      try (DatagramSocket socket = new DatagramSocket()) {
+      synchronized (socketLock) {
+        if (socket == null || socket.isClosed() || address == null) {
+          return;
+        }
+        DatagramPacket pkt = new DatagramPacket(data, data.length, address, port);
         socket.send(pkt);
       }
     } catch (Throwable ignore) {
       // Best-effort, ignore errors in script path
+    }
+  }
+
+  @Override
+  public void close() {
+    synchronized (socketLock) {
+      closeSocket();
+      address = null;
+    }
+  }
+
+  private void closeSocket() {
+    if (socket != null) {
+      socket.close();
+      socket = null;
     }
   }
 }

--- a/btrace-extensions/btrace-statsd/src/test/java/io/btrace/statsd/StatsdImplTest.java
+++ b/btrace-extensions/btrace-statsd/src/test/java/io/btrace/statsd/StatsdImplTest.java
@@ -72,6 +72,7 @@ class StatsdImplTest {
     byte[] bytes = new byte[1024];
     DatagramPacket packet = new DatagramPacket(bytes, bytes.length);
     receiver.receive(packet);
-    return new String(packet.getData(), packet.getOffset(), packet.getLength(), StandardCharsets.US_ASCII);
+    return new String(
+        packet.getData(), packet.getOffset(), packet.getLength(), StandardCharsets.US_ASCII);
   }
 }

--- a/btrace-extensions/btrace-statsd/src/test/java/io/btrace/statsd/StatsdImplTest.java
+++ b/btrace-extensions/btrace-statsd/src/test/java/io/btrace/statsd/StatsdImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008, 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.btrace.statsd;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.btrace.core.SharedSettings;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class StatsdImplTest {
+  private final String originalHost = SharedSettings.GLOBAL.getStatsdHost();
+  private final int originalPort = SharedSettings.GLOBAL.getStatsdPort();
+
+  @AfterEach
+  void restoreSettings() {
+    SharedSettings.GLOBAL.setStatsdHost(originalHost);
+    SharedSettings.GLOBAL.setStatsdPort(originalPort);
+  }
+
+  @Test
+  void sendsRepeatedIncrementsThroughInitializedSocket() throws Exception {
+    try (DatagramSocket receiver = new DatagramSocket(0)) {
+      receiver.setSoTimeout(1000);
+      SharedSettings.GLOBAL.setStatsdHost("127.0.0.1");
+      SharedSettings.GLOBAL.setStatsdPort(receiver.getLocalPort());
+      StatsdImpl statsd = new StatsdImpl();
+      statsd.initialize(null);
+
+      statsd.increment("requests", "region:west");
+      statsd.increment("requests", "region:west");
+
+      assertEquals("requests:1|c|#region:west", receive(receiver));
+      assertEquals("requests:1|c|#region:west", receive(receiver));
+      statsd.close();
+      assertDoesNotThrow(() -> statsd.increment("requests"));
+      assertThrows(SocketTimeoutException.class, () -> receive(receiver));
+    }
+  }
+
+  @Test
+  void disablesEmissionWhenInitializationFails() {
+    SharedSettings.GLOBAL.setStatsdHost("invalid.invalid");
+    StatsdImpl statsd = new StatsdImpl();
+
+    assertDoesNotThrow(() -> statsd.initialize(null));
+    assertDoesNotThrow(() -> statsd.increment("requests"));
+    assertDoesNotThrow(statsd::close);
+  }
+
+  private static String receive(DatagramSocket receiver) throws Exception {
+    byte[] bytes = new byte[1024];
+    DatagramPacket packet = new DatagramPacket(bytes, bytes.length);
+    receiver.receive(packet);
+    return new String(packet.getData(), packet.getOffset(), packet.getLength(), StandardCharsets.US_ASCII);
+  }
+}

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceExtensionPlugin.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceExtensionPlugin.groovy
@@ -790,7 +790,7 @@ class BTraceExtensionPlugin implements Plugin<Project> {
                             'BTrace-Extension-Version': extension.version,
                             'BTrace-Extension-Name': extension.name,
                             'BTrace-Extension-Description': extension.description,
-                            'BTrace-API-Version': '2.3+',
+                            'BTrace-API-Version': '3.0+',
                             'BTrace-Java-Version': '8+',
                             'BTrace-Extension-Services': {
                                 if (servicesStr && !servicesStr.isEmpty()) return servicesStr

--- a/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceExtensionPluginTest.java
+++ b/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceExtensionPluginTest.java
@@ -56,6 +56,10 @@ class BTraceExtensionPluginTest {
         File apiJar = projectDir.resolve("ext/build/libs/ext-1.0-api.jar").toFile();
         assertTrue(apiJar.isFile(), "API jar should exist");
         try (JarFile jar = new JarFile(apiJar)) {
+            assertEquals(
+                    "3.0+",
+                    jar.getManifest().getMainAttributes().getValue("BTrace-API-Version"),
+                    "API manifest should advertise the 3.0 API baseline");
             assertNotNull(
                     jar.getEntry("META-INF/btrace/test-resource.txt"),
                     "API jar should keep main resources");

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -36,6 +36,32 @@ task buildEventsJar(type: Jar) {
     archiveClassifier = ""
 }
 
+def externalTypeClientHome = layout.buildDirectory.dir('external-type-client-home')
+def externalTypeClientLibs = externalTypeClientHome.map { it.dir('libs') }
+def externalTypeExtensions = externalTypeClientHome.map { it.dir('extensions') }
+def releaseBtraceJar = project(':btrace-dist').layout.buildDirectory.file("resources/main/v${project.version}/libs/btrace.jar")
+def externalTypeArchive = project(':btrace-extensions:btrace-ext-test').layout.buildDirectory.file("distributions/btrace-ext-test-${project.version}-extension.zip")
+
+task stageExternalTypeClientHome {
+    dependsOn ':btrace-dist:btraceJar', ':btrace-extensions:btrace-ext-test:packageExtension'
+    inputs.file releaseBtraceJar
+    inputs.file externalTypeArchive
+    outputs.dir externalTypeClientHome
+
+    doLast {
+        File clientHome = externalTypeClientHome.get().asFile
+        project.delete(clientHome)
+        project.copy {
+            from releaseBtraceJar
+            into new File(clientHome, 'libs')
+        }
+        project.copy {
+            from project.zipTree(externalTypeArchive.get().asFile)
+            into new File(clientHome, 'extensions/btrace-ext-test')
+        }
+    }
+}
+
 task compileTestProbes {
     dependsOn compileTestJava, ':btrace-agent:jar', ':btrace-compiler:jar'
     // Wire all extension buildApiJar tasks dynamically (parent aggregator dissolved)
@@ -103,7 +129,8 @@ test {
     }
     dependsOn cleanTest, buildEventsJar, compileTestProbes,
              ':btrace-dist:btraceJar',
-             ':btrace-dist:explodeExtensions'
+             ':btrace-dist:explodeExtensions',
+             stageExternalTypeClientHome
 
     testLogging.showStandardStreams = true
 
@@ -182,6 +209,8 @@ test {
         props.load(Files.newInputStream(releaseFile))
     }
     def libsPath = "${projectDir}/../btrace-dist/build/resources/main/v${project.version}/libs/"
+    systemProperty 'btrace.externalType.client.libs', externalTypeClientLibs.get().asFile.absolutePath
+    systemProperty 'btrace.externalType.extensions', externalTypeExtensions.get().asFile.absolutePath
     def isJava8 = props.getProperty("JAVA_VERSION")?.contains("1.8")
     if (isJava8) {
         jvmArgs "-Dproject.dir=${projectDir}", "-Dproject.version=${project.version}", "-Dbtrace.libs=${libsPath}"

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -43,7 +43,7 @@ def releaseBtraceJar = project(':btrace-dist').layout.buildDirectory.file("resou
 def externalTypeArchive = project(':btrace-extensions:btrace-ext-test').layout.buildDirectory.file("distributions/btrace-ext-test-${project.version}-extension.zip")
 
 task stageExternalTypeClientHome {
-    dependsOn ':btrace-dist:btraceJar', ':btrace-extensions:btrace-ext-test:packageExtension'
+    dependsOn ':btrace-dist:btraceJar', ':btrace-dist:copyDtraceLib', ':btrace-extensions:btrace-ext-test:packageExtension'
     inputs.file releaseBtraceJar
     inputs.file externalTypeArchive
     outputs.dir externalTypeClientHome

--- a/integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java
+++ b/integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java
@@ -21,6 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,6 +57,23 @@ public class ExternalTypeAdapterIntegrationTest extends RuntimeTest {
 
   @Test
   public void testExternalTypeAdapterTagAndValue() throws Exception {
+    Path integrationBuild =
+        Paths.get(System.getProperty("project.dir"), "build").toAbsolutePath().normalize();
+    Path stagedClientLibs =
+        Paths.get(System.getProperty("btrace.externalType.client.libs")).toAbsolutePath().normalize();
+    Path stagedExtensions =
+        Paths.get(System.getProperty("btrace.externalType.extensions")).toAbsolutePath().normalize();
+    assertTrue(stagedClientLibs.startsWith(integrationBuild), "staged client libs must be isolated");
+    assertTrue(stagedExtensions.startsWith(integrationBuild), "staged extensions must be isolated");
+    assertTrue(Files.isRegularFile(stagedClientLibs.resolve("btrace.jar")));
+    assertTrue(Files.isDirectory(stagedExtensions.resolve("btrace-ext-test")));
+    Path releaseExtensions =
+        Paths.get(System.getProperty("btrace.libs")).getParent().resolve("extensions");
+    assertFalse(
+        Files.exists(releaseExtensions.resolve("btrace-ext-test")),
+        "test extension must not be staged in the release distribution");
+    targetExtensionPath = stagedExtensions.toString();
+    clientBtraceLibs = stagedClientLibs.toString();
     attachDelayMs = 500;
     testDynamic(
         "resources.Main",

--- a/integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java
+++ b/integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java
@@ -60,10 +60,15 @@ public class ExternalTypeAdapterIntegrationTest extends RuntimeTest {
     Path integrationBuild =
         Paths.get(System.getProperty("project.dir"), "build").toAbsolutePath().normalize();
     Path stagedClientLibs =
-        Paths.get(System.getProperty("btrace.externalType.client.libs")).toAbsolutePath().normalize();
+        Paths.get(System.getProperty("btrace.externalType.client.libs"))
+            .toAbsolutePath()
+            .normalize();
     Path stagedExtensions =
-        Paths.get(System.getProperty("btrace.externalType.extensions")).toAbsolutePath().normalize();
-    assertTrue(stagedClientLibs.startsWith(integrationBuild), "staged client libs must be isolated");
+        Paths.get(System.getProperty("btrace.externalType.extensions"))
+            .toAbsolutePath()
+            .normalize();
+    assertTrue(
+        stagedClientLibs.startsWith(integrationBuild), "staged client libs must be isolated");
     assertTrue(stagedExtensions.startsWith(integrationBuild), "staged extensions must be isolated");
     assertTrue(Files.isRegularFile(stagedClientLibs.resolve("btrace.jar")));
     assertTrue(Files.isDirectory(stagedExtensions.resolve("btrace-ext-test")));

--- a/integration-tests/src/test/java/tests/RuntimeTest.java
+++ b/integration-tests/src/test/java/tests/RuntimeTest.java
@@ -109,6 +109,8 @@ public abstract class RuntimeTest {
   private static final List<String> extraJvmArgs = new ArrayList<>();
 
   protected boolean attachDebugger = false;
+  protected String targetExtensionPath;
+  protected String clientBtraceLibs;
 
   public static void classSetup() {
     if (System.getProperty("btrace.comm.protocol") == null) {
@@ -217,6 +219,8 @@ public abstract class RuntimeTest {
     btracePort = 0;
     startupRetransform = true;
     timeout = defaultTimeoutMs;
+    targetExtensionPath = null;
+    clientBtraceLibs = null;
   }
 
   @SuppressWarnings("DefaultCharset")
@@ -303,7 +307,7 @@ public abstract class RuntimeTest {
     args.add(testApp);
 
     ProcessBuilder pb = new ProcessBuilder(args);
-    pb.environment().remove("JAVA_TOOL_OPTIONS");
+    configureTargetEnvironment(pb);
 
     Process p = pb.start();
     PrintWriter pw = new PrintWriter(p.getOutputStream());
@@ -501,7 +505,7 @@ public abstract class RuntimeTest {
     args.add(testApp);
 
     ProcessBuilder pb = new ProcessBuilder(args);
-    pb.environment().remove("JAVA_TOOL_OPTIONS");
+    configureTargetEnvironment(pb);
 
     Process p = pb.start();
     PrintWriter pw = new PrintWriter(p.getOutputStream());
@@ -713,7 +717,7 @@ public abstract class RuntimeTest {
     args.add(testApp);
 
     ProcessBuilder pb = new ProcessBuilder(args);
-    pb.environment().remove("JAVA_TOOL_OPTIONS");
+    configureTargetEnvironment(pb);
 
     Process p = pb.start();
     PrintWriter pw = new PrintWriter(p.getOutputStream());
@@ -1042,7 +1046,7 @@ public abstract class RuntimeTest {
     args.addAll(Arrays.asList(cmdArgs));
 
     ProcessBuilder pb = new ProcessBuilder(args);
-    pb.environment().remove("JAVA_TOOL_OPTIONS");
+    configureTargetEnvironment(pb);
 
     return new TestApp(pb.start(), debugTestApp);
   }
@@ -1354,6 +1358,7 @@ public abstract class RuntimeTest {
           1,
           Arrays.asList("--add-exports", "jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED"));
     }
+    replaceClientBtraceLibs(argVals);
     ProcessBuilder pb = new ProcessBuilder(argVals);
 
     pb.environment().remove("JAVA_TOOL_OPTIONS");
@@ -1380,6 +1385,26 @@ public abstract class RuntimeTest {
     }
 
     return p;
+  }
+
+  private void configureTargetEnvironment(ProcessBuilder processBuilder) {
+    processBuilder.environment().remove("JAVA_TOOL_OPTIONS");
+    if (targetExtensionPath != null) {
+      processBuilder.environment().put("BTRACE_EXT_PATH", targetExtensionPath);
+    }
+  }
+
+  private void replaceClientBtraceLibs(List<String> arguments) {
+    if (clientBtraceLibs == null) {
+      return;
+    }
+    for (int i = 0; i < arguments.size(); i++) {
+      if (arguments.get(i).startsWith("-Dbtrace.libs=")) {
+        arguments.set(i, "-Dbtrace.libs=" + clientBtraceLibs);
+        return;
+      }
+    }
+    throw new IllegalStateException("Client invocation is missing -Dbtrace.libs");
   }
 
   private Process attachOneliner(

--- a/internal/plans/2026-07-18-issue-889-extensions-pre-release-fixes.md
+++ b/internal/plans/2026-07-18-issue-889-extensions-pre-release-fixes.md
@@ -1,0 +1,174 @@
+# Issue #889: extensions pre-release fixes implementation plan
+
+## Prerequisites and boundaries
+
+- Implement only the four fixes in
+  `internal/specs/2026-07-18-issue-889-extensions-pre-release-fixes.md`; preserve unrelated
+  working-tree changes.
+- Keep `btrace-ext-test` buildable for the ExternalType regression but outside every release
+  distribution. Do not change descriptor forms or package-level descriptor versions.
+- Keep the target-agent and client-compiler paths separate: the target discovers the staged test
+  extension through `BTRACE_EXT_PATH`; the client discovers it through an isolated per-test
+  `-Dbtrace.libs` home.
+
+## Ordered implementation and gates
+
+1. Restrict distribution packaging in `btrace-dist/build.gradle`.
+
+   - Replace the current all-extension-project discovery for `copyExtensions` with the explicit
+     maintained project-path allowlist from the design:
+     `btrace-contracts`, `btrace-gpu-bridge`, `btrace-llm-trace`, `btrace-metrics`,
+     `btrace-rag-quality`, `btrace-statsd`, and `btrace-utils`.
+   - Continue to depend on each allowed project's `packageExtension` and copy its
+     `*-extension.zip`; do not package `btrace-ext-test` or either example project.
+   - Extend `btrace-dist/src/test/java/io/btrace/dist/BTraceJarPackagingTest.java` (or a focused
+     sibling distribution-artifact test) to assert the built `extensions/` ZIP/exploded contents
+     contain exactly the maintained IDs and exclude `btrace-ext-test`, `btrace-hadoop-example`,
+     and `btrace-spark-example`.
+
+   **Gate:** `:btrace-dist:test` proves the release artifact contains no test/example extension;
+   adding future plugin-bearing projects cannot silently make them shippable.
+
+2. Preserve the ExternalType regression with isolated staging.
+
+   - In `integration-tests/build.gradle`, add a staging task dependent on both
+     `:btrace-extensions:btrace-ext-test:packageExtension` and `:btrace-dist:btraceJar`. The
+     staging task must copy the freshly built `btrace.jar` into
+     `integration-tests/build/external-type-client-home/libs/` only after `btraceJar` completes,
+     then expand the test extension into `extensions/btrace-ext-test/` with its API and
+     implementation JAR layout intact. Publish the staged `libs/` and `extensions/` roots as
+     dedicated test system properties; never write, link, or expand the test extension under
+     `btrace-dist/build/**`.
+   - Wire `:integration-tests:test` to depend on this staging task (in addition to its existing
+     distribution dependencies), so every selected `ExternalTypeAdapterIntegrationTest` run sees
+     a fresh isolated client home rather than a stale or missing staged artifact.
+   - Extend `integration-tests/src/test/java/tests/RuntimeTest.java` with resettable, opt-in
+     per-test hooks: one applies `BTRACE_EXT_PATH=<staged home>/extensions` only to target JVM
+     `ProcessBuilder`s; the other replaces the existing `-Dbtrace.libs` argument only for the
+     attach client `ProcessBuilder` with `<staged home>/libs`.
+   - Update `integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java` to
+     configure both hooks from the staging properties, assert the isolated paths are beneath the
+     integration-test build directory, and retain its static/virtual adapter-output assertions.
+     Reset hooks after each test so no later integration test inherits the client-home or target
+     extension path.
+
+   **Gate:** task ordering proves `btraceJar` and the test-extension package exist before the
+   staging copy, and `tests.ExternalTypeAdapterIntegrationTest` passes with the target agent
+   loading via `BTRACE_EXT_PATH` and client compilation scanning the staged sibling `extensions/`;
+   the built release distribution remains free of `btrace-ext-test` before and after the test.
+
+3. Cache StatsD resources by extension lifecycle.
+
+   - Update `btrace-extensions/btrace-statsd/src/main/java/io/btrace/statsd/StatsdImpl.java` to
+     resolve configured host/port and create/cache one `InetAddress` plus `DatagramSocket` during
+     `initialize`; `increment` must only create/send its local packet through those resources.
+   - Make setup failures disable emission without retries or exception escape on a probe thread.
+     Coordinate concurrent sends with `close()`, which releases the cached socket. Preserve the
+     public API, UDP counter/tags format, `NETWORK` permission, and best-effort behavior.
+   - Add the test configuration required by this previously untested module in
+     `btrace-extensions/btrace-statsd/build.gradle`, and add focused UDP/lifecycle coverage under
+     `btrace-extensions/btrace-statsd/src/test/java/io/btrace/statsd/`.
+
+   **Gate:** repeated increments reach a local UDP receiver without per-call endpoint setup;
+   failed setup and close races remain non-throwing and cleanup closes the socket.
+
+4. Correct metric square accumulation.
+
+   - Update `btrace-extensions/btrace-metrics/src/main/java/io/btrace/metrics/stats/StatsMetricImpl.java`
+     to use `DoubleAdder` for sum-of-squares and widen before multiplying.
+   - Extend `btrace-extensions/btrace-metrics/src/test/java/io/btrace/metrics/StatsMetricTest.java`
+     with samples such as `0` and `4_000_000_000L`, whose square exceeds `Long.MAX_VALUE`, and
+     assert a finite, correct, non-zero population standard deviation within floating-point
+     tolerance. Retain ordinary snapshot assertions.
+
+   **Gate:** the regression fails under integral square overflow and passes with the double
+   accumulator, without changing public metric APIs or unrelated sum behavior.
+
+5. Correct generated manifest metadata.
+
+   - Change only the generated `BTrace-API-Version` value in
+     `btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceExtensionPlugin.groovy` from
+     `2.3+` to `3.0+`.
+   - Extend `btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceExtensionPluginTest.java`
+     to open the generated API JAR and assert the manifest attribute is exactly `3.0+`.
+
+   **Gate:** the test validates the artifact manifest rather than the Gradle configuration alone;
+   extension artifact/version naming is unchanged.
+
+6. Inspect the final diff and release artifact.
+
+   - Confirm no descriptor, loader-policy, launcher, attach/protocol, StatsD batching/retry, or
+     public API changes were introduced.
+   - Run `git diff --check`, inspect the built distribution's `extensions/` contents, and confirm
+     the ExternalType staging tree remains only under `integration-tests/build/`.
+
+   **Gate:** the final diff matches every design boundary and no test-only archive is present in
+   `btrace-dist/build`.
+
+## Verification sequence
+
+Run from the repository root with a workspace-local cache. Redirect every Gradle run to the named
+log, use `rg` to filter it, then read the filtered result; do not consume raw Gradle output. If a
+run encounters the documented address-selection failure, rerun that same command with
+`JAVA_TOOL_OPTIONS="-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false"`.
+
+```bash
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-extensions:btrace-metrics:test > /tmp/btrace-issue-889-metrics.log 2>&1
+rg -n "BUILD (SUCCESSFUL|FAILED)|FAILED|ERROR|StatsMetricTest|tests" /tmp/btrace-issue-889-metrics.log
+```
+
+```bash
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-extensions:btrace-statsd:test > /tmp/btrace-issue-889-statsd.log 2>&1
+rg -n "BUILD (SUCCESSFUL|FAILED)|FAILED|ERROR|Statsd.*Test|tests" /tmp/btrace-issue-889-statsd.log
+```
+
+```bash
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew -p btrace-gradle-plugin test > /tmp/btrace-issue-889-plugin.log 2>&1
+rg -n "BUILD (SUCCESSFUL|FAILED)|FAILED|ERROR|BTraceExtensionPluginTest|tests" /tmp/btrace-issue-889-plugin.log
+```
+
+```bash
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-dist:test > /tmp/btrace-issue-889-dist-test.log 2>&1
+rg -n "BUILD (SUCCESSFUL|FAILED)|FAILED|ERROR|BTraceJarPackagingTest|tests" /tmp/btrace-issue-889-dist-test.log
+```
+
+```bash
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-dist:build > /tmp/btrace-issue-889-dist-build.log 2>&1
+rg -n "BUILD (SUCCESSFUL|FAILED)|FAILED|ERROR|copyExtensions|explodeExtensions" /tmp/btrace-issue-889-dist-build.log
+```
+
+```bash
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:test -Pintegration --tests tests.ExternalTypeAdapterIntegrationTest > /tmp/btrace-issue-889-external-type.log 2>&1
+rg -n "BUILD (SUCCESSFUL|FAILED)|FAILED|ERROR|ExternalTypeAdapterIntegrationTest|tests" /tmp/btrace-issue-889-external-type.log
+```
+
+```bash
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-extensions:btrace-metrics:spotlessCheck :btrace-extensions:btrace-statsd:spotlessCheck :btrace-dist:spotlessCheck > /tmp/btrace-issue-889-spotless.log 2>&1
+rg -n "BUILD (SUCCESSFUL|FAILED)|FAILED|ERROR|spotless" /tmp/btrace-issue-889-spotless.log
+```
+
+## Stop conditions
+
+- Stop and return to design review if test-only staging requires copying into the release output,
+  if client compilation cannot be isolated through the temporary `btrace.libs` home, or if target
+  extension discovery needs an unapproved loader-policy change.
+- Stop if StatsD caching requires asynchronous transport, retries, a public API change, or a
+  semantic change to its best-effort failure behavior.
+- Stop if the double accumulator cannot meet the stated metric regression without changing the
+  documented snapshot contract; reconsider the numerical design before widening scope.
+- Stop if a descriptor-format cleanup, legacy annotation version change, or unrelated extension
+  becomes necessary; it is explicitly deferred from #889.
+- Do not commit until all applicable gates and verification steps pass, unless the user explicitly
+  directs otherwise.
+
+## Completion criteria
+
+- The release distribution ships exactly the seven allowlisted extensions and no test/examples.
+- The ExternalType test stages `btrace-ext-test` only below `integration-tests/build`, exposes it
+  to the target with `BTRACE_EXT_PATH`, exposes it to the client through isolated `btrace.libs`,
+  and leaves `btrace-dist/build` untouched.
+- StatsD uses initialized cached endpoint/socket resources and closes them safely; metrics report
+  correct finite stddev for overflow-inducing inputs.
+- Generated API JAR manifests contain `BTrace-API-Version: 3.0+`.
+- All scoped unit, plugin, distribution, focused integration, Spotless, and final diff checks are
+  clean, with no descriptor changes.

--- a/internal/specs/2026-07-18-issue-889-extensions-pre-release-fixes.md
+++ b/internal/specs/2026-07-18-issue-889-extensions-pre-release-fixes.md
@@ -1,0 +1,145 @@
+# Issue #889: extensions pre-release fixes
+
+Date: 2026-07-18  
+Status: implementation contract for [#889](https://github.com/btraceio/btrace/issues/889)
+
+## Scope
+
+Fix four bounded 3.0 pre-release defects:
+
+1. Ship only maintained extensions in the distribution.
+2. Remove DNS lookup and UDP-socket allocation from the StatsD probe path.
+3. Prevent `StatsMetricImpl` standard-deviation corruption from `long` square overflow.
+4. Update generated extension API-JAR metadata from `BTrace-API-Version: 2.3+` to `3.0+`.
+
+## Distribution contract
+
+In `btrace-dist/build.gradle`, replace dynamic packaging of every project that applies
+`io.btrace.extension` with this explicit, ordered project-path allowlist:
+
+- `:btrace-extensions:btrace-contracts`
+- `:btrace-extensions:btrace-gpu-bridge`
+- `:btrace-extensions:btrace-llm-trace`
+- `:btrace-extensions:btrace-metrics`
+- `:btrace-extensions:btrace-rag-quality`
+- `:btrace-extensions:btrace-statsd`
+- `:btrace-extensions:btrace-utils`
+
+`copyExtensions` must depend on and copy packages only for those projects. The built distribution's
+`extensions/` directory must exclude `btrace-ext-test`, `btrace-hadoop-example`, and
+`btrace-spark-example`. A new extension is not release-shipped until it is intentionally added to
+this list.
+
+### ExternalType test-only staging
+
+`ExternalTypeAdapterIntegrationTest` dynamically starts a target JVM and a separate client JVM.
+The agent initializes extension discovery inside the target, while client compilation scans only
+the sibling `extensions/` directory of its `-Dbtrace.libs` directory. Consequently, the test
+extension needs two isolated, process-specific exposures; `BTRACE_EXT_PATH` alone is insufficient
+for client compilation.
+
+Add an `integration-tests/build.gradle` staging task that depends on
+`:btrace-extensions:btrace-ext-test:packageExtension` and builds the temporary client home
+`integration-tests/build/external-type-client-home/`. It must stage a `libs/` directory containing
+the built client artifact needed for the client invocation and expand the test extension ZIP under
+`extensions/btrace-ext-test/`, preserving the API/implementation JAR layout. Expose both the
+client-home `libs/` path and the staged extension root to the test JVM through dedicated test
+system properties. Do not copy, link, or expand the test extension into `btrace-dist/build/**`.
+
+Add a narrowly scoped `RuntimeTest` child-process environment hook, enabled only by
+`ExternalTypeAdapterIntegrationTest`. The test resolves both staging properties and asks the
+harness to put `BTRACE_EXT_PATH=<temporary client home>/extensions` (the parent of
+`btrace-ext-test`) only on the dynamic target JVM's `ProcessBuilder`, so the agent discovers the
+test extension through its environment repository.
+For the separate client `attach` process, the harness must instead replace its existing
+`-Dbtrace.libs=<release libs>` argument with
+`-Dbtrace.libs=<temporary client home>/libs`; that makes `Client.getExtensionApiClasspath()` scan
+the staged sibling `extensions/` directory when compiling the probe. Do not set either override
+globally for every integration test, mutate the parent environment, or give the target JVM the
+client-only `btrace.libs` override. Clear both per-test hooks in `RuntimeTest.reset()` so later
+tests cannot inherit them.
+
+## StatsD contract
+
+Update `btrace-extensions/btrace-statsd/src/main/java/io/btrace/statsd/StatsdImpl.java` to use the
+extension lifecycle. During `initialize`, capture the configured host/port, resolve the host once,
+and create/cache one `DatagramSocket` and destination address. `increment` may build and send its
+local UDP packet, but must not resolve DNS, allocate a socket, or perform endpoint setup.
+
+If initialization cannot configure an endpoint, emission is disabled for that extension instance:
+probe calls remain no-op, best-effort, and non-throwing without repeated DNS retries. `close()`
+must release the cached socket, and send/close must be coordinated for concurrent probe calls.
+The public API, `NETWORK` permission, counter/tags wire format, default port, and synchronous
+best-effort delivery remain unchanged. Changing StatsD settings after initialization is not live
+reconfiguration; detach and reattach to use another endpoint.
+
+## Metrics contract
+
+In `btrace-extensions/btrace-metrics/src/main/java/io/btrace/metrics/stats/StatsMetricImpl.java`,
+replace the `LongAdder` sum-of-squares accumulator with `DoubleAdder` and widen before
+multiplication (`(double) value * value`). Retain count, sum, min/max, reset, snapshot API, and
+the current population-variance calculation. This narrowly fixes square overflow; it does not
+redesign the algorithm or change the separate integral-sum overflow behavior.
+
+## Manifest contract
+
+In `btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceExtensionPlugin.groovy`, generate
+`BTrace-API-Version: 3.0+` for API JAR manifests. Extension artifact/version naming remains driven
+by existing Gradle project and extension metadata; no loader range-parsing change is required.
+
+## Tests and acceptance
+
+- Add distribution-artifact coverage proving all seven allowlisted extensions are present and the
+  test/example IDs are absent from packaged and exploded output.
+- Update `ExternalTypeAdapterIntegrationTest` and `RuntimeTest` coverage to prove the target gets
+  the staged `BTRACE_EXT_PATH`, the client gets the isolated `btrace.libs` home, and the adapter
+  still dispatches its static and virtual calls. Assert the temporary home is beneath
+  `integration-tests/build` and that neither staging nor the test creates `btrace-ext-test` below
+  the built release distribution.
+- Add StatsD unit coverage with a local UDP receiver: repeated increments deliver the expected
+  payload through initialized cached resources, setup failure remains non-fatal, and close releases
+  the socket.
+- Extend `btrace-extensions/btrace-metrics/src/test/java/io/btrace/metrics/StatsMetricTest.java`
+  with overflow-inducing samples such as `0` and `4_000_000_000L`; assert a finite, correct,
+  non-zero population standard deviation.
+- Extend Gradle-plugin manifest coverage to inspect a generated API JAR and assert `3.0+`.
+- `:btrace-dist:build` is the release acceptance artifact: inspect `extensions/` after that build,
+  then run only `tests.ExternalTypeAdapterIntegrationTest` to prove the test-only staging path.
+
+## Verification boundary
+
+Run from the repository root with `GRADLE_USER_HOME=$(pwd)/.gradle-user`; redirect each Gradle run
+to `/tmp/btrace-issue-889-*.log`, filter it with `rg` for task/test failures and `BUILD SUCCESSFUL`,
+then inspect the filtered output. Required checks are:
+
+```text
+:btrace-extensions:btrace-metrics:test
+:btrace-extensions:btrace-statsd:test
+:btrace-dist:test
+:btrace-dist:build
+:integration-tests:test -Pintegration --tests tests.ExternalTypeAdapterIntegrationTest
+:btrace-extensions:btrace-metrics:spotlessCheck
+:btrace-extensions:btrace-statsd:spotlessCheck
+:btrace-dist:spotlessCheck
+```
+
+Run the Gradle-plugin test task from its included-build directory and inspect its generated API-JAR
+manifest test result. If a documented address-selection failure occurs, repeat the same command
+with the repository's IPv4 `JAVA_TOOL_OPTIONS` setting. Do not broaden this issue to an attach,
+protocol, or general extension end-to-end suite beyond the one test-only-staging regression.
+
+## Deferred and non-goals
+
+Do not change user-installed extension discovery, `extensions.conf` allow/deny policy, launchers,
+StatsD batching/retries/asynchronous delivery, or public metric APIs. Descriptor convergence is
+explicitly deferred: DSL-only, DSL plus `@ServiceDescriptor`, and legacy package-level
+`@ExtensionDescriptor` forms (including legacy `version = "1.0"`) need a separate migration and
+compatibility review. Runtime manifest metadata remains authoritative.
+
+## Compatibility and security boundary
+
+Release contents intentionally lose only test/example extensions; maintained extension IDs and
+APIs remain stable. StatsD continues to require `NETWORK` and remains best-effort UDP, but avoids
+unbounded DNS/socket work on instrumented application threads. Metrics change only previously
+incorrect overflow cases. No authentication, trust-policy, attach, protocol, or inbound network
+surface changes.


### PR DESCRIPTION
## Summary

Fixes the four extension pre-release defects from #889:

- The distribution now packages an explicit allow-list of maintained extensions, excluding test and example modules.
- The ExternalType integration path stages `btrace-ext-test` in an isolated test-only client home rather than release output.
- StatsD resolves its endpoint and opens one UDP socket during extension initialization, then closes it on detach.
- Metrics use a double-valued square accumulator so large latency values do not corrupt standard deviation.
- Generated extension API JARs now declare `BTrace-API-Version: 3.0+`.

## Why

Previously every extension subproject was released automatically, StatsD performed blocking DNS and socket allocation for each probe call, and `long` square overflow silently produced incorrect standard deviations.

## Validation

- `:btrace-extensions:btrace-metrics:test :btrace-extensions:btrace-statsd:test`
- `:btrace-dist:test`
- `:btrace-gradle-plugin:test`
- `git diff --check`

The focused ExternalType integration test is included in the change but was not run in this session.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/909)
<!-- Reviewable:end -->
