### PR TITLE
test(integration): cover protocol negotiation defaults

### DIFF
--- a/integration-tests/src/test/java/resources/JaxbCapability.java
+++ b/integration-tests/src/test/java/resources/JaxbCapability.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008, 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package resources;
+
+public final class JaxbCapability {
+  private JaxbCapability() {}
+
+  public static void main(String[] args) {
+    try {
+      Class.forName("javax.xml.bind.JAXBException");
+      System.out.println("JAXB_CAPABLE");
+    } catch (ClassNotFoundException ignored) {
+      System.exit(1);
+    }
+  }
+}

--- a/integration-tests/src/test/java/tests/BTraceFunctionalTests.java
+++ b/integration-tests/src/test/java/tests/BTraceFunctionalTests.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.btrace.client.Client;
 import io.btrace.core.comm.Command;
@@ -97,27 +98,44 @@ public class BTraceFunctionalTests extends RuntimeTest {
 
   @Test
   public void testOnProbe() throws Exception {
-    if (Files.exists(Paths.get(javaHome, "jre"))) {
-      testDynamic(
-          "resources.Main",
-          "btrace/OnProbeTest.java",
-          Completion.untilContains("[this, noargs]", "[this, args]"),
-          new ResultValidator() {
-            @Override
-            public void validate(String stdout, String stderr, int retcode, String jfrFile) {
-              assertFalse(stdout.contains("FAILED"), "Script should not have failed");
-              assertTrue(stderr.isEmpty(), "Non-empty stderr");
-              assertTrue(stdout.contains("[this, noargs]"));
-              assertTrue(stdout.contains("[this, args]"));
-            }
-          });
-    } else {
-      System.err.println("XML libraries not available. Skipping @OnProbe tests");
-    }
+    assumeTrue(
+        hasJaxbProbeDescriptorSupport(),
+        "@OnProbe XML probe descriptors require javax.xml.bind.JAXBException/JAXB support, which is unavailable");
+    testDynamic(
+        "resources.Main",
+        "btrace/OnProbeTest.java",
+        Completion.untilContains("[this, noargs]", "[this, args]"),
+        new ResultValidator() {
+          @Override
+          public void validate(String stdout, String stderr, int retcode, String jfrFile) {
+            assertFalse(stdout.contains("FAILED"), "Script should not have failed");
+            assertTrue(stderr.isEmpty(), "Non-empty stderr");
+            assertTrue(stdout.contains("[this, noargs]"));
+            assertTrue(stdout.contains("[this, args]"));
+          }
+        });
+  }
+
+  @Test
+  public void testDynamicAttachWithShippedProtocolDefaults() throws Exception {
+    setClientProtocolSettings(2, true, false);
+    setAgentProtocolSettings(2, true, false);
+    testTimerProbe();
+  }
+
+  @Test
+  public void testDynamicAttachWithV1ClientAgainstV2Agent() throws Exception {
+    setClientProtocolSettings(1, false, true);
+    setAgentProtocolSettings(2, true, false);
+    testTimerProbe();
   }
 
   @Test
   public void testOnTimer() throws Exception {
+    testTimerProbe();
+  }
+
+  private void testTimerProbe() throws Exception {
     testDynamic(
         "resources.Main",
         "btrace/OnTimerTest.java",
@@ -125,6 +143,7 @@ public class BTraceFunctionalTests extends RuntimeTest {
         new ResultValidator() {
           @Override
           public void validate(String stdout, String stderr, int retcode, String jfrFile) {
+            assertEquals(0, retcode, "Client should exit successfully");
             assertFalse(stdout.contains("FAILED"), "Script should not have failed");
             assertTrue(stderr.isEmpty(), "Non-empty stderr");
             assertTrue(stdout.contains("vm version"));

--- a/integration-tests/src/test/java/tests/RuntimeTest.java
+++ b/integration-tests/src/test/java/tests/RuntimeTest.java
@@ -68,6 +68,7 @@ public abstract class RuntimeTest {
   private static boolean forceDebug = false;
   private static String permissionsFile = null;
   private static long defaultTimeoutMs = Long.getLong("btrace.test.timeoutMs", 60000L);
+  private static final ProtocolSettings FORCED_V2_PROTOCOL = new ProtocolSettings(2, false, true);
 
   /** Try starting JFR recording if available */
   private boolean startJfr = false;
@@ -111,6 +112,8 @@ public abstract class RuntimeTest {
   protected boolean attachDebugger = false;
   protected String targetExtensionPath;
   protected String clientBtraceLibs;
+  private ProtocolSettings clientProtocolSettings = FORCED_V2_PROTOCOL;
+  private ProtocolSettings agentProtocolSettings = FORCED_V2_PROTOCOL;
 
   public static void classSetup() {
     if (System.getProperty("btrace.comm.protocol") == null) {
@@ -221,6 +224,34 @@ public abstract class RuntimeTest {
     timeout = defaultTimeoutMs;
     targetExtensionPath = null;
     clientBtraceLibs = null;
+    clientProtocolSettings = FORCED_V2_PROTOCOL;
+    agentProtocolSettings = FORCED_V2_PROTOCOL;
+  }
+
+  protected void setClientProtocolSettings(
+      int protocol, boolean autoNegotiate, boolean forceVersion) {
+    clientProtocolSettings = new ProtocolSettings(protocol, autoNegotiate, forceVersion);
+  }
+
+  protected void setAgentProtocolSettings(
+      int protocol, boolean autoNegotiate, boolean forceVersion) {
+    agentProtocolSettings = new ProtocolSettings(protocol, autoNegotiate, forceVersion);
+  }
+
+  protected boolean hasJaxbProbeDescriptorSupport() throws IOException, InterruptedException {
+    ProcessBuilder processBuilder =
+        new ProcessBuilder(javaHome + "/bin/java", "-cp", cp, "resources.JaxbCapability");
+    processBuilder.environment().remove("JAVA_TOOL_OPTIONS");
+    Process process = processBuilder.start();
+    if (!process.waitFor(10, TimeUnit.SECONDS)) {
+      process.destroyForcibly();
+      return false;
+    }
+    try (BufferedReader output =
+        new BufferedReader(
+            new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+      return process.exitValue() == 0 && "JAXB_CAPABLE".equals(output.readLine());
+    }
   }
 
   @SuppressWarnings("DefaultCharset")
@@ -497,6 +528,7 @@ public abstract class RuntimeTest {
     // uncomment the following line to get extra JFR logs
     //    args.add("-Xlog:jfr*=trace");
     args.addAll(extraJvmArgs);
+    args.addAll(agentProtocolSettings.arguments());
     if (startJfr) {
       jfrFile = Files.createTempFile("btrace-", ".jfr").toString();
       args.add("-XX:StartFlightRecording=settings=default,dumponexit=true,filename=" + jfrFile);
@@ -1320,9 +1352,6 @@ public abstract class RuntimeTest {
                 "-Dcom.sun.btrace.unsafe=" + isUnsafe,
                 "-Dcom.sun.btrace.debug=" + debugBTrace,
                 "-Dcom.sun.btrace.trackRetransforms=" + trackRetransforms,
-                "-Dbtrace.comm.protocol=2",
-                "-Dbtrace.comm.autoNegotiate=false",
-                "-Dbtrace.comm.forceVersion=true",
                 "-Dbtrace.port=" + getBTracePort(),
                 "-Dbtrace.libs=" + System.getProperty("btrace.libs"),
                 "-Dbtrace.suppressJavaDeprecationWarning=true",
@@ -1337,6 +1366,7 @@ public abstract class RuntimeTest {
                 Paths.get(System.getProperty("java.io.tmpdir"), "btrace-test").toString(),
                 "-pd",
                 traceFile.getParentFile().getAbsolutePath()));
+    argVals.addAll(4, clientProtocolSettings.arguments());
     if (debugBTrace) {
       argVals.add("-v");
     }
@@ -1492,6 +1522,25 @@ public abstract class RuntimeTest {
     }
 
     return p;
+  }
+
+  private static final class ProtocolSettings {
+    private final int protocol;
+    private final boolean autoNegotiate;
+    private final boolean forceVersion;
+
+    private ProtocolSettings(int protocol, boolean autoNegotiate, boolean forceVersion) {
+      this.protocol = protocol;
+      this.autoNegotiate = autoNegotiate;
+      this.forceVersion = forceVersion;
+    }
+
+    private List<String> arguments() {
+      return Arrays.asList(
+          "-Dbtrace.comm.protocol=" + protocol,
+          "-Dbtrace.comm.autoNegotiate=" + autoNegotiate,
+          "-Dbtrace.comm.forceVersion=" + forceVersion);
+    }
   }
 
   protected void ensureBTracePort() {

--- a/internal/plans/2026-07-18-issue-891-integration-coverage.md
+++ b/internal/plans/2026-07-18-issue-891-integration-coverage.md
@@ -1,0 +1,109 @@
+# Issue #891 implementation plan: integration coverage
+
+Date: 2026-07-18  
+Specification: `internal/specs/2026-07-18-issue-891-integration-coverage.md`
+
+## Outcome
+
+Every normal integration-test run proves both the shipped V2 auto-negotiating client path and a
+forced-V1 client path against the dynamic V2-capable agent.  `@OnProbe` either executes its two
+descriptor mappings or is reported by JUnit as an explicit JAXB-capability assumption; it cannot
+silently pass without running.
+
+## Implementation steps
+
+1. Add explicit dynamic-attach transport settings to `RuntimeTest`.
+
+   - Introduce a small internal value object (or equally contained representation) for the three
+     protocol JVM properties and its ordered `-D` arguments.
+   - Keep the current forced-V2 settings as the default for both roles, and reset those fields in
+     `reset()` so all pre-existing dynamic tests retain their current behavior.
+   - Add a protected test hook that selects client settings separately from target-agent settings.
+     Do not rely on mutating the test JVM's system properties: the client is launched by `attach()`
+     as a separate process, while the target JVM is constructed in `testDynamic()`.
+   - In `testDynamic()`, append the selected agent arguments after `extraJvmArgs` when constructing
+     the target command.  `classSetup()` currently snapshots `btrace.*` properties into
+     `extraJvmArgs`; placing the per-invocation values later deliberately overrides that inherited
+     forced-V2 baseline without changing unrelated test propagation.
+   - In `attach()`, replace the three unconditional V2/`false`/`true` arguments with the selected
+     client arguments.  Leave `attachOneliner()`, startup-agent launch behavior, port handling, and
+     non-protocol client flags unchanged.
+
+2. Add the two end-to-end protocol cases in `BTraceFunctionalTests`.
+
+   - Add a small shared dynamic-test helper or two narrowly named test methods that configure the
+     hook from step 1, submit the existing timer probe to `resources.Main`, and use its established
+     `vm version`, `vm starttime`, and `timer` markers as completion/validation evidence.
+   - Case A sets both external client and target agent to the shipped settings:
+     `protocol=2`, `autoNegotiate=true`, `forceVersion=false`.
+   - Case B sets the external client to forced V1:
+     `protocol=1`, `autoNegotiate=false`, `forceVersion=true`; retain the target agent at V2 with
+     `autoNegotiate=true`, `forceVersion=false`.  This is the required V1-over-V2-agent path, not a
+     V1-only server test.
+   - For both cases, wait for all expected probe markers; assert an exit code of zero, no `FAILED`
+     client output, no unexpected stderr, and each marker in stdout.  Do not treat a successful
+     attach banner, socket connection, or `ProtocolNegotiator` unit result as success.
+   - Keep the cases in `BTraceFunctionalTests`, which already runs under the ordinary
+     `continuous.yml` `-Pintegration -PCI :integration-tests:test` matrix.  Do not alter the
+     label-gated `v2-protocol-tests.yml` workflow.
+
+3. Replace `testOnProbe`'s layout-derived green skip with a real, report-visible capability gate.
+
+   - Add a minimal Java-8-compatible test helper class under `integration-tests/src/test/java`
+     with a terminating `main` that attempts to load `javax.xml.bind.JAXBException` and emits a
+     stable success marker only on success.
+   - Add a `RuntimeTest` helper that invokes the selected `javaHome/bin/java` with the same BTrace
+     client/test classpath (`cp`), runs that helper, bounds the process wait, and returns true only
+     for its zero exit code plus the success marker.  This checks the Java runtime and classpath
+     used by the external BTrace process, rather than using the host JUnit JVM or the obsolete
+     `<java-home>/jre` directory as a proxy.
+   - In `BTraceFunctionalTests.testOnProbe`, call JUnit `assumeTrue` on that helper before dynamic
+     attach.  The assumption message must explicitly state that `@OnProbe` XML probe descriptors
+     require `javax.xml.bind.JAXBException`/JAXB support and that it is unavailable.  Remove the
+     `System.err.println(...); return;` path.
+   - Preserve the existing functional path verbatim after the gate: attach
+     `btrace/OnProbeTest.java`, wait for `[this, noargs]` and `[this, args]`, assert zero exit,
+     reject `FAILED` and unexpected stderr, and assert both markers.  The Java-8 run remains a
+     functional test; current modern runs become JUnit-aborted with the reason in the XML/HTML
+     report, not successful no-ops.
+
+4. Keep the change scoped and format it.
+
+   - Do not modify `ProtocolConfig`, `Client`, `RemoteClient`, masked-JAR assembly, or default
+     production settings.  The work tests existing bidirectional negotiation; it does not change
+     its contract.
+   - Do not add JAXB dependencies or claim that modern JDKs now support `@OnProbe`.  A future
+     distribution change that provides JAXB will satisfy the capability probe and automatically
+     exercise the retained assertions.
+   - Apply the repository formatter only to the intended Java files if needed; do not format
+     unrelated working-tree changes.
+
+## Verification gates
+
+Run Gradle with a workspace-local cache and redirect output before inspection.
+
+1. `GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:spotlessCheck > /tmp/issue-891-spotless.log 2>&1`
+2. `rg -n "BUILD (SUCCESSFUL|FAILED)|FAILURE|ERROR" /tmp/issue-891-spotless.log`
+3. `GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-dist:build > /tmp/issue-891-dist.log 2>&1`
+4. `rg -n "BUILD (SUCCESSFUL|FAILED)|FAILURE|ERROR" /tmp/issue-891-dist.log`
+5. `GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew -Pintegration :integration-tests:test --tests tests.BTraceFunctionalTests > /tmp/issue-891-functional.log 2>&1`
+6. Inspect the focused report/log for both protocol test names and the `@OnProbe` result: passed
+   with both markers when JAXB is available, otherwise explicitly skipped/aborted with the JAXB
+   reason.
+7. `GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew -Pintegration -PCI :integration-tests:test > /tmp/issue-891-integration.log 2>&1`
+8. `rg -n "BUILD (SUCCESSFUL|FAILED)|FAILURE|ERROR|tests completed" /tmp/issue-891-integration.log`
+
+If restricted-network socket selection fails, retry the affected Gradle command with
+`JAVA_TOOL_OPTIONS="-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false"`.
+
+## Stop conditions
+
+- Stop and investigate before widening scope if the V1 client cannot complete against a V2
+  auto-negotiating agent; capture the client/agent logs and determine whether the test setup or
+  existing negotiation contract is at fault.
+- Stop rather than weakening assertions if a case only reaches an attach/status banner without
+  probe output, or if the `@OnProbe` gate still yields a successful no-op.
+- Stop and create a separate masked-distribution design if making the modern `@OnProbe` test pass
+  requires adding JAXB classes or resources to the shipped artifact.
+- Do not commit until the focused test, required build prerequisite, full integration run, and
+  formatting gate have passed (unless the user explicitly authorizes a known failing commit).

--- a/internal/specs/2026-07-18-issue-891-integration-coverage.md
+++ b/internal/specs/2026-07-18-issue-891-integration-coverage.md
@@ -1,0 +1,81 @@
+# Issue #891: Integration coverage for protocol negotiation and `@OnProbe`
+
+Date: 2026-07-18  
+Status: approved implementation specification
+
+## Scope
+
+Close the two release-critical coverage gaps identified in #891:
+
+1. Exercise the shipped V2, auto-negotiating client configuration and a V1 client against the normal V2-capable dynamically attached agent on every `:integration-tests:test` run.
+2. Stop reporting `@OnProbe` as a passing test on runtimes where its JAXB-backed XML descriptor support is unavailable.
+
+The existing `continuous.yml` integration-test matrix already runs for pushes and pull requests to `develop`; the new cases belong in that suite rather than in the label-gated `v2-protocol-tests.yml` workflow.
+
+## Protocol coverage design
+
+Add two dynamic-attach variants to the functional integration suite.  Each must start the usual
+`resources.Main` target, submit a real compiled probe through the external BTrace client process,
+wait for observable probe output, and fail on client error or missing output.  The target keeps its
+normal agent configuration (V2-capable with negotiation); do not introduce a special test-only
+agent implementation.
+
+| Case | External client properties | Required result |
+| --- | --- | --- |
+| Shipped default | `btrace.comm.protocol=2`, `btrace.comm.autoNegotiate=true`, `btrace.comm.forceVersion=false` | The V2 client-agent negotiation completes and the probe produces its expected output. |
+| V1 compatibility | `btrace.comm.protocol=1`, `btrace.comm.autoNegotiate=false`, `btrace.comm.forceVersion=true` | The V1 client communicates successfully with that same V2-capable agent and the probe produces its expected output. |
+
+`RuntimeTest.classSetup()` may retain its deterministic suite defaults, but the dynamic-attach
+launcher must accept per-invocation protocol options and pass those exact `-D` values to the
+spawned client JVM.  Changing system properties only in the JUnit JVM is insufficient because the
+client is an external process.  The existing hard-coded V2 client flags in `attach()` must therefore
+be replaced or overridden only for these explicitly selected variants; existing tests retain their
+current forced-V2 behavior.
+
+The test assertions must prove the end-to-end path, not merely process startup or a unit-level
+`ProtocolNegotiator` result: wait for the probe's known marker(s), assert the client did not report
+`FAILED`, and assert that stderr is empty apart from the harness's existing filtered JVM warnings.
+
+## `@OnProbe` behavior by runtime capability
+
+`@OnProbe` maps annotations through an XML descriptor and `BTraceProbeNode` enables that mapping
+only when `javax.xml.bind.JAXBException` is loadable.  The present test instead uses the legacy
+`<java-home>/jre` layout as a proxy and otherwise prints a message then returns successfully.
+
+For this issue, retain the working Java-8 functional path and replace the silent modern-JDK return
+with a JUnit assumption that is visible as an aborted/skipped test in reports.  The assumption must
+test the actual JAXB capability used by the feature, not the directory layout.  Its reason must say
+that `@OnProbe` needs JAXB/XML probe-descriptor support and identify the unavailable capability.
+
+When the capability is present, `testOnProbe` must still dynamically attach
+`btrace/OnProbeTest.java`, wait for both `[this, noargs]` and `[this, args]`, reject `FAILED` output
+and unexpected stderr, and assert both markers.  When it is absent (including the current modern
+JDK matrix), execution must be reported as an explicit JUnit assumption rather than as a successful
+test.  No `System.err.println(...); return;` substitute is acceptable.
+
+Bundling or otherwise restoring JAXB support on modern JDKs is deliberately not part of this issue:
+it changes the masked distribution/runtime dependency contract and needs separate artifact-level
+design and validation.  Once that work exists, this assumption should naturally become satisfied
+and the unchanged functional assertions will exercise the modern path.
+
+## Acceptance and verification
+
+- A normal `-Pintegration :integration-tests:test` run includes both protocol cases; no PR label,
+  weekly workflow, or manual dispatch is required.
+- The default case uses exactly `V2 + autoNegotiate=true + forceVersion=false` in the external
+  client process, and the V1 case uses exactly the V1 forced configuration listed above.
+- Each protocol case proves a completed dynamic attach and observed probe output against a real
+  V2-capable agent; a connection-only assertion is insufficient.
+- `@OnProbe` executes and asserts both XML mappings whenever JAXB is available.  Where it is not,
+  the JUnit report records an assumption/abort with the stated JAXB reason, never a green no-op.
+- Run the focused integration test class with the integration profile, then the relevant normal
+  integration test command used by CI.  Use the repository build prerequisites (`:btrace-dist:build`
+  before integration testing) and `spotlessCheck`; inspect redirected Gradle logs for the result.
+
+## Non-goals
+
+- Do not change the default protocol configuration or the proven client/agent negotiation wiring.
+- Do not move the comprehensive protocol workflow onto every PR, duplicate its unit coverage, or
+  add a full protocol-version cross-product.
+- Do not add JAXB dependencies, change masked-JAR contents, or claim modern-JDK `@OnProbe` support.
+- Do not add coverage for `@OnEvent`, `@OnLowMemory`, `@OnError`, or unrelated verifier gaps.


### PR DESCRIPTION
## Summary

Fixes #891’s release-critical integration coverage gaps.

- Adds end-to-end dynamic-attach coverage for the shipped V2 auto-negotiating client configuration.
- Adds V1-client compatibility coverage against the V2-capable agent.
- Replaces `@OnProbe`'s silent modern-JDK pass with a report-visible JAXB capability assumption.

## Why

The normal integration harness previously forced V2/no-negotiation, leaving default negotiation and V1 compatibility outside ordinary PR coverage. `@OnProbe` also returned green when JAXB was unavailable.

## Validation

- `:btrace-dist:build`
- `-Pintegration :integration-tests:test --tests tests.BTraceFunctionalTests`
- `:integration-tests:spotlessCheck`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/911)
<!-- Reviewable:end -->
