### PR TITLE
fix(gradle-plugin): withdraw unpublished Maven coordinates (#884)

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -103,6 +103,9 @@ jobs:
         java: [ 8.0.492-tem, 11.0.31-tem, 17.0.19-tem, 21.0.11-tem, 25.0.3-tem, 27.ea.31-open ]
     env:
       TEST_JAVA_HOME: "/home/runner/.sdkman/candidates/java/${{ matrix.java }}"
+      # Runners are ephemeral, so the Testcontainers Ryuk reaper is unnecessary. Disabling it
+      # removes a Docker Hub image pull that intermittently times out and fails Docker-based tests.
+      TESTCONTAINERS_RYUK_DISABLED: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -624,7 +624,7 @@ jobs:
           echo "Verified Plugin Portal IDs io.btrace.extension and io.btrace.fat-agent at ${{ inputs.release_version }}"
 
   # ============================================================
-  # Job 5c: Update JBang catalog
+  # Job 5d: Update JBang catalog
   # ============================================================
   update-jbang-catalog:
     name: Update JBang Catalog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -567,6 +567,63 @@ jobs:
           exit 1
 
   # ============================================================
+  # Job 5c: Publish Gradle plugins to the Gradle Plugin Portal
+  # ============================================================
+  publish-gradle-plugins:
+    name: Publish Gradle Plugins
+    needs: [prepare-release, wait-for-maven]
+    runs-on: ubuntu-latest
+    if: ${{ inputs.dry_run != true }}
+    steps:
+      - name: Checkout RC tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.RC_TAG }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+
+      - name: Validate Plugin Portal publications
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+        run: |
+          ./gradlew -p btrace-gradle-plugin -PbtraceVersion=${{ inputs.release_version }} \
+            publishPlugins --validate-only --no-daemon
+
+      - name: Publish Plugin Portal artifacts
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+        run: |
+          ./gradlew -p btrace-gradle-plugin -PbtraceVersion=${{ inputs.release_version }} \
+            publishPlugins --no-daemon
+
+      - name: Verify Plugin Portal availability
+        run: |
+          mkdir -p plugin-portal-smoke
+          cat > plugin-portal-smoke/settings.gradle <<'EOF'
+          pluginManagement {
+            repositories { gradlePluginPortal() }
+          }
+          rootProject.name = 'btrace-plugin-portal-smoke'
+          EOF
+          cat > plugin-portal-smoke/build.gradle <<EOF
+          plugins {
+            id 'io.btrace.extension' version '${{ inputs.release_version }}'
+            id 'io.btrace.fat-agent' version '${{ inputs.release_version }}'
+          }
+          EOF
+          ./gradlew -p plugin-portal-smoke tasks --no-daemon
+          echo "Verified Plugin Portal IDs io.btrace.extension and io.btrace.fat-agent at ${{ inputs.release_version }}"
+
+  # ============================================================
   # Job 5c: Update JBang catalog
   # ============================================================
   update-jbang-catalog:
@@ -734,7 +791,7 @@ jobs:
   # ============================================================
   release-smoke:
     name: Release Acquisition and First Trace
-    needs: [prepare-release, wait-for-maven, update-jbang-catalog, build-distributions]
+    needs: [prepare-release, wait-for-maven, publish-gradle-plugins, update-jbang-catalog, build-distributions]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     if: ${{ inputs.dry_run != true }}
@@ -1110,7 +1167,7 @@ jobs:
   # ============================================================
   summary:
     name: Release Summary
-    needs: [validate, build-and-test, integration-tests, prepare-release, stage-maven, wait-for-maven, update-jbang-catalog, build-distributions, release-smoke, finalize-tag, create-github-release, update-sdkman, update-milestones]
+    needs: [validate, build-and-test, integration-tests, prepare-release, stage-maven, wait-for-maven, publish-gradle-plugins, update-jbang-catalog, build-distributions, release-smoke, finalize-tag, create-github-release, update-sdkman, update-milestones]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -1164,6 +1221,7 @@ jobs:
           echo "| Prepare Release | ${{ needs.prepare-release.result || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Stage Maven | ${{ needs.stage-maven.result || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Wait for Maven | ${{ needs.wait-for-maven.result || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Publish Gradle Plugins | ${{ needs.publish-gradle-plugins.result || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Build Distributions | ${{ needs.build-distributions.result || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Release Smoke | ${{ needs.release-smoke.result || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Finalize Tag | ${{ needs.finalize-tag.result || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,6 +275,9 @@ jobs:
         java: [8.0.492-tem, 11.0.31-tem, 17.0.19-tem, 21.0.11-tem, 25.0.3-tem, 27.ea.31-open]
     env:
       TEST_JAVA_HOME: "/home/runner/.sdkman/candidates/java/${{ matrix.java }}"
+      # Runners are ephemeral, so the Testcontainers Ryuk reaper is unnecessary. Disabling it
+      # removes a Docker Hub image pull that intermittently times out and fails Docker-based tests.
+      TESTCONTAINERS_RYUK_DISABLED: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Use [JBang](https://www.jbang.dev/) to run BTrace without manual installation:
 curl -Ls https://sh.jbang.dev | bash -s - app setup
 
 # Use BTrace immediately (replace <version> with desired version, e.g., 3.0.0)
-jbang io.btrace:btrace-client:<version> <PID> <script.java>
+jbang io.btrace:btrace:<version> <PID> <script.java>
 
 # After first run, use shorter alias
 jbang btrace <PID> <script.java>
@@ -265,7 +265,8 @@ plugins {
 
 btraceFatAgent {
     embedExtensions {
-        maven('io.btrace:btrace-metrics:3.0.0')
+        // BTrace bundles extension packages in its distribution's extensions/ directory.
+        file('/path/to/btrace-metrics-3.0.0-extension.zip')
         project(':my-custom-extension')
     }
 }
@@ -330,7 +331,9 @@ See the [Tutorial](docs/BTraceTutorial.md) for detailed documentation.
 Extensions CLI: use `btracex` to inspect and manage extensions and the simplified permission policy:
 - `btracex inspect <zip|dir>` prints extension id, version, services, and whether it’s privileged.
 - `btracex policy print|set [--policy-file <path>|--home|--classpath <outDir>]` edits `allowExtensions`, `denyExtensions`, `allowPrivileged`.
-- `btracex list` shows installed extensions; `btracex install` installs from Maven coordinates.
+- `btracex list` shows installed extensions; `btracex install` accepts a local extension package or
+  separately published third-party Maven coordinates. BTrace-built packages are supplied in the
+  distribution's `extensions/` directory, not as individual Maven artifacts.
 
 Note: Extension “required permissions” are informational and help operators assess risk. Implementation linking is controlled by per‑extension allow/deny lists and the `allowPrivileged` flag; when blocked, APIs remain available and SHIMs are used so probes continue safely.
 

--- a/btrace-gradle-plugin/README.md
+++ b/btrace-gradle-plugin/README.md
@@ -99,7 +99,7 @@ Build self-contained fat agent JARs with embedded extensions for single-JAR depl
 ### Features
 - Embeds extensions directly into the agent JAR
 - Auto-discovers extension projects in multi-project builds
-- Supports project references, Maven coordinates, and local files
+- Supports project references, separately published third-party Maven coordinates, and local files
 - API classes as `.class` files (bootstrap), impl as `.classdata` (runtime loaded)
 - Integrates with ShadowJar for package relocation
 
@@ -125,9 +125,9 @@ btraceFatAgent {
         project(':btrace-spark')
         projects(':btrace-metrics', ':btrace-utils')
 
-        // Maven coordinates
-        maven('io.btrace:btrace-kafka-extension:3.0.0')
-        maven(group: 'io.btrace', name: 'btrace-flink-extension', version: '3.0.0')
+        // BTrace-built packages from the distribution's extensions/ directory
+        file('/path/to/btrace-kafka-extension-3.0.0-extension.zip')
+        file('/path/to/btrace-flink-extension-3.0.0-extension.zip')
 
         // Local extension ZIPs or directories
         file('/path/to/extension.zip')
@@ -236,8 +236,8 @@ btraceFatAgent {
     agentJarTask = 'btraceJar'
 
     embedExtensions {
-        maven('io.btrace:btrace-metrics:3.0.0')
-        maven('io.btrace:btrace-statsd:3.0.0')
+        file('/path/to/btrace-metrics-3.0.0-extension.zip')
+        file('/path/to/btrace-statsd-3.0.0-extension.zip')
         file('libs/my-custom-extension.zip')
     }
 }
@@ -324,7 +324,9 @@ jar -tf btrace-dist/build/resources/main/v*/libs/btrace-agent-fat.jar | grep btr
 
 ### Fat Agent Plugin
 - Use auto-discovery for monorepo setups
-- Use Maven coordinates for external/published extensions
+- Use Maven coordinates only for separately published third-party extensions. BTrace-built
+  extensions are packages in the BTrace distribution's `extensions/` directory and should be
+  embedded with `file(...)`.
 - Test the fat agent in isolation before production deployment
 - Package relocations help avoid classpath conflicts in target JVMs
 

--- a/btrace-gradle-plugin/build.gradle
+++ b/btrace-gradle-plugin/build.gradle
@@ -1,7 +1,11 @@
+import org.gradle.api.tasks.bundling.Jar
+
 plugins {
     id 'groovy'
     id 'java-gradle-plugin'
     id 'maven-publish'
+    id 'signing'
+    id 'com.gradle.plugin-publish' version '2.0.0'
 }
 
 java {
@@ -11,7 +15,8 @@ java {
 }
 
 group = project.findProperty('GROUP') ?: (rootProject.group ?: 'io.btrace')
-version = rootProject.version
+def requestedBTraceVersion = providers.gradleProperty('btraceVersion').orNull
+version = requestedBTraceVersion ?: '0.0.0-local'
 
 repositories {
     gradlePluginPortal()
@@ -45,6 +50,8 @@ test {
 }
 
 gradlePlugin {
+    website = 'https://github.com/btraceio/btrace'
+    vcsUrl = 'https://github.com/btraceio/btrace.git'
     plugins {
         btraceExtension {
             id = 'io.btrace.extension'
@@ -61,7 +68,47 @@ gradlePlugin {
     }
 }
 
+tasks.named('jar', Jar) {
+    manifest {
+        attributes('Implementation-Version': project.version)
+    }
+}
+
+def validatePublicationVersion = {
+    if (requestedBTraceVersion == null ||
+            !(requestedBTraceVersion ==~ /[0-9]+\.[0-9]+\.[0-9]+/)) {
+        throw new GradleException(
+                'Publishing BTrace Gradle plugins requires -PbtraceVersion=<concrete X.Y.Z release version>.')
+    }
+}
+
+def signingKey = System.getenv('GPG_SIGNING_KEY')
+def signingPassword = System.getenv('GPG_SIGNING_PWD')
+if (signingKey != null && !signingKey.trim().isEmpty()) {
+    signing {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign publishing.publications
+    }
+} else {
+    tasks.matching { it.name.startsWith('sign') }.configureEach {
+        onlyIf { false }
+    }
+}
+
+tasks.matching { it.name.startsWith('publish') }.configureEach {
+    doFirst(validatePublicationVersion)
+}
+
 publishing {
+    def publicationRepository = providers.gradleProperty('publicationRepository').orNull
+    if (publicationRepository != null) {
+        repositories {
+            maven {
+                name = 'external'
+                url = uri(publicationRepository)
+            }
+        }
+    }
     publications {
         // java-gradle-plugin will add pluginMaven and marker publications automatically.
         // This block allows publishing to local/remote Maven repositories.

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceExtensionPlugin.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceExtensionPlugin.groovy
@@ -156,13 +156,16 @@ class BTraceExtensionPlugin implements Plugin<Project> {
 
         // Auto-register @ExternalType annotation processor on the main source set.
         // In-tree builds reference the sibling subproject directly; external consumers resolve
-        // the published artifact by version.
+        // the single public BTrace distribution at the explicitly configured BTrace version.
         def processorProject = project.rootProject.findProject(':btrace-core')
         if (processorProject != null) {
             project.dependencies.add('annotationProcessor', processorProject)
         } else {
-            project.dependencies.add('annotationProcessor',
-                "io.btrace:btrace-core:${project.version}")
+            project.afterEvaluate {
+                String btraceVersion = BTraceVersion.resolve(
+                    project, extension.btraceVersion, BTraceExtensionPlugin, 'btraceExtension.btraceVersion')
+                project.dependencies.add('annotationProcessor', "io.btrace:btrace:${btraceVersion}")
+            }
         }
 
         // Configure duplicate handling for resource tasks
@@ -1382,6 +1385,8 @@ class BTraceExtensionMetadata {
     String version
     String name
     String description
+    /** Version of the public io.btrace:btrace distribution used by external builds. */
+    String btraceVersion
     List<String> services = []
     List<String> additionalExports = []
     List<String> excludedExports = []

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentExtension.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentExtension.groovy
@@ -17,7 +17,7 @@ import org.gradle.api.file.FileCollection
  *
  *     embedExtensions {
  *         project(':btrace-spark')
- *         maven('io.btrace:btrace-kafka:2.3.0')
+ *         file('/path/to/btrace-kafka-extension.zip')
  *         file('/path/to/extension.zip')
  *     }
  *
@@ -35,6 +35,9 @@ class BTraceFatAgentExtension {
     /** Output JAR base name (default: 'btrace-agent-fat') */
     String baseName = 'btrace-agent-fat'
 
+    /** Version of the public io.btrace:btrace distribution used to compile source probes. */
+    String btraceVersion
+
     /** Output directory (default: project.layout.buildDirectory.dir('libs')) */
     File outputDir
 
@@ -47,7 +50,10 @@ class BTraceFatAgentExtension {
     /** Reference to the task producing the masked BTrace JAR (normally btraceJar). */
     Object agentJarTask
 
-    /** Legacy reference to a separate boot JAR task. Prefer a single masked btraceJar. */
+    /**
+     * Legacy reference to a separate boot JAR task. This is unsupported because a fat agent must
+     * be assembled from one masked BTrace engine; use {@link #agentJarTask} or btraceEngine.
+     */
     Object bootJarTask
 
     /** Whether to auto-discover extensions from subprojects (default: false) */

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy
@@ -9,6 +9,7 @@ import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.file.DuplicatesStrategy
 import javax.lang.model.SourceVersion
 import java.util.jar.JarFile
+import java.util.jar.Manifest
 
 /**
  * Gradle plugin for building fat agent JARs with embedded extensions.
@@ -26,7 +27,7 @@ import java.util.jar.JarFile
  * btraceFatAgent {
  *     embedExtensions {
  *         project(':btrace-spark')
- *         maven('io.btrace:btrace-kafka:2.3.0')
+ *         file('/path/to/btrace-kafka-extension.zip')
  *     }
  * }
  * </pre>
@@ -50,8 +51,43 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
         // Create DSL extension
         def extension = project.extensions.create('btraceFatAgent', BTraceFatAgentExtension, project)
 
+        // External consumers use this single, pinned masked distribution. It deliberately has no
+        // relationship to the extension author's project version or to withdrawn module artifacts.
+        def btraceEngine = project.configurations.maybeCreate('btraceEngine')
+        btraceEngine.canBeConsumed = false
+        btraceEngine.canBeResolved = true
+        btraceEngine.defaultDependencies { dependencies ->
+            String btraceVersion = BTraceVersion.resolve(
+                project,
+                extension.btraceVersion,
+                BTraceFatAgentPlugin,
+                'btraceFatAgent.btraceVersion')
+            dependencies.add(project.dependencies.create("io.btrace:btrace:${btraceVersion}"))
+        }
+
         // Create staging directory
         def stagingDir = project.layout.buildDirectory.dir('fat-agent-staging').get().asFile
+        def engineStagingDir = project.layout.buildDirectory.dir('btrace-engine-staging').get().asFile
+
+        def stageBTraceEngine = project.tasks.register('stageBTraceEngine') {
+            group = 'BTrace Fat Agent'
+            description = 'Resolves and stages the masked BTrace engine for an external fat agent'
+            inputs.files(project.provider { btraceEngine.singleFile })
+                .withPropertyName('btraceEngine')
+                .withPathSensitivity(PathSensitivity.RELATIVE)
+            outputs.dir(engineStagingDir)
+            doLast {
+                File engineJar = btraceEngine.singleFile
+                validateMaskedEngine(engineJar)
+                project.delete(engineStagingDir)
+                project.copy {
+                    from project.zipTree(engineJar)
+                    into engineStagingDir
+                    exclude 'META-INF/MANIFEST.MF'
+                }
+                project.logger.lifecycle("[fat-agent] Staged masked BTrace engine: ${engineJar}")
+            }
+        }
 
         // Task: Resolve and stage extensions
         def stageExtensions = project.tasks.register('stageExtensions') {
@@ -206,19 +242,10 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
                 exclude 'embedded-extensions.txt'
             }
 
-            // Configure manifest
+            // The source engine manifest is installed lazily in the external path below. This task
+            // then changes only the fat-agent-specific Boot-Class-Path and embedded-extension data.
             manifest {
-                attributes(
-                    'Premain-Class': 'io.btrace.boot.Loader',
-                    'Agent-Class': 'io.btrace.boot.Loader',
-                    'Main-Class': 'io.btrace.boot.Loader',
-                    'Can-Redefine-Classes': 'true',
-                    'Can-Retransform-Classes': 'true',
-                    'Boot-Class-Path': "${extension.baseName}.jar",
-                    'BTrace-Version': project.version,
-                    'BTrace-Agent-Main': 'io.btrace.agent.Main',
-                    'BTrace-Client-Main': 'io.btrace.client.Main'
-                )
+                attributes('Boot-Class-Path': "${extension.baseName}.jar")
             }
 
             doFirst {
@@ -248,17 +275,26 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
                 discoverExtensions(project, extension)
             }
 
-            // Include base agent/boot JARs if specified
+            // An in-tree producer remains supported when it produces the same masked engine
+            // contract as btrace-dist:btraceJar.
             if (extension.agentJarTask != null) {
                 def agentTask = project.tasks.named(extension.agentJarTask.toString()).get()
                 fatAgentTask.dependsOn(agentTask)
                 fatAgentTask.from(project.zipTree(agentTask.archiveFile))
+                fatAgentTask.doFirst {
+                    seedManifestFromEngine(fatAgentTask, agentTask.archiveFile.get().asFile)
+                }
+            } else {
+                fatAgentTask.dependsOn(stageBTraceEngine)
+                fatAgentTask.from(engineStagingDir)
+                fatAgentTask.doFirst {
+                    seedManifestFromEngine(fatAgentTask, btraceEngine.singleFile)
+                }
             }
 
             if (extension.bootJarTask != null) {
-                def bootTask = project.tasks.named(extension.bootJarTask.toString()).get()
-                fatAgentTask.dependsOn(bootTask)
-                fatAgentTask.from(project.zipTree(bootTask.archiveFile))
+                throw new GradleException(
+                    '[fat-agent] bootJarTask is unsupported. Supply one masked agentJarTask or configure btraceFatAgent.btraceVersion.')
             }
 
             // Wire extension project dependencies
@@ -335,6 +371,34 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
         }
     }
 
+    private static void validateMaskedEngine(File engineJar) {
+        new JarFile(engineJar).withCloseable { jar ->
+            def attributes = jar.manifest?.mainAttributes
+            if (attributes == null) {
+                throw invalidFatAgent(engineJar, 'missing META-INF/MANIFEST.MF')
+            }
+            requireJarEntry(jar, engineJar, LOADER_ENTRY)
+            requireJarEntry(jar, engineJar, MASKED_AGENT_MAIN_ENTRY)
+            requireManifestAttribute(attributes, engineJar, 'Premain-Class', LOADER_CLASS)
+            requireManifestAttribute(attributes, engineJar, 'Agent-Class', LOADER_CLASS)
+            requireManifestAttribute(attributes, engineJar, 'Main-Class', LOADER_CLASS)
+            requireManifestAttribute(attributes, engineJar, 'BTrace-Agent-Main', AGENT_MAIN_CLASS)
+        }
+    }
+
+    private static void seedManifestFromEngine(def fatAgentTask, File engineJar) {
+        validateMaskedEngine(engineJar)
+        new JarFile(engineJar).withCloseable { jar ->
+            Manifest manifest = jar.manifest
+            manifest.mainAttributes.each { key, value ->
+                fatAgentTask.manifest.attributes([(key.toString()): value.toString()])
+            }
+        }
+        // A fat agent is self-contained, so this is the one source-manifest attribute adjusted.
+        fatAgentTask.manifest.attributes(
+            ['Boot-Class-Path': fatAgentTask.archiveFile.get().asFile.name])
+    }
+
     private static void requireJarEntry(JarFile jar, File fatJar, String entry) {
         if (jar.getJarEntry(entry) == null) {
             throw invalidFatAgent(fatJar, "missing ${entry}")
@@ -353,7 +417,7 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
     private static GradleException invalidFatAgent(File fatJar, String problem) {
         return new GradleException(
             "[fat-agent] Invalid masked BTrace fat JAR ${fatJar}: ${problem}. " +
-                "Configure agentJarTask to reference the btraceJar task.")
+                "Configure agentJarTask to reference the btraceJar task or set btraceFatAgent.btraceVersion for an external build.")
     }
 
     /**
@@ -456,10 +520,12 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
 
             project.logger.info("[fat-agent] Compiling probes from: ${sourceDir}")
 
-            // Use Gradle's JavaExec to run btracec
+            // The public BTrace artifact is a masked distribution. Run its loader and select the
+            // compiler client entry point rather than assuming a conventional btrace-client JAR.
             project.javaexec {
                 classpath = project.files(compilerJar)
-                mainClass = 'io.btrace.compiler.Compiler'
+                mainClass = LOADER_CLASS
+                jvmArgs '-Dbtrace.client.main=io.btrace.compiler.Compiler'
                 args = ['-d', outputDir.absolutePath]
 
                 // Add all .java files
@@ -473,15 +539,15 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
     }
 
     /**
-     * Find btrace-compiler JAR in project dependencies.
+     * Find the public BTrace distribution used to launch the compiler.
      */
     private File findBTraceCompiler(Project project) {
         // Try to find from btrace-dist or similar project
         def distProject = project.rootProject.subprojects.find { it.name == 'btrace-dist' }
         if (distProject != null) {
-            def clientJar = distProject.tasks.findByName('clientJar')?.archiveFile?.get()?.asFile
-            if (clientJar?.exists()) {
-                return clientJar
+            def btraceJar = distProject.tasks.findByName('btraceJar')?.archiveFile?.get()?.asFile
+            if (btraceJar?.exists()) {
+                return btraceJar
             }
         }
 
@@ -490,11 +556,14 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
             def config = project.configurations.findByName('btracec') ?:
                 project.configurations.create('btracec')
             if (config.dependencies.isEmpty()) {
-                config.dependencies.add(project.dependencies.create('io.btrace:btrace-client:+'))
+                def extension = project.extensions.getByName('btraceFatAgent') as BTraceFatAgentExtension
+                String btraceVersion = BTraceVersion.resolve(
+                    project, extension.btraceVersion, BTraceFatAgentPlugin, 'btraceFatAgent.btraceVersion')
+                config.dependencies.add(project.dependencies.create("io.btrace:btrace:${btraceVersion}"))
             }
-            return config.resolve().find { it.name.contains('btrace-client') }
+            return config.resolve().find { it.name.startsWith('btrace-') }
         } catch (Exception e) {
-            project.logger.debug("[fat-agent] Could not resolve btrace-client: ${e.message}")
+            project.logger.debug("[fat-agent] Could not resolve BTrace distribution: ${e.message}")
         }
 
         return null

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceVersion.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceVersion.groovy
@@ -1,0 +1,34 @@
+package io.btrace.gradle
+
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+
+/** Resolves the version of the public BTrace distribution used by this plugin. */
+final class BTraceVersion {
+    private BTraceVersion() {}
+
+    static String resolve(Project project, String explicitVersion, Class<?> pluginClass, String propertyName) {
+        String version = explicitVersion?.trim()
+        if (version == null || version.isEmpty()) {
+            version = pluginClass?.package?.implementationVersion?.trim()
+        }
+        if (version == null || version.isEmpty()) {
+            throw new GradleException(
+                "BTrace version is unavailable. Set ${propertyName} to a concrete BTrace release version " +
+                "(for example, btraceVersion = '3.0.0').")
+        }
+        validate(version, propertyName)
+        return version
+    }
+
+    static void validate(String version, String propertyName) {
+        if (version == null || version.trim().isEmpty() ||
+                version ==~ /.*[+\[\]\(\),].*/ ||
+                version.equalsIgnoreCase('latest.release') ||
+                version.equalsIgnoreCase('latest.integration') ||
+                version.equalsIgnoreCase('unspecified')) {
+            throw new GradleException(
+                "${propertyName} must be a concrete BTrace release version; dynamic versions and ranges are not supported.")
+        }
+    }
+}

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceVersion.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceVersion.groovy
@@ -21,6 +21,9 @@ final class BTraceVersion {
         return version
     }
 
+    // Resolve-time validation: rejects dynamic selectors and ranges only. Pre-release qualifiers
+    // (e.g. '3.0.0-rc1', '3.0.0-SNAPSHOT') are deliberately allowed so a consumer may pin one.
+    // The stricter X.Y.Z gate for *publishing* the plugins lives in btrace-gradle-plugin/build.gradle.
     static void validate(String version, String propertyName) {
         if (version == null || version.trim().isEmpty() ||
                 version ==~ /.*[+\[\]\(\),].*/ ||

--- a/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceExtensionPluginTest.java
+++ b/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceExtensionPluginTest.java
@@ -134,6 +134,37 @@ class BTraceExtensionPluginTest {
     }
 
     @Test
+    @DisplayName("external builds use the explicitly pinned public BTrace distribution")
+    void externalBuildUsesPinnedBTraceDistribution() throws IOException {
+        writeFile(settingsFile, "rootProject.name = 'external-extension'\n");
+        writeFile(
+                rootBuildFile,
+                "plugins { id 'io.btrace.extension' }\n"
+                        + "version = '9.9.9'\n"
+                        + "btraceExtension { btraceVersion = '3.0.0' }\n"
+                        + "tasks.register('printProcessor') { doLast {\n"
+                        + "  configurations.annotationProcessor.dependencies.each { println \"PROCESSOR=${it.group}:${it.name}:${it.version}\" }\n"
+                        + "} }\n");
+
+        BuildResult result = createRunner().withArguments("printProcessor").build();
+
+        assertTrue(result.getOutput().contains("PROCESSOR=io.btrace:btrace:3.0.0"));
+        assertFalse(result.getOutput().contains("btrace-core"));
+    }
+
+    @Test
+    @DisplayName("external builds require an explicit BTrace version without a published plugin JAR")
+    void externalBuildWithoutBTraceVersionFailsClearly() throws IOException {
+        writeFile(settingsFile, "rootProject.name = 'external-extension'\n");
+        writeFile(rootBuildFile, "plugins { id 'io.btrace.extension' }\n");
+
+        BuildResult result = createRunner().withArguments("tasks").buildAndFail();
+
+        assertTrue(result.getOutput().contains("btraceExtension.btraceVersion"));
+        assertTrue(result.getOutput().contains("concrete BTrace release version"));
+    }
+
+    @Test
     @DisplayName("published API source and javadoc artifacts stay API-only")
     void apiPublicationsStayApiOnly() throws IOException {
         writeExtensionProject();

--- a/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceFatAgentPluginTest.java
+++ b/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceFatAgentPluginTest.java
@@ -33,7 +33,6 @@ import java.nio.file.Path;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.Attributes;
-import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -108,6 +107,37 @@ class BTraceFatAgentPluginTest {
             .build();
 
         assertTrue(result.getOutput().contains("BASE_NAME=my-custom-agent"));
+    }
+
+    @Test
+    @DisplayName("external builds assemble a fat agent from one pinned masked engine")
+    void externalBuildUsesPinnedMaskedEngine() throws IOException {
+        writeMaskedEngineFixture("3.0.0");
+        writeFile(
+                buildFile,
+                "plugins { id 'io.btrace.fat-agent' }\n"
+                        + "repositories { maven { url = uri('repo') } }\n"
+                        + "version = '99.0.0-extension'\n"
+                        + "btraceFatAgent { btraceVersion = '3.0.0' }\n"
+                        + "tasks.register('printEngine') { doLast {\n"
+                        + "  configurations.btraceEngine.dependencies.each { println \"ENGINE=${it.group}:${it.name}:${it.version}\" }\n"
+                        + "} }\n");
+
+        BuildResult result = createRunner().withArguments("fatAgentJar", "printEngine").build();
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":stageBTraceEngine").getOutcome());
+        assertEquals(TaskOutcome.SUCCESS, result.task(":fatAgentJar").getOutcome());
+        assertTrue(result.getOutput().contains("ENGINE=io.btrace:btrace:3.0.0"));
+        try (JarFile jar =
+                new JarFile(projectDir.resolve("build/libs/btrace-agent-fat.jar").toFile())) {
+            assertNotNull(jar.getEntry("io/btrace/boot/Loader.class"));
+            assertNotNull(
+                    jar.getEntry("META-INF/btrace/agent/io/btrace/agent/Main.classdata"));
+            assertEquals("io.btrace.boot.Loader", jar.getManifest().getMainAttributes().getValue("Main-Class"));
+            assertEquals("io.btrace.boot.Loader", jar.getManifest().getMainAttributes().getValue("Premain-Class"));
+            assertEquals("io.btrace.boot.Loader", jar.getManifest().getMainAttributes().getValue("Agent-Class"));
+            assertEquals("btrace-agent-fat.jar", jar.getManifest().getMainAttributes().getValue("Boot-Class-Path"));
+        }
     }
 
     @Test
@@ -248,7 +278,8 @@ class BTraceFatAgentPluginTest {
                         + "    from 'probes'\n"
                         + "    include 'com.example.NestedProbe'\n"
                         + "  }\n"
-                        + "}\n");
+                        + "}\n"
+                        + "jar { manifest { attributes('Main-Class': 'io.btrace.boot.Loader', 'Premain-Class': 'io.btrace.boot.Loader', 'Agent-Class': 'io.btrace.boot.Loader', 'BTrace-Agent-Main': 'io.btrace.agent.Main', 'Boot-Class-Path': 'test-project.jar') } }\n");
 
         BuildResult result = createRunner().withArguments("fatAgentJar").build();
 
@@ -377,7 +408,8 @@ class BTraceFatAgentPluginTest {
                         + "    from layout.buildDirectory.dir('compiled-probes').get().asFile\n"
                         + "    include 'com.example.NestedProbe'\n"
                         + "  }\n"
-                        + "}\n");
+                        + "}\n"
+                        + "jar { manifest { attributes('Main-Class': 'io.btrace.boot.Loader', 'Premain-Class': 'io.btrace.boot.Loader', 'Agent-Class': 'io.btrace.boot.Loader', 'BTrace-Agent-Main': 'io.btrace.agent.Main', 'Boot-Class-Path': 'test-project.jar') } }\n");
 
         createRunner().withArguments("fatAgentJar", "classes").build();
 
@@ -704,6 +736,40 @@ class BTraceFatAgentPluginTest {
                 "package io.btrace.boot; public final class Loader {}\n",
                 StandardCharsets.UTF_8);
         Files.write(maskedAgentMain, new byte[] {0});
+    }
+
+    private void writeMaskedEngineFixture(String version) throws IOException {
+        Path engine =
+                projectDir.resolve("repo/io/btrace/btrace/").resolve(version).resolve("btrace-" + version + ".jar");
+        Files.createDirectories(engine.getParent());
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attributes.putValue("Main-Class", "io.btrace.boot.Loader");
+        attributes.putValue("Premain-Class", "io.btrace.boot.Loader");
+        attributes.putValue("Agent-Class", "io.btrace.boot.Loader");
+        attributes.putValue("Boot-Class-Path", "btrace.jar");
+        attributes.putValue("BTrace-Agent-Main", "io.btrace.agent.Main");
+        attributes.putValue("BTrace-Client-Main", "io.btrace.client.Main");
+        try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(engine), manifest)) {
+            output.putNextEntry(new JarEntry("io/btrace/boot/Loader.class"));
+            output.write(new byte[] {0});
+            output.closeEntry();
+            output.putNextEntry(
+                    new JarEntry("META-INF/btrace/agent/io/btrace/agent/Main.classdata"));
+            output.write(new byte[] {0});
+            output.closeEntry();
+            output.putNextEntry(new JarEntry("META-INF/btrace/client/fixture.classdata"));
+            output.write(new byte[] {0});
+            output.closeEntry();
+        }
+        Files.writeString(
+                engine.resolveSibling("btrace-" + version + ".pom"),
+                "<project><modelVersion>4.0.0</modelVersion><groupId>io.btrace</groupId>"
+                        + "<artifactId>btrace</artifactId><version>"
+                        + version
+                        + "</version></project>",
+                StandardCharsets.UTF_8);
     }
 
     private Path writeExtensionFixture(String permissions) throws IOException {

--- a/docs/BTraceExtensionDevelopmentGuide.md
+++ b/docs/BTraceExtensionDevelopmentGuide.md
@@ -320,6 +320,12 @@ repositories = [ "${btrace.home}/extensions", "${user.home}/.btrace/extensions" 
 
 For environments where installing extensions separately is impractical (Spark, Hadoop, Kubernetes), extensions can be embedded directly in a fat agent JAR.
 
+BTrace's built-in extensions are extension packages in a BTrace distribution's `extensions/`
+directory (or from the matching `packageExtension` task in a source checkout). Use `file(...)` to
+embed one, or `project(...)` for an in-tree/custom extension. `maven(...)` is reserved for a
+separately published third-party extension; BTrace does not publish its bundled extensions as Maven
+artifacts.
+
 ### Building a Fat Agent with Your Extension
 
 Use the BTrace Fat Agent Plugin to create a self-contained agent JAR:
@@ -336,8 +342,8 @@ btraceFatAgent {
         // Your extension project (if in same multi-project build)
         project(':my-extension')
 
-        // Published extensions from Maven
-        maven('io.btrace:btrace-metrics:3.0.0')
+        // BTrace-built packages from the distribution's extensions/ directory
+        file('/path/to/btrace-metrics-3.0.0-extension.zip')
 
         // Local extension ZIPs
         file('libs/other-extension.zip')

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -71,7 +71,7 @@ sdk install jbang                   # SDKMAN
 **Use BTrace with JBang** (no separate BTrace installation needed):
 ```bash
 # Attach to running application (replace <version> with desired version, e.g., 3.0.0)
-jbang io.btrace:btrace-client:<version> <PID> <script.java>
+jbang io.btrace:btrace:<version> <PID> <script.java>
 
 # Add the BTrace JBang catalog (one time), then use the shorter alias
 jbang catalog add --name btraceio https://raw.githubusercontent.com/btraceio/jbang-catalog/main/jbang-catalog.json
@@ -296,7 +296,7 @@ BTrace offers multiple deployment modes to suit different use cases:
 Use JBang to run BTrace without installation:
 
 ```bash
-jbang io.btrace:btrace-client:<version> <PID> <script.java>
+jbang io.btrace:btrace:<version> <PID> <script.java>
 
 # One-time catalog setup for the short alias
 jbang catalog add --name btraceio https://raw.githubusercontent.com/btraceio/jbang-catalog/main/jbang-catalog.json
@@ -791,6 +791,10 @@ ENTRYPOINT ["java", "-javaagent:/opt/btrace/btrace-agent-fat.jar", "-jar", "/app
 
 For custom extension combinations, use the Gradle plugin:
 
+Built-in extensions are supplied as packages in the BTrace distribution's `extensions/` directory.
+Use `file(...)` for those packages or `project(...)` for an in-tree/custom extension. The
+`maven(...)` source is only for separately published third-party extensions.
+
 ```groovy
 plugins {
     id 'io.btrace.fat-agent'
@@ -800,11 +804,11 @@ btraceFatAgent {
     baseName = 'my-btrace-agent'
 
     embedExtensions {
-        // From Maven Central
-        maven('io.btrace:btrace-metrics:3.0.0')
-        maven('io.btrace:btrace-statsd:3.0.0')
+        // BTrace-built extension packages from the distribution's extensions/ directory
+        file('/path/to/btrace-metrics-3.0.0-extension.zip')
+        file('/path/to/btrace-statsd-3.0.0-extension.zip')
 
-        // Local extension
+        // Custom/local extension package
         file('libs/my-custom-extension.zip')
     }
 }

--- a/docs/QuickReference.md
+++ b/docs/QuickReference.md
@@ -520,7 +520,7 @@ btracex inspect [<path|dir|zip|id>] [--json]   # no args opens the interactive r
 btracex list [--json]
 btracex policy print [--policy-file <path>|--home|--classpath <outDir>] [--json]
 btracex policy set [--allowExtensions <ids>] [--denyExtensions <ids>] [--allowPrivileged <bool>] [--policy-file <path>|--home|--classpath <outDir>]
-btracex install <groupId:artifactId:version> [--repo <url> ...] [--id <extId>] [--dry-run]
+btracex install <groupId:artifactId:version|zip|url> [--repo <url> ...] [--id <extId>] [--dry-run]
 ```
 
 **Examples:**
@@ -531,8 +531,8 @@ btracex inspect my-extension.zip
 # List installed extensions
 btracex list
 
-# Install an extension from Maven coordinates
-btracex install io.btrace:btrace-statsd:3.0.0
+# Install a BTrace-built extension package from the distribution's extensions/ directory
+btracex install /path/to/btrace-statsd-3.0.0-extension.zip
 ```
 
 ### btracep

--- a/docs/ReleaseChecklist.md
+++ b/docs/ReleaseChecklist.md
@@ -25,6 +25,7 @@ shell-escaped command, exit code, filtered result lines, and complete command ou
 |------|------------------|-----------------|
 | Core, agent, client | `./gradlew --continue :btrace-core:test :btrace-agent:test :btrace-client:test` | All module tests pass |
 | Gradle plugins | `cd btrace-gradle-plugin && ../gradlew test` | All extension and fat-agent tests pass |
+| Plugin Portal validation | `./gradlew -p btrace-gradle-plugin -PbtraceVersion=<release> publishPlugins --validate-only` | Both plugin IDs and marker publications validate at the exact release version |
 | Maven fat-agent removal | `test ! -e btrace-maven-plugin/build.gradle` | The unpublished module remains absent |
 | Formatting | `./gradlew spotlessCheck` | Pass |
 | Clean masked JAR | `./gradlew clean :btrace-dist:btraceJar` | Pass; `libs/btrace.jar` exists |
@@ -90,6 +91,7 @@ extracted candidate distribution and retains target, client, compiler, migration
 | Surface | Required evidence |
 |---------|-------------------|
 | Maven Central | Candidate POM and masked JAR resolve; version and Apache-2.0 metadata match |
+| Gradle Plugin Portal | `io.btrace.extension` and `io.btrace.fat-agent` validate, publish, and resolve at the candidate version; neither is staged to Maven Central |
 | JBang | Exact Maven coordinate and `btrace@btraceio` catalog alias report the candidate version |
 | SDKMAN | Archive has `bin/` and `libs/` at its root; no extra version directory |
 | Docker | OCI version/license labels match and `/opt/btrace/libs/btrace.jar` is the intended layout |

--- a/docs/architecture/migrating-from-libs-profiles.md
+++ b/docs/architecture/migrating-from-libs-profiles.md
@@ -66,7 +66,7 @@ btraceFatAgent {
     baseName = 'my-btrace-agent'
     embedExtensions {
         project(':my-spark-extension')
-        maven('io.btrace:btrace-metrics:3.0.0')
+        file('/path/to/btrace-metrics-3.0.0-extension.zip')
     }
 }
 ```

--- a/docs/tutorials/06-write-your-own-extension.md
+++ b/docs/tutorials/06-write-your-own-extension.md
@@ -46,8 +46,8 @@ java {
 }
 
 dependencies {
-    apiCompileOnly 'io.btrace:btrace-core:3.0.0'
-    implCompileOnly 'io.btrace:btrace-core:3.0.0'
+    apiCompileOnly 'io.btrace:btrace:3.0.0'
+    implCompileOnly 'io.btrace:btrace:3.0.0'
 }
 
 btraceExtension {
@@ -355,15 +355,12 @@ rm -rf "$BTRACE_HOME/extensions/order-counter" ~/.btrace/permissions.properties
   interfaces annotated with `io.btrace.core.extensions.ServiceDescriptor`. Confirm the annotation
   is on the compiled service interface (not only its implementation). An explicit `services` list
   remains available when an extension cannot annotate the interface it exports.
-- **`Could not find io.btrace:btrace-core:<your-project-version>`** — the plugin auto-registers
-  the `@ExternalType` annotation processor, and outside the BTrace monorepo (no sibling
-  `:btrace-core` project) it resolves that processor as
-  `"io.btrace:btrace-core:${project.version}"` — your extension project's *own* `version`, not the
-  BTrace release you're building against (`BTraceExtensionPlugin.groovy`, the
-  `processorProject == null` branch). This is why this tutorial's `build.gradle` sets
-  `version = '3.0.0'` to match the BTrace release instead of, say, `1.0`: if your extension's own
-  versioning scheme diverges from BTrace's, this auto-registration will request a `btrace-core`
-  coordinate that doesn't exist on Maven Central.
+- **`btraceExtension.btraceVersion` is required** — when the plugin runs from a development or
+  TestKit classpath it cannot read a published plugin manifest. Set
+  `btraceExtension { btraceVersion = '3.0.0' }` explicitly. Published Plugin Portal builds carry
+  that version in their implementation manifest. External builds resolve only
+  `io.btrace:btrace:<btraceVersion>` for the `@ExternalType` processor; an extension's own
+  `version` may therefore follow its independent release scheme.
 - **The probe fails to link instead of running** — you deployed it before Step 6's permission
   grant, or against a demo app process that was already running (and had already loaded an older
   policy) before you wrote the policy file. Start a fresh `java DemoApp.java` after Step 6.

--- a/docs/tutorials/08-fat-agent.md
+++ b/docs/tutorials/08-fat-agent.md
@@ -40,8 +40,9 @@ btrace-metrics-3.0.0-extension.zip
 
 > **What just happened?** `packageExtension` is a real task registered by the `io.btrace.extension`
 > Gradle plugin for every extension module (`BTraceExtensionPlugin.groovy`) — it zips the API jar
-> and the shaded implementation jar together under classifier `extension`. That's the artifact
-> shape the fat-agent plugin's `file()` and `maven()` sources expect to unpack.
+> and the shaded implementation jar together under classifier `extension`. Use that package with
+> the fat-agent plugin's `file()` source. `maven()` remains for separately published third-party
+> extensions; BTrace's bundled extensions are not Maven artifacts.
 
 Copy it into a scratch directory, renamed to match the extension's real id (`btrace-metrics`) —
 you'll see exactly why that naming matters in Step 3:
@@ -71,6 +72,7 @@ plugins {
 
 btraceFatAgent {
     baseName = 'demo-btrace-agent'
+    btraceVersion = '3.0.0'
 
     embedExtensions {
         file('btrace-metrics.zip')
@@ -78,7 +80,7 @@ btraceFatAgent {
 }
 ```
 
-`baseName` and the `embedExtensions { file(...) }` / `maven(...)` / `project(...)` source builders
+`baseName`, `btraceVersion`, and the `embedExtensions { file(...) }` / `maven(...)` / `project(...)` source builders
 are exactly the DSL surface the plugin exposes — verified against
 `BTraceFatAgentExtension.groovy` (fields `baseName`, `outputDir`, `manifestAttributes`,
 `relocations`, `autoDiscover`; the `ExtensionSourceSpec` builders `project()`, `maven()`, `file()`,

--- a/docs/tutorials/demo/fat-agent-build.gradle
+++ b/docs/tutorials/demo/fat-agent-build.gradle
@@ -9,8 +9,14 @@ plugins {
     id 'io.btrace.fat-agent' version '3.0.0'
 }
 
+repositories {
+    mavenCentral()
+}
+
 btraceFatAgent {
     baseName = 'demo-btrace-agent'
+    // The public masked engine used when this is not an in-tree BTrace build.
+    btraceVersion = '3.0.0'
 
     embedExtensions {
         // Points at the btrace-metrics extension zip you built in Step 1.

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -131,6 +131,7 @@ test {
              ':btrace-dist:btraceJar',
              ':btrace-dist:explodeExtensions',
              stageExternalTypeClientHome
+    dependsOn gradle.includedBuild('btrace-gradle-plugin').task(':jar')
 
     testLogging.showStandardStreams = true
 

--- a/integration-tests/src/test/java/tests/Issue884PublishedFatAgentE2ETest.java
+++ b/integration-tests/src/test/java/tests/Issue884PublishedFatAgentE2ETest.java
@@ -37,6 +37,9 @@ import tests.harness.Completion;
 class Issue884PublishedFatAgentE2ETest {
   private static final String VERSION = "3.0.0";
 
+  /** Must match the ASM version the Gradle plugin declares in {@code btrace-gradle-plugin}. */
+  private static final String ASM_VERSION = "9.9.1";
+
   @TempDir Path temporaryDirectory;
 
   @BeforeAll
@@ -103,10 +106,8 @@ class Issue884PublishedFatAgentE2ETest {
 
     publishPluginArtifacts(root, repository);
     publishArtifact(repository, "io/btrace", "btrace", VERSION, engineJar);
-    publishDependency(
-        repository, "org.ow2.asm", "asm", root, "2ceea6ab43bcae1979b2a6d85fc0ca429877e5ab");
-    publishDependency(
-        repository, "org.ow2.asm", "asm-tree", root, "b6b1b3366296163b4b1f540731aad0a2baa484d8");
+    publishDependency(repository, "org.ow2.asm", "asm", ASM_VERSION);
+    publishDependency(repository, "org.ow2.asm", "asm-tree", ASM_VERSION);
   }
 
   private void publishPluginArtifacts(Path root, Path repository) throws Exception {
@@ -138,26 +139,11 @@ class Issue884PublishedFatAgentE2ETest {
         StandardCharsets.UTF_8);
   }
 
-  private void publishDependency(
-      Path repository, String group, String artifact, Path root, String cacheHash)
+  private void publishDependency(Path repository, String group, String artifact, String version)
       throws IOException {
-    String version = "9.9.1";
-    Path source =
-        root.resolve(
-            ".gradle-user/caches/modules-2/files-2.1/"
-                + group
-                + "/"
-                + artifact
-                + "/"
-                + version
-                + "/"
-                + cacheHash
-                + "/"
-                + artifact
-                + "-"
-                + version
-                + ".jar");
-    assertTrue(Files.isRegularFile(source), "missing cached dependency: " + source);
+    Path source = locateCachedArtifact(group, artifact, version);
+    assertTrue(
+        source != null, "missing cached dependency: " + group + ":" + artifact + ":" + version);
     Path directory = repository.resolve(group.replace('.', '/')).resolve(artifact).resolve(version);
     Files.createDirectories(directory);
     Files.copy(source, directory.resolve(artifact + "-" + version + ".jar"));
@@ -165,6 +151,36 @@ class Issue884PublishedFatAgentE2ETest {
         directory.resolve(artifact + "-" + version + ".pom"),
         pom(group, artifact, version, ""),
         StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Locates a resolved dependency JAR inside the active Gradle dependency cache. The cache lives
+   * under {@code GRADLE_USER_HOME} (falling back to {@code ~/.gradle}); the per-artifact SHA-1
+   * subdirectory is discovered rather than hard-coded so the lookup survives cache-layout details.
+   */
+  private Path locateCachedArtifact(String group, String artifact, String version)
+      throws IOException {
+    String gradleUserHome = System.getenv("GRADLE_USER_HOME");
+    Path base =
+        (gradleUserHome != null && !gradleUserHome.isEmpty())
+            ? Paths.get(gradleUserHome)
+            : Paths.get(System.getProperty("user.home"), ".gradle");
+    Path moduleDirectory =
+        base.resolve("caches/modules-2/files-2.1")
+            .resolve(group)
+            .resolve(artifact)
+            .resolve(version);
+    if (!Files.isDirectory(moduleDirectory)) {
+      return null;
+    }
+    String fileName = artifact + "-" + version + ".jar";
+    try (java.util.stream.Stream<Path> entries = Files.walk(moduleDirectory)) {
+      return entries
+          .filter(path -> path.getFileName().toString().equals(fileName))
+          .filter(Files::isRegularFile)
+          .findFirst()
+          .orElse(null);
+    }
   }
 
   private String pom(String group, String artifact, String version, String extra) {

--- a/integration-tests/src/test/java/tests/Issue884PublishedFatAgentE2ETest.java
+++ b/integration-tests/src/test/java/tests/Issue884PublishedFatAgentE2ETest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2008, 2024, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import tests.harness.Completion;
+
+/** Proves the published-plugin external fat-agent path using only a temporary local repository. */
+class Issue884PublishedFatAgentE2ETest {
+  private static final String VERSION = "3.0.0";
+
+  @TempDir Path temporaryDirectory;
+
+  @BeforeAll
+  static void setUpHarness() {
+    RuntimeTest.classSetup();
+  }
+
+  @Test
+  void publishedMarkersBuildFatAgentThatServesRealDynamicAttach() throws Exception {
+    Path root = Paths.get(System.getProperty("project.dir")).getParent();
+    Path repository = temporaryDirectory.resolve("repository");
+    publishFixtureRepository(root, repository);
+    compileExternalExtensionConsumer(root, repository);
+    Path fatAgent = buildExternalConsumer(root, repository);
+    Path localEngine =
+        repository
+            .resolve("io/btrace/btrace/")
+            .resolve(VERSION)
+            .resolve("btrace-" + VERSION + ".jar");
+    assertMaskedAgent(fatAgent);
+    assertTrue(Files.isRegularFile(localEngine), "missing staged BTrace engine: " + localEngine);
+
+    String originalLibraries = System.getProperty("btrace.libs");
+    String originalClientJar = System.getProperty("btrace.client.jar");
+    try {
+      System.setProperty("btrace.libs", fatAgent.getParent().toString());
+      System.setProperty("btrace.client.jar", localEngine.toString());
+      Files.copy(
+          fatAgent,
+          fatAgent.getParent().resolve("btrace.jar"),
+          StandardCopyOption.REPLACE_EXISTING);
+
+      RuntimeTest harness = new RuntimeTest() {};
+      harness.reset();
+      harness.timeout = 30_000L;
+      harness.testDynamic(
+          "resources.Main",
+          "btrace/OnTimerTest.java",
+          null,
+          Completion.untilContains("timer"),
+          (stdout, stderr, retcode, jfrFile) -> {
+            assertTrue(stdout.contains("timer"), stdout);
+            assertFalse(stdout.contains("FAILED"), stdout);
+            assertTrue(stderr.isEmpty(), stderr);
+          });
+    } finally {
+      if (originalLibraries == null) {
+        System.clearProperty("btrace.libs");
+      } else {
+        System.setProperty("btrace.libs", originalLibraries);
+      }
+      if (originalClientJar == null) {
+        System.clearProperty("btrace.client.jar");
+      } else {
+        System.setProperty("btrace.client.jar", originalClientJar);
+      }
+    }
+  }
+
+  private void publishFixtureRepository(Path root, Path repository) throws Exception {
+    Path engineJar =
+        root.resolve("btrace-dist/build/resources/main/v3.0.0-SNAPSHOT/libs/btrace.jar");
+    assertTrue(Files.isRegularFile(engineJar), "missing masked engine JAR: " + engineJar);
+
+    publishPluginArtifacts(root, repository);
+    publishArtifact(repository, "io/btrace", "btrace", VERSION, engineJar);
+    publishDependency(
+        repository, "org.ow2.asm", "asm", root, "2ceea6ab43bcae1979b2a6d85fc0ca429877e5ab");
+    publishDependency(
+        repository, "org.ow2.asm", "asm-tree", root, "b6b1b3366296163b4b1f540731aad0a2baa484d8");
+  }
+
+  private void publishPluginArtifacts(Path root, Path repository) throws Exception {
+    Process process =
+        new ProcessBuilder(
+                root.resolve("gradlew").toString(),
+                "-p",
+                root.resolve("btrace-gradle-plugin").toString(),
+                "-PbtraceVersion=" + VERSION,
+                "-PpublicationRepository=" + repository,
+                "publish")
+            .directory(root.toFile())
+            .redirectErrorStream(true)
+            .start();
+    assertTrue(process.waitFor(90, TimeUnit.SECONDS), "plugin publication did not finish");
+    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    assertTrue(process.exitValue() == 0, output);
+  }
+
+  private void publishArtifact(
+      Path repository, String groupPath, String artifact, String version, Path source)
+      throws IOException {
+    Path directory = repository.resolve(groupPath).resolve(artifact).resolve(version);
+    Files.createDirectories(directory);
+    Files.copy(source, directory.resolve(artifact + "-" + version + ".jar"));
+    Files.writeString(
+        directory.resolve(artifact + "-" + version + ".pom"),
+        pom("io.btrace", artifact, version, ""),
+        StandardCharsets.UTF_8);
+  }
+
+  private void publishDependency(
+      Path repository, String group, String artifact, Path root, String cacheHash)
+      throws IOException {
+    String version = "9.9.1";
+    Path source =
+        root.resolve(
+            ".gradle-user/caches/modules-2/files-2.1/"
+                + group
+                + "/"
+                + artifact
+                + "/"
+                + version
+                + "/"
+                + cacheHash
+                + "/"
+                + artifact
+                + "-"
+                + version
+                + ".jar");
+    assertTrue(Files.isRegularFile(source), "missing cached dependency: " + source);
+    Path directory = repository.resolve(group.replace('.', '/')).resolve(artifact).resolve(version);
+    Files.createDirectories(directory);
+    Files.copy(source, directory.resolve(artifact + "-" + version + ".jar"));
+    Files.writeString(
+        directory.resolve(artifact + "-" + version + ".pom"),
+        pom(group, artifact, version, ""),
+        StandardCharsets.UTF_8);
+  }
+
+  private String pom(String group, String artifact, String version, String extra) {
+    return "<project><modelVersion>4.0.0</modelVersion><groupId>"
+        + group
+        + "</groupId><artifactId>"
+        + artifact
+        + "</artifactId><version>"
+        + version
+        + "</version>"
+        + extra
+        + "</project>";
+  }
+
+  private Path buildExternalConsumer(Path root, Path repository) throws Exception {
+    Path consumer = temporaryDirectory.resolve("consumer");
+    Files.createDirectories(consumer);
+    String repositoryUri = repository.toUri().toString();
+    Files.writeString(
+        consumer.resolve("settings.gradle"),
+        "pluginManagement { repositories { maven { url = uri('"
+            + repositoryUri
+            + "') } } }\nrootProject.name = 'issue-884-consumer'\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        consumer.resolve("build.gradle"),
+        "plugins {\n"
+            + "  id 'io.btrace.extension' version '"
+            + VERSION
+            + "' apply false\n"
+            + "  id 'io.btrace.fat-agent' version '"
+            + VERSION
+            + "'\n"
+            + "}\n"
+            + "repositories { maven { url = uri('"
+            + repositoryUri
+            + "') } }\n"
+            + "btraceFatAgent { }\n",
+        StandardCharsets.UTF_8);
+    Process process =
+        new ProcessBuilder(
+                root.resolve("gradlew").toString(), "-p", consumer.toString(), "fatAgentJar")
+            .directory(root.toFile())
+            .redirectErrorStream(true)
+            .start();
+    assertTrue(process.waitFor(90, TimeUnit.SECONDS), "external consumer did not finish");
+    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    assertTrue(process.exitValue() == 0, output);
+    assertTrue(output.contains("Staged masked BTrace engine"), output);
+    return consumer.resolve("build/libs/btrace-agent-fat.jar");
+  }
+
+  private void compileExternalExtensionConsumer(Path root, Path repository) throws Exception {
+    Path consumer = temporaryDirectory.resolve("extension-consumer");
+    Path source = consumer.resolve("src/main/java/example/ExternalService.java");
+    Files.createDirectories(source.getParent());
+    Files.writeString(
+        source,
+        "package example;\n"
+            + "import io.btrace.core.extensions.ServiceDescriptor;\n"
+            + "@ServiceDescriptor public interface ExternalService {}\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        consumer.resolve("settings.gradle"),
+        "rootProject.name = 'issue-884-extension-consumer'\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        consumer.resolve("build.gradle"),
+        "plugins { id 'java-library' }\n"
+            + "repositories { maven { url = uri('"
+            + repository.toUri()
+            + "') } }\n"
+            + "dependencies { compileOnly 'io.btrace:btrace:"
+            + VERSION
+            + "' }\n",
+        StandardCharsets.UTF_8);
+    Process process =
+        new ProcessBuilder(
+                root.resolve("gradlew").toString(), "-p", consumer.toString(), "compileJava")
+            .directory(root.toFile())
+            .redirectErrorStream(true)
+            .start();
+    assertTrue(process.waitFor(60, TimeUnit.SECONDS), "external extension compile did not finish");
+    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    assertTrue(process.exitValue() == 0, output);
+  }
+
+  private void assertMaskedAgent(Path fatAgent) throws Exception {
+    assertTrue(Files.isRegularFile(fatAgent), "missing fat agent: " + fatAgent);
+    try (JarFile jar = new JarFile(fatAgent.toFile())) {
+      assertTrue(jar.getEntry("io/btrace/boot/Loader.class") != null);
+      assertTrue(jar.getEntry("META-INF/btrace/agent/io/btrace/agent/Main.classdata") != null);
+      Attributes attributes = jar.getManifest().getMainAttributes();
+      assertTrue("io.btrace.boot.Loader".equals(attributes.getValue("Main-Class")));
+      assertTrue("io.btrace.boot.Loader".equals(attributes.getValue("Premain-Class")));
+      assertTrue("io.btrace.boot.Loader".equals(attributes.getValue("Agent-Class")));
+    }
+  }
+}

--- a/integration-tests/src/test/java/tests/RuntimeTest.java
+++ b/integration-tests/src/test/java/tests/RuntimeTest.java
@@ -1345,6 +1345,7 @@ public abstract class RuntimeTest {
       StringBuilder stderr)
       throws Exception {
     File traceFile = locateTrace(trace);
+    String clientClasspath = clientClasspath();
     List<String> argVals =
         new ArrayList<>(
             Arrays.asList(
@@ -1356,7 +1357,7 @@ public abstract class RuntimeTest {
                 "-Dbtrace.libs=" + System.getProperty("btrace.libs"),
                 "-Dbtrace.suppressJavaDeprecationWarning=true",
                 "-cp",
-                cp,
+                clientClasspath,
                 "io.btrace.boot.Loader",
                 "-p",
                 String.valueOf(getBTracePort()),
@@ -1435,6 +1436,18 @@ public abstract class RuntimeTest {
       }
     }
     throw new IllegalStateException("Client invocation is missing -Dbtrace.libs");
+  }
+
+  private static String clientClasspath() {
+    String explicitClientJar = System.getProperty("btrace.client.jar");
+    if (explicitClientJar == null || explicitClientJar.trim().isEmpty()) {
+      return cp;
+    }
+    int firstSeparator = cp.indexOf(File.pathSeparator);
+    if (firstSeparator < 0) {
+      return explicitClientJar;
+    }
+    return explicitClientJar + cp.substring(firstSeparator);
   }
 
   private Process attachOneliner(

--- a/internal/plans/2026-07-16-issue-884-withdraw-unpublished-maven-coordinates.md
+++ b/internal/plans/2026-07-16-issue-884-withdraw-unpublished-maven-coordinates.md
@@ -1,0 +1,354 @@
+# Issue #884 implementation plan: withdraw unpublished Maven coordinates
+
+Date: 2026-07-16  
+Design input: `internal/specs/2026-07-16-issue-884-withdraw-unpublished-maven-coordinates.md`  
+Decision: retain PR #900's deletion of `btrace-maven-plugin`. The only public Maven Central
+engine/library artifact is `io.btrace:btrace`; `io.btrace.extension` and `io.btrace.fat-agent` are
+the only supported plugins and publish through the Gradle Plugin Portal.
+
+## Baseline safety rules
+
+1. Start every gate with `git status --short`; preserve all existing unrelated and untracked work.
+   Do not use `git reset`, `git checkout`, `git clean`, or blanket formatting.
+2. Do not commit any #884 change until all implementation and verification gates pass, per
+   `AGENTS.md`. Stage only the intentional final #884 files.
+3. Run Gradle with `GRADLE_USER_HOME=$(pwd)/.gradle-user`, redirect each command's output to a file,
+   filter it before reading, and add the repository IPv4 `JAVA_TOOL_OPTIONS` if the environment
+   requires it.
+4. Treat the masked `btrace-dist` JAR as opaque base content. This issue must not change class
+   partitions, entry-point manifest attributes, loader behavior, or `META-INF/btrace/` layout.
+5. Do not restore, implement, test, publish, or document a Maven fat-agent plugin. The removed
+   module is not a fallback for any gate in this plan.
+
+## Gate 0 — repository-wide inventory and Maven-plugin deletion proof
+
+**Files changed:** none initially. Save the categorized results in PR/release evidence, not a new
+user-facing guide.
+
+1. Run root-level searches (including `.github`, excluding generated build outputs, Git metadata, and
+   the workspace cache):
+
+   ```sh
+   rg -n --hidden --glob '!**/build/**' --glob '!.git/**' --glob '!.gradle-user/**' \
+     "io\\.btrace:btrace-[[:alnum:]_.-]+" .
+   rg -n --hidden --glob '!**/build/**' --glob '!.git/**' --glob '!.gradle-user/**' \
+     "btrace-client:\+|btrace-core:\$\\{project\\.version\\}|btrace-(agent|boot)" .
+   rg -n --hidden --glob '!**/build/**' --glob '!.git/**' --glob '!.gradle-user/**' \
+     "btrace-maven-plugin|FatAgentMojo|fat-agent-pom" .
+   git merge-base --is-ancestor 9bd52b9b HEAD
+   test -z "$(git ls-tree -d --name-only HEAD btrace-maven-plugin)"
+   test -z "$(git ls-files btrace-maven-plugin)"
+   test -z "$(find btrace-maven-plugin -mindepth 1 -print -quit 2>/dev/null)"
+   test ! -e docs/tutorials/demo/fat-agent-pom.xml
+   ```
+
+2. Categorize every hit as one of:
+
+   - active public dependency, command, Maven plugin/application guidance, plugin JavaDoc, executable
+     sample, release task, or production resolver — must be removed/migrated;
+   - active source module/path notation — allowed only when it cannot be read as a public Maven GAV;
+   - historical architecture/removal wording — allowed only when it explicitly says the module or GAV
+     is internal, deleted, or non-installable;
+   - `internal/plans/`, `internal/specs/`, or other historical internal records — classify and retain
+     as evidence rather than rewriting accepted history merely to make `rg` empty.
+
+3. `9bd52b9b` (PR #900) must be an ancestor of `HEAD`; stop the implementation if it is not. Also
+   require the tracked-tree checks above to show no module. This current checkout may retain an empty,
+   ignored worktree directory at `btrace-maven-plugin/`; it is not a restored module and must be left
+   untouched. Stop and obtain direction if that ignored directory contains build/source/resource files
+   or becomes tracked, rather than deleting user work. Confirm no `btrace-maven-plugin` entry in
+   `settings.gradle`, no tracked source/resource/plugin descriptor path, no documentation demo POM,
+   and no release task, summary, Central wait check, or artifact list can select/name it. PR #900
+   removal wording is the only permitted historical reference.
+4. Record the allowed release contract: Central stages only `io.btrace:btrace`; Plugin Portal handles
+   only the implementation plus markers for `io.btrace.extension` and `io.btrace.fat-agent`.
+
+**Pass:** PR #900 is verified in `HEAD`, every active occurrence has a migration/deletion
+disposition, and the Maven plugin is absent from the tracked source, build, resources, demo, settings,
+release, and public installation surfaces.
+
+## Gate 1 — pin external Gradle plugin resolution to the masked engine
+
+**Production files:**
+
+- `btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceExtensionPlugin.groovy`
+- `btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentExtension.groovy`
+- `btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy`
+- add one package-private version-resolution helper in
+  `btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/` if that prevents duplicate validation.
+
+**Focused tests:**
+
+- `btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceExtensionPluginTest.java`
+- `btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceFatAgentPluginTest.java`
+- reusable fixtures only under `btrace-gradle-plugin/src/test/resources/`; otherwise use each
+  TestKit test's temporary project directory.
+
+1. Add a DSL `btraceVersion` (or clearly equivalent documented setting) which is independent of the
+   extension author's `project.version` and `btraceExtension.version`.
+2. Make the published plugin implementation JAR carry its concrete release value in
+   `Implementation-Version`; add one helper which reads that version from the loaded plugin class's
+   package/code source. This manifest attribute is the sole implicit default. If it is unavailable in
+   TestKit/development, require explicit `btraceVersion`; never guess from the consumer project.
+3. Validate before resolving: reject null/blank, `+`, ranges/selectors, `unspecified`, and release
+   publication snapshot/mismatch values with an actionable message naming the required setting.
+4. Preserve the in-tree `project(':btrace-core')` annotation-processor branch exactly. In an external
+   root with no sibling core project, add only
+   `io.btrace:btrace:<validated-btraceVersion>` to `annotationProcessor`.
+5. Replace `BTraceFatAgentPlugin.findBTraceCompiler()`'s dynamic `btrace-client:+` resolution with
+   the same pinned `io.btrace:btrace:<validated-btraceVersion>`. For the masked artifact, launch
+   `io.btrace.boot.Loader` with `-Dbtrace.client.main=io.btrace.compiler.Compiler`, pass the existing
+   compiler arguments, and require a zero exit status. Do not use a conventional client JAR classpath
+   or revive any withdrawn GAV.
+6. Define the external fat-agent engine assembly path. Create one non-consumable, resolvable
+   configuration/provider (for example `btraceEngine`) that is populated with exactly
+   `io.btrace:btrace:<validated-btraceVersion>` and exposes one resolved masked JAR. Register a lazy
+   unpack/staging task fed by that provider; `fatAgentJar` must depend on it and package its staged
+   contents. The external consumer path must work with no `agentJarTask`, `bootJarTask`, sibling
+   project, or `includeBuild`.
+7. Seed the output manifest from the resolved engine's original manifest before adding any fat-agent
+   attributes. Preserve the masked engine's `Main-Class`, `Premain-Class`, `Agent-Class`, loader/main
+   routing attributes, and BTrace metadata; only add/adjust the documented fat-agent attributes such
+   as embedded-extension information. Do not generate a fresh manifest from hard-coded entry points,
+   and do not overlay a separate boot JAR. Keep explicit in-tree producer-task compatibility only when
+   it produces the same masked engine contract.
+8. Make the unpacked engine provider a declared task input and validate the final artifact against
+   both the required `io/btrace/boot/Loader.class`/masked entries and the preserved manifest contract.
+   A missing, conventional, or mismatched input JAR must fail before a fat-agent output is accepted.
+9. Add TestKit coverage proving:
+
+   - in-tree annotation processing remains the project dependency;
+   - an external project with deliberately different project/extension versions records exactly the
+     configured `io.btrace:btrace:<btraceVersion>` dependency;
+   - a separately resolved, locally published plugin implementation with a manifest version permits
+     omitted DSL `btraceVersion` and uses that exact version; TestKit classpath execution without the
+     manifest fails with the explicit-setting remedy;
+   - missing/blank/dynamic/ranged values fail before dependency resolution;
+   - an external consumer with no agent/boot task resolves the single pinned `btraceEngine`, runs
+     `fatAgentJar`, and unpacks its local masked-JAR fixture. Assert the exact GAV request, the
+     dependency/staging task relationship, Loader and representative `META-INF/btrace/` entries, and
+     that the output's required Loader/agent manifest attributes match the source engine;
+   - `bundledProbes.fromSource(...)` resolves only pinned `btrace`, launches Loader with the client
+     main property, compiles a valid minimal probe from a locally published masked-JAR fixture, and
+     creates the expected probe output. Skipping compilation, warning-only behavior, a nonzero exit,
+     or any client/core GAV request fails the test.
+
+**Commands:**
+
+```sh
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew -p btrace-gradle-plugin test > /tmp/issue-884-gradle-plugin.log 2>&1
+rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|BTraceExtensionPluginTest|BTraceFatAgentPluginTest" /tmp/issue-884-gradle-plugin.log
+rg -n "io\\.btrace:btrace-(core|client):|btrace-client:\+" btrace-gradle-plugin/src/main btrace-gradle-plugin/src/test
+```
+
+**Pass:** external resolution and base assembly are exactly the single pinned masked `btrace` engine;
+the monorepo path remains intact; no dynamic, separate boot, or withdrawn engine/client coordinate
+remains.
+
+## Gate 2 — remove obsolete public documentation and Maven-fat-agent remnants
+
+**Files to inspect/change according to Gate 0:**
+
+- `README.md`
+- `docs/GettingStarted.md`
+- `docs/QuickReference.md`
+- `docs/BTraceExtensionDevelopmentGuide.md`
+- `docs/architecture/migrating-from-libs-profiles.md`
+- `docs/architecture/fat-agent-plugin.md`
+- `docs/tutorials/06-write-your-own-extension.md`
+- `docs/tutorials/08-fat-agent.md`
+- delete `docs/tutorials/demo/fat-agent-pom.xml`
+- `btrace-gradle-plugin/README.md`
+- `btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentExtension.groovy`
+- `btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy`
+- `docs/releasing.md`, `docs/ReleaseChecklist.md`, and `.github/workflows/release.yml` wherever
+  Gate 0 finds Maven-plugin release/application wording.
+
+1. Migrate every direct JBang command from `io.btrace:btrace-client:<version>` to
+   `io.btrace:btrace:<version>`; retain `jbang btrace` and explain the masked JAR's `Main-Class`
+   dispatch only where useful.
+2. Replace BTrace-owned Gradle extension GAV examples (including metrics, statsd, and the
+   `btrace-kafka` JavaDoc examples) with actual built/distribution extension ZIP paths used by
+   `file(...)`. Retain `project(...)` for in-tree/custom extensions; state that `maven(...)` is only
+   for third-party extensions which their publisher actually makes available.
+3. Remove all Maven fat-agent sections, Maven embedding snippets, `<extension>` examples, demo-POM
+   links/copies, and Maven plugin installation/application claims. Redirect the deployment use case
+   to the Gradle `file(...)`/`project(...)` workflow; do not translate Maven XML into a fictitious ZIP
+   parameter.
+4. Remove public `btrace-maven-plugin` and `FatAgentMojo` mentions. Where a release/removal history
+   must retain one, label it explicitly "deleted by PR #900; non-installable" and do not include an
+   invocation or coordinate users could copy.
+5. For extension-author documentation, first compile the documented external project against
+   `io.btrace:btrace`. Use that dependency only if the regular masked-JAR entries expose the required
+   API; otherwise document the supported source/distribution path and file a follow-up API issue —
+   never restore `btrace-core` as a public coordinate.
+6. Use only normal Plugin Portal consumer snippets:
+
+   ```groovy
+   plugins {
+       id 'io.btrace.extension' version '<release-version>'
+       // or: id 'io.btrace.fat-agent' version '<release-version>'
+   }
+   ```
+
+   Do not advertise Maven Central marker GAVs, `resolutionStrategy`, or local `includeBuild` as the
+   public installation mechanism.
+
+**Commands:**
+
+```sh
+rg -n --hidden --glob '!**/build/**' --glob '!.git/**' --glob '!.gradle-user/**' \
+  "io\\.btrace:btrace-[[:alnum:]_.-]+|btrace-maven-plugin|FatAgentMojo|fat-agent-pom" .
+rg -n --hidden --glob '!**/build/**' --glob '!.git/**' --glob '!.gradle-user/**' \
+  "jbang io\\.btrace:btrace-client|maven\('io\\.btrace:btrace-|<extension>io\\.btrace:btrace-" .
+test ! -e docs/tutorials/demo/fat-agent-pom.xml
+```
+
+Manually classify remaining internal historical hits. Every other public, executable, JavaDoc, or
+production-resolver hit must be removed or migrated.
+
+**Pass:** no public consumer guidance claims a deleted Maven plugin, Maven fat-agent path, or
+unpublished BTrace module/extension coordinate; the Gradle local-package route is actionable.
+
+## Gate 3 — configure Plugin Portal-only publication and version/signing safeguards
+
+**Files:**
+
+- `btrace-gradle-plugin/build.gradle`
+- `btrace-gradle-plugin/settings.gradle` only if it is actually introduced for plugin management
+- `.github/workflows/release.yml`
+- `docs/releasing.md`, `docs/ReleaseChecklist.md`, and Portal-facing snippets identified in Gate 2.
+
+1. Keep `btrace-dist` as the only Central publication. Do not add Central repositories, publications,
+   signing work, or sources/Javadoc tasks for a removed Maven plugin.
+2. Apply a pinned Gradle-compatible `com.gradle.plugin-publish` plus `signing` in the included Gradle
+   build; retain `java-gradle-plugin`. Configure Portal metadata (site, VCS, descriptions, useful
+   tags) and Portal-supported signing for both IDs. Do not publish their implementation or markers to
+   Maven Central.
+3. Make `-PbtraceVersion=<release-version>` the included build's mandatory release contract. It must
+   drive the implementation JAR manifest, implementation publication, and both marker POM versions.
+   A visibly development-only fallback is acceptable locally; remote publication must fail early for
+   missing, snapshot, unspecified, dynamic, or mismatched values.
+4. Keep `stage-maven` limited to
+   `:btrace-dist:publishAllPublicationsToSonatypeRepository`, with Central credentials/GPG material
+   for `io.btrace:btrace` only. Its artifact summary and Central wait check must name/check only that
+   artifact.
+5. Add an explicitly dependent Portal publish job from the same RC tag. Run
+   `./gradlew -p btrace-gradle-plugin -PbtraceVersion=${{ inputs.release_version }} publishPlugins --validate-only`
+   before the real `publishPlugins`, injecting `GRADLE_PUBLISH_KEY` and `GRADLE_PUBLISH_SECRET` only
+   for Portal upload. Report both IDs, exact version, validate-only result, upload result, and a
+   bounded `gradlePluginPortal()` availability check.
+6. Wire `finalize-tag`, `create-github-release`, downstream public-release consumers, and `summary`
+   to require both successful `wait-for-maven` and Portal availability. The summary must separately
+   list Central's sole `btrace` artifact and both Portal IDs/statuses; no final tag or GitHub release
+   may claim plugin availability before both IDs resolve.
+
+**Commands/evidence:**
+
+```sh
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew -p btrace-gradle-plugin -PbtraceVersion=<release-version> publishPlugins --validate-only > /tmp/issue-884-plugin-portal-validate.log 2>&1
+rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|validate|publish" /tmp/issue-884-plugin-portal-validate.log
+```
+
+Inspect the implementation POM and both marker POMs in the isolated publication repository; each
+must have exactly `<release-version>`. Re-run remote-publication configuration with missing and
+mismatched `btraceVersion` and require failure before upload. Any quality/format task configured for
+the included build must be invoked with `./gradlew -p btrace-gradle-plugin <task>`, never as a root
+subproject task.
+
+**Pass:** only `btrace` is Central-ready; the two Gradle plugin IDs/markers are Portal-ready, signed,
+and version-locked to the release property.
+
+## Gate 4 — hermetic pre-release functional E2E
+
+**Integration implementation:**
+
+- add `integration-tests/src/test/java/tests/Issue884PublishedFatAgentE2ETest.java`, reusing the
+  process/attach/protocol utilities in `integration-tests/src/test/java/tests/RuntimeTest.java` and
+  target fixtures in `integration-tests/src/test/java/resources/`;
+- add one minimal dedicated probe/target resource under `integration-tests/src/test/java/resources/`
+  only if existing `TestApp`/script fixtures cannot make an unambiguous observable assertion;
+- add test build wiring in `integration-tests/build.gradle` only if the scenario cannot obtain the
+  existing distribution/integration-test outputs through current tasks.
+
+1. Build the exact release-version masked engine, then publish only
+   `io.btrace:btrace:<release-version>` and the Gradle plugin implementation plus both marker
+   artifacts to an isolated temporary Maven repository. Do not query Maven Central or the Plugin
+   Portal for pre-release evidence.
+2. Create a standalone temporary Gradle consumer with a fresh `GRADLE_USER_HOME`, no sibling BTrace
+   projects, no `includeBuild`, and no TestKit plugin-classpath injection. Its
+   `pluginManagement.repositories` and normal dependency repositories point solely at the isolated
+   repository. Resolve both marker IDs through normal `plugins {}` declarations; use the fat-agent
+   plugin's external `btraceEngine` provider path (with no `agentJarTask` or `bootJarTask`) to build
+   a fat agent from the exact masked engine.
+3. Configure the consumer with an explicit release `btraceVersion` in one run and a second run with
+   the setting omitted, proving the locally published plugin implementation's `Implementation-Version`
+   supplies the exact release version. Record resolved component IDs/GAVs and assert no
+   `btrace-core`, `btrace-client`, agent/boot, extension, Maven-plugin, dynamic, or external
+   repository dependency is used.
+4. Assert that the generated fat agent contains the locally resolved engine's Loader and masked
+   entries and preserves its required Loader/agent manifest attributes before starting it. Start a
+   real target JVM with that generated fat agent. From the *locally published masked*
+   `io.btrace:btrace:<release-version>` artifact, invoke the real BTrace client to dynamically attach
+   to that target and submit a real probe. The client/agent interaction must use the actual attach and
+   wire-protocol path, not an in-process `Client` mock or agent-startup-only assertion.
+5. Wait for and assert a deterministic observable probe effect (for example a uniquely formatted
+   probe output line caused by an exercised target method). Capture child-process stdout/stderr,
+   attach exit status, protocol completion, and cleanup/timeout diagnostics. A successful agent JVM
+   launch without an attach, probe submission, and observable output is a test failure.
+6. Inspect the masked engine and generated fat-agent manifests/entries with `jar tf` and `unzip -p`:
+   `Main-Class`, `Premain-Class`, `Agent-Class`, and representative `META-INF/btrace/` content must
+   survive. This test is required integration coverage for a user-visible cross-process behavior;
+   TestKit and unit tests in Gate 1 do not substitute for it.
+
+**Commands:**
+
+```sh
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-dist:build > /tmp/issue-884-dist.log 2>&1
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:test > /tmp/issue-884-integration.log 2>&1
+rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Issue884PublishedFatAgentE2ETest|tests" /tmp/issue-884-dist.log /tmp/issue-884-integration.log
+jar tf <isolated-repo-btrace-jar> | rg "META-INF/btrace|io/btrace/boot/Loader"
+unzip -p <generated-fat-agent.jar> META-INF/MANIFEST.MF
+```
+
+**Pass:** an isolated ordinary consumer resolves local markers/engine, creates a fat agent, and a
+real locally published BTrace client attaches to a real agent target, sends a probe, and observes its
+expected effect.
+
+## Gate 5 — release smoke and final audit
+
+1. After real Central release and Plugin Portal approval only, use a clean standalone consumer with
+   default `gradlePluginPortal()` to apply both public IDs and Maven Central to resolve
+   `io.btrace:btrace:<release-version>`. Record exact Portal URLs, Central URL, IDs, versions, and
+   output; local success does not substitute for this external state.
+2. Re-run Gate 0's root-level inventory and manually classify the internal historical results. Verify
+   there is no active module directory/source/resources/demo/settings/release reference to the Maven
+   plugin and no production resolver/public consumer reference to a withdrawn GAV.
+3. Run final verification, always reading filtered logs:
+
+   ```sh
+   GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew -p btrace-gradle-plugin test > /tmp/issue-884-gradle-plugin.log 2>&1
+   GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-dist:build > /tmp/issue-884-dist.log 2>&1
+   GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:test > /tmp/issue-884-integration.log 2>&1
+   GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew spotlessCheck > /tmp/issue-884-spotless.log 2>&1
+   rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|tests" /tmp/issue-884-*.log
+   git diff --check
+   ```
+
+4. Before committing, compare the final changed-file list to Gates 1–4 and preserve unrelated
+   changes. The PR description/release evidence must state the release value, `-PbtraceVersion`,
+   isolated repository, three exact publication POM versions, signed Portal commands, E2E target/
+   client/probe observable result, manifest proof, and post-release Central/Portal availability.
+
+**Completion criteria:**
+
+- `btrace-maven-plugin`, its source/resources/build/release/demo/install surface, and any active
+  Maven fat-agent guidance remain deleted; historical wording is explicitly non-installable.
+- `btrace-dist` remains the sole Maven Central engine/library artifact.
+- External Gradle consumers resolve only pinned `io.btrace:btrace:<btraceVersion>` and use neither
+  dynamic selectors nor withdrawn module coordinates; in-tree processing still uses its project
+  dependency.
+- Both public Gradle plugin markers and implementation publish through the Plugin Portal with exact
+  release version and signing; Central never receives markers or a Maven plugin.
+- The isolated pre-release E2E has proven normal marker resolution, generated-fat-agent startup, real
+  client attach/probe protocol flow, and observable output using the exact locally published engine.

--- a/internal/specs/2026-07-16-issue-884-withdraw-unpublished-maven-coordinates.md
+++ b/internal/specs/2026-07-16-issue-884-withdraw-unpublished-maven-coordinates.md
@@ -1,0 +1,402 @@
+# Issue #884: Withdraw unpublished Maven coordinates
+
+## Status and decision
+
+**Issue:** [#884](https://github.com/btraceio/btrace/issues/884), "[3.0] Published Maven surface omits coordinates the README and plugins resolve".
+
+**Final operator decision:** retain PR #900's deletion of the Maven fat-agent plugin. The single
+public Maven Central artifact is `io.btrace:btrace`. `btrace-maven-plugin` must be absent from the
+repository, build, release surface, and all public installation/application documentation. Explicit
+historical or removal-status wording is allowed where needed to record PR #900, provided it clearly
+states that the plugin is deleted and non-installable. BTrace must not document, restore, publish, or
+internally require published `btrace-core`, `btrace-agent`, `btrace-boot`, `btrace-client`,
+`btrace-runtime`, `btrace-compiler`, `btrace-maven-plugin`, or `btrace-extensions/*` coordinates.
+
+The two Gradle plugins are the explicit exception: `io.btrace.extension` and
+`io.btrace.fat-agent` are supported public plugins and must be published through the Gradle Plugin
+Portal. Publishing those plugins must never be used to publish the withdrawn engine/library,
+extension, or Maven-plugin modules.
+
+## Context
+
+`btrace-dist` produces the signed `io.btrace:btrace` publication.  The release workflow currently
+stages only `:btrace-dist:publishAllPublicationsToSonatypeRepository`.  It is a masked, self-contained
+JAR: its manifest uses `io.btrace.boot.Loader` for `Main-Class`, `Premain-Class`, and `Agent-Class`;
+the agent, client, compiler, boot, core API, and runtime support are deliberately packaged within it.
+See [Masked JAR Architecture](../../docs/architecture/MaskedJarArchitecture.md).
+
+The repository nevertheless exposes paths that resolve unpublished module or extension GAVs.  They
+fail for a released build even though the normal distribution/JBang alias path works.  These failures
+are an inaccurate public contract, not a request to publish the individual modules.
+
+## Goals
+
+1. Make every supported external engine dependency resolve `io.btrace:btrace:<btrace-version>`.
+2. Make the external Gradle extension-plugin annotation-processor fallback resolve the same masked
+   distribution rather than `btrace-core`.
+3. Remove user-facing instructions that present bundled BTrace extensions as Maven Central artifacts,
+   Maven fat-agent support, or the deleted Maven plugin.
+   Teach users to use the extension packages bundled with a BTrace distribution or an extension ZIP
+   they built/obtained separately.
+4. Publish and sign the public Gradle plugins to the Gradle Plugin Portal for 3.0, including marker
+   artifacts.
+5. Preserve the in-tree build path and the existing masked-JAR layout/loader behavior.
+
+## Non-goals
+
+- Publishing or signing individual BTrace library modules or BTrace extension modules.
+- Changing the masked-JAR class partitioning, manifest entry points, or loader behavior.
+- Restoring, reimplementing, testing, or publishing `btrace-maven-plugin` or its `fat-agent` goal.
+  The module is intentionally deleted and must not remain as dormant source or build configuration.
+- Removing support for third-party extension Maven repositories.  The generic `maven(...)` extension
+  source remains valid for coordinates that their publishers actually publish; only BTrace-owned,
+  unpublished examples and implied support are withdrawn.
+- Changing local-project or local-file extension embedding.
+
+## Affected components and required changes
+
+### 1. Gradle extension plugin external fallback
+
+**Files:**
+
+- `btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceExtensionPlugin.groovy`
+- `btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentExtension.groovy`
+- `btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy`
+- focused TestKit/unit tests under `btrace-gradle-plugin/src/test/`
+
+Keep the in-tree branch, which supplies `project(':btrace-core')`, unchanged.  In the external branch
+where the root project has no `:btrace-core`, register `io.btrace:btrace:<version>` on
+`annotationProcessor` rather than `io.btrace:btrace-core:<version>`.
+
+The fallback version must be BTrace's version, not the extension author's arbitrary
+`project.version`.  Add a `btraceVersion` setting to the extension-plugin DSL (or an equivalently
+named, documented setting) which defaults to the published plugin's implementation version.  Validate
+an explicit value as a non-empty, concrete release/version selector before dependency creation; when
+the implementation version is unavailable in a development/TestKit environment, require the explicit
+setting instead of guessing.  Use that resolved BTrace version for the external
+`annotationProcessor` dependency.  It is independent of `btraceExtension.version`, which remains the
+version of the extension being built.
+
+Tests must verify all of the following: the in-tree branch remains a project dependency; an external
+synthetic project with a deliberately different project/extension version requests exactly
+`io.btrace:btrace:<btraceVersion>`; and missing/invalid BTrace version configuration fails with an
+actionable error rather than resolving a dynamic or project-derived coordinate.
+
+#### Gradle fat-agent compiler lookup
+
+`BTraceFatAgentPlugin.findBTraceCompiler()` also dynamically resolves the withdrawn
+`io.btrace:btrace-client:+` coordinate for `bundledProbes.fromSource(...)`.  Replace it with the
+version-pinned `io.btrace:btrace:<btraceVersion>` engine artifact, using the same validated
+BTrace-version source (published plugin implementation version or explicit `btraceVersion`) as above.
+Never use `+`, a version range, or an extension project's version.
+
+The implementation must make the masked distribution usable by the probe-compilation path rather
+than assuming a conventional standalone `btrace-client` JAR.  It may use the distribution's supported
+loader/CLI entry point if `io.btrace.compiler.Compiler` is not directly classpath-loadable from the
+masked JAR; it must not restore an unpublished dependency as a workaround.  Add a TestKit regression
+that records the configured/resolved dependency and runs the source-probe path against a minimal
+locally published masked `btrace` fixture.  It must prove the exact pinned GAV and successful probe
+compilation (or a clear, non-resolution failure if the fixture intentionally lacks compiler content).
+
+### 2. Public documentation and examples
+
+**Primary files known to contain invalid BTrace-owned coordinates:**
+
+- `README.md`
+- `docs/GettingStarted.md`
+- `docs/QuickReference.md`
+- `docs/BTraceExtensionDevelopmentGuide.md`
+- `docs/architecture/migrating-from-libs-profiles.md`
+- `docs/architecture/fat-agent-plugin.md`
+- `docs/tutorials/06-write-your-own-extension.md`
+- `docs/tutorials/08-fat-agent.md`
+- `docs/tutorials/demo/fat-agent-pom.xml`
+- `btrace-gradle-plugin/README.md`
+- JavaDoc/examples in `btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy`
+
+The implementation must perform a repository-wide final search rather than limiting itself to this
+list.  User-facing documentation may not advertise any of these as resolvable BTrace artifacts:
+
+```
+io.btrace:btrace-client
+io.btrace:btrace-agent
+io.btrace:btrace-boot
+io.btrace:btrace-core
+io.btrace:btrace-runtime
+io.btrace:btrace-compiler
+io.btrace:btrace-metrics
+io.btrace:btrace-statsd
+io.btrace:btrace-kafka-extension
+io.btrace:btrace-flink-extension
+io.btrace:btrace-maven-plugin
+```
+
+#### CLI/JBang migration
+
+Change direct JBang invocations from:
+
+```
+jbang io.btrace:btrace-client:<version> <PID> <script.java>
+```
+
+to:
+
+```
+jbang io.btrace:btrace:<version> <PID> <script.java>
+```
+
+Explain, where appropriate, that the masked JAR dispatches to the client through its `Main-Class`.
+Retain the `jbang btrace` alias path.
+
+#### Extension/embed migration
+
+Replace **Gradle** examples such as `maven('io.btrace:btrace-metrics:...')` with a supported
+local-file/package workflow.  The documentation must state both facts below:
+
+1. Built-in extensions are distributed in the BTrace distribution's `extensions/` directory as
+   extension packages (and may be obtained by building `packageExtension` in a source checkout).
+2. `file(...)` is the supported way to embed one of those packages in a fat agent; `project(...)`
+   remains the supported in-tree/custom project option.  `maven(...)` is only for a separately
+   published third-party extension, not BTrace's bundled extensions.
+
+Examples must use an actual package filename/path appropriate to the consuming tool rather than
+inventing an unpublished GAV.  Preserve tutorial-specific explanations of an extension ZIP's expected
+extension ID and packaging layout.
+
+`file(...)` is a Gradle fat-agent DSL feature only. Remove all Maven fat-agent embedding examples,
+Maven demo POM configuration, and Maven-plugin installation/application guidance. Do not replace
+Maven `<extension>` elements with ZIP paths and do not describe a Gradle `file(...)` package as a
+Maven capability. Redirect users who need an embedded extension to the documented Gradle
+file/project workflow. `btrace-maven-plugin` and its `fat-agent` goal are deleted; no future Maven
+local-package feature is in scope for this issue.
+
+For the extension-development tutorial, replace compile-only `btrace-core` dependencies with the
+supported `btrace` artifact only if its regular class entries provide the needed extension API.  The
+implementation gate below requires compiling the documented external consumer before this claim is
+published.  If that artifact cannot provide the required API, do not reintroduce a private GAV:
+document the supported distribution/source-based extension-development route and record the missing
+public API as a separate issue.
+
+### 3. Required Gradle-plugin publication workstream
+
+**Files:**
+
+- `btrace-gradle-plugin/build.gradle`
+- `btrace-gradle-plugin/settings.gradle` if the Plugin Publish plugin/version is centrally declared
+- `.github/workflows/release.yml`
+- release-facing README/documentation that names a plugin application coordinate
+
+`btrace-gradle-plugin` currently applies `maven-publish`, but does not yet apply `signing` or configure
+the Gradle Plugin Portal. It is an included build, not a root subproject, so its publication tasks
+must be invoked through that build explicitly. The existing `stage-maven` job invokes only
+`:btrace-dist:publishAllPublicationsToSonatypeRepository`; it cannot publish the Gradle plugins.
+
+#### Included-build release-version contract
+
+The Gradle plugin build has an independent root and currently sets `version = rootProject.version`.
+When it is run as an included build, that root has no release version supplied by the main build;
+publishing it would otherwise produce an unspecified or stale version.  Define one explicit shared
+release property, `btraceVersion`, consumed by `btrace-gradle-plugin/build.gradle`.  For a release,
+`-PbtraceVersion=${{ inputs.release_version }}` is mandatory, must be validated as the workflow's
+concrete release version, and must become the version of the implementation publication and both
+plugin-marker publications.  A normal development build may retain a clearly identified development
+fallback, but any non-local publication must fail rather than publish an unspecified, snapshot, or
+mismatched version.
+
+The release workflow must pass the exact same release version to every publication command.  In
+particular, it must invoke the included build independently, for example using
+`./gradlew -p btrace-gradle-plugin -PbtraceVersion=${{ inputs.release_version }} <publish-task>`;
+root-build task paths do not publish its artifacts.  Apply this rule to its local/staging verification
+commands as well as its real Plugin Portal release command.
+
+#### Required artifacts and binding publication channels
+
+The Gradle plugins must publish through the **Gradle Plugin Portal**, not Maven Central. Add and
+configure a pinned, Gradle-compatible `com.gradle.plugin-publish` version in
+`btrace-gradle-plugin`, retaining `java-gradle-plugin` and the metadata required by the Portal.
+Publish the implementation and marker artifacts for both
+`io.btrace.extension` and `io.btrace.fat-agent`. Supply a website, VCS URL, descriptions, and useful
+tags/categories in the `gradlePlugin` metadata so the Portal review and consumer listing are complete.
+Apply `signing` so Portal-published artifacts are signed through the Plugin Publish plugin's supported
+signing integration.
+
+The public installation examples must use the ordinary Portal consumer route:
+
+```groovy
+plugins {
+    id 'io.btrace.extension' version '<release-version>'
+    // or: id 'io.btrace.fat-agent' version '<release-version>'
+}
+```
+
+Consumers may use the default `gradlePluginPortal()` repository (or explicitly add it in
+`pluginManagement.repositories`). Do not document a Maven Central marker coordinate or a
+`resolutionStrategy` workaround for these public plugins. The maintainer decision does not permit
+relying on the repository's local `includeBuild` behavior as a release mechanism.
+
+#### Signing and release workflow
+
+Keep the existing signing/release-safe GPG configuration solely for the `io.btrace:btrace` Central
+publication. Configure the Gradle plugin's `signing` integration for Plugin Portal publication. Add
+the required CI secrets:
+
+- Central Portal token/user credentials and the GPG signing key/password for
+  `io.btrace:btrace` only.
+- `GRADLE_PUBLISH_KEY` and `GRADLE_PUBLISH_SECRET` for the Gradle Plugin Portal API key/secret.
+
+Keep `stage-maven` limited to publishing `io.btrace:btrace` to Maven Central from the release-candidate
+tag. Add a separate, explicitly dependent Plugin Portal publish job that invokes the included build with
+`./gradlew -p btrace-gradle-plugin -PbtraceVersion=${{ inputs.release_version }} publishPlugins` and
+the Portal credential environment variables. Before that real upload, run the identical included-build
+command with `publishPlugins --validate-only`. Do not assume the `pluginManagement { includeBuild(...) }`
+declaration exposes publication tasks on the root build.
+
+The Central staging summary must list `io.btrace:btrace` only, never the deleted Maven plugin or
+Gradle plugin markers. Preserve the manual Central Portal review/release step for that artifact.
+The Portal job must report both IDs, their version, the validate-only result, upload result, and the
+Portal availability check. Initial Portal approval can delay public availability; the release must
+surface that status explicitly and must not claim that either Gradle plugin is installable until the
+Portal resolves it.
+
+No release job may publish `btrace-core`, `btrace-agent`, `btrace-boot`, `btrace-client`, runtime,
+compiler, `btrace-maven-plugin`, or BTrace extension modules. The Gradle plugins are supported tools,
+not a precedent for publishing the internal modules that they use.
+
+## Compatibility and migration
+
+| Previous unsupported flow | Supported replacement |
+| --- | --- |
+| `jbang io.btrace:btrace-client:<version> ...` | `jbang io.btrace:btrace:<version> ...` or `jbang btrace ...` |
+| Maven fat-agent/plugin documentation | Deleted; use the documented Gradle fat-agent `file(...)` or `project(...)` workflow |
+| External Gradle plugin resolves `btrace-core` processor | It resolves `io.btrace:btrace:<version>`; source extensions use the documented supported dependency route |
+| `maven('io.btrace:btrace-metrics:...')` | `file('<path-to-btrace-metrics-extension-package>')`, or a local project |
+| Maven `<extension>io.btrace:btrace-metrics:...</extension>` | Withdrawn; use the documented Gradle `file(...)` or `project(...)` embedding workflow |
+| In-repo `includeBuild` makes Gradle plugins available | Release users apply `io.btrace.extension` or `io.btrace.fat-agent` by version through the Gradle Plugin Portal |
+| Maven fat-agent plugin exists in a source checkout | Deleted; no module, build inclusion, demo, or release surface remains |
+
+This is a correction before/for 3.0.  No compatibility promise is made for the withdrawn GAVs because
+they were never released.  The documentation must make the reason visible enough that a user does not
+mistake an unavailable Central lookup for a temporary repository outage.
+
+## Implementation gates
+
+1. **Inventory/deletion gate:** record all BTrace-owned GAV occurrences with `rg`; categorize each as
+   source module notation (allowed), historic/architecture explanation (allowed only when explicitly
+   marked non-published), or an external-consumer resolution/example (must change). Confirm that
+   `btrace-maven-plugin/` is absent in full: its `build.gradle`, all `src/main`, `src/test`, and
+   resources, generated plugin descriptor, and every build artifact/configuration are gone. Confirm
+   `docs/tutorials/demo/fat-agent-pom.xml` is deleted, `settings.gradle` has no inclusion/reference,
+   and no release workflow task can select it. Historical documentation may mention the deleted plugin
+   only when explicitly labelled historical and non-installable.
+2. **Gradle fallback gate:** change the external annotation processor fallback and test it without a
+   sibling `:btrace-core` project; retain a regression test for in-tree behavior.
+3. **Documentation gate:** migrate every external resolution/example and update `docs/README.md` only
+   if a guide is added or renamed (none is expected).
+4. **Maven deletion gate:** remove Maven fat-agent examples and Maven plugin installation/application
+   guidance. Verify `rg` finds no user-facing `btrace-maven-plugin`, `FatAgentMojo`, or BTrace-owned
+   Maven extension GAV as a supported flow; any historic mention must meet the inventory gate's
+   explicit non-installable wording.
+5. **Pinned-resolution gate:** add TestKit coverage for the external extension plugin and fat-agent
+   source-probe lookup.  It must use a deliberately different extension project version and a pinned
+   BTrace version, observe only `io.btrace:btrace:<btraceVersion>`, and reject missing/invalid version
+   settings.  No dynamic `+` or BTrace client/core module lookup may remain.
+6. **Plugin Portal configuration gate:** apply `com.gradle.plugin-publish`, configure both public IDs
+   and their Portal metadata, and run
+   `./gradlew -p btrace-gradle-plugin -PbtraceVersion=<release-version> publishPlugins --validate-only`
+   with Portal credentials. The validation must pass before upload.
+7. **Plugin signing gate:** run the Gradle Plugin Portal validate-only task with the configured
+   signing integration and fail the release candidate early if the required Central or Portal
+   credentials are absent.
+8. **Included-build version gate:** invoke the Gradle plugin's independent publish task with
+   `-PbtraceVersion=<release-version>`, inspect the implementation POM and both marker POMs in the
+   local/staging repository, and assert each `<version>` is exactly `<release-version>`.  Repeat with
+   the property missing and with a mismatch to prove a release publication fails safely.
+9. **Release-workflow gate:** exercise the release publishing commands from a release-version checkout
+   (or a non-destructive dry-run/test repository equivalent) and verify that the distribution, Maven
+   Central engine artifact and Plugin Portal Gradle-plugin artifacts are all selected with the exact
+   release property. Review the Central and Portal job summaries.
+10. **Hermetic external-consumer gate:** publish a release-version `btrace-dist` artifact and the
+    Gradle plugin implementation plus both marker artifacts to an isolated local/staging Maven
+    repository.  Run a standalone Gradle project with no sibling BTrace projects and an isolated
+    Gradle cache.  It must use `pluginManagement.repositories { maven { ... } }` and a normal
+    `plugins { id 'io.btrace.extension' version '<release-version>' }` (and, separately, the
+    `io.btrace.fat-agent` ID) to resolve the published marker and implementation artifacts.  It must
+    not use TestKit plugin classpath injection or `includeBuild`.  Its normal dependency repository
+    must resolve/compile only the exact `io.btrace:btrace:<release-version>` GAV.  This is the
+    pre-release proof; it must not depend on a previously released Central artifact.
+11. **Post-release smoke gate:** after the maintainer releases the Central staging repository and the
+    Plugin Portal accepts/publishes both IDs, run the standalone consumer against Maven Central and
+    resolve/apply the public Gradle plugins through `gradlePluginPortal()`. Record the artifact
+    versions, Portal URLs, and check output in the release evidence.
+12. **Pre-release end-to-end gate:** locally publish the exact-release masked engine and Gradle plugin
+   implementation plus both marker artifacts to the isolated test repository. A standalone build must
+   apply the plugins through normal `plugins {}` marker resolution from that repository (never
+   `includeBuild` or TestKit classpath injection), build a fat agent, and launch a real target JVM
+   using that generated agent. Invoke the real BTrace client from the locally published masked
+   `io.btrace:btrace:<release-version>` artifact to attach to the target and send a probe. Assert the
+   probe's observable result, thereby exercising the client-to-agent attach/protocol path rather than
+   merely proving that an agent starts. Add or extend this as an `integration-tests` scenario. Gradle
+   Plugin Portal resolution is a post-release smoke only; unit and TestKit coverage do not replace
+   this client, agent, target-JVM, and protocol path.
+
+## Acceptance criteria
+
+- No supported/public consumer path resolves `io.btrace:btrace-agent`, `btrace-boot`, `btrace-core`,
+  `btrace-maven-plugin`, or any other withdrawn BTrace module from Maven Central.
+- `btrace-maven-plugin` is absent: no module directory, build script, main/test/resource source,
+  plugin descriptor, demo POM, settings inclusion, release task, or user-facing installation guide
+  remains. Historical documentation, if retained, explicitly calls it deleted and non-installable.
+- An external Gradle extension project records/resolves `io.btrace:btrace:<version>` as its annotation
+  processor fallback from a validated BTrace/plugin version, never from the extension project's
+  version; the monorepo path still uses `project(':btrace-core')`.
+- Gradle fat-agent source-probe compilation resolves only the version-pinned
+  `io.btrace:btrace:<btraceVersion>` engine artifact and has a regression test; no dynamic
+  `btrace-client:+` lookup remains.
+- Direct JBang examples use `io.btrace:btrace:<version>`.
+- BTrace documentation gives no standalone Maven GAV for bundled extensions or other unpublished
+  modules.  It gives an actionable Gradle local-package/project alternative and makes no equivalent
+  unsupported Maven claim.
+- `rg` finds no unqualified BTrace-owned unpublished coordinate in external-consumer code or docs.
+  Intentional module paths and clearly historical architecture text may remain only with wording that
+  they are internal/not Maven publications.
+- The Gradle extension and fat-agent plugin IDs resolve through the Gradle Plugin Portal, including
+  their marker artifacts; the Maven Central artifacts and Portal publications have their configured
+  signing verification.
+- The Gradle plugin implementation POM and both plugin-marker POMs carry exactly the release version
+  supplied as `-PbtraceVersion`; the included build cannot publish without that verified version.
+- The release workflow publishes/checks only `io.btrace:btrace` in Central and the two Gradle plugins
+  in the Gradle Plugin Portal; it cannot publish or list `btrace-maven-plugin` as a release artifact.
+- `btrace-dist` remains the only engine/library Maven publication; no individual internal module or
+  BTrace extension is newly published as a side effect.
+
+## Verification
+
+Run from the repository root with the workspace-local Gradle cache, capturing output before reading it:
+
+```sh
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew -p btrace-gradle-plugin test > /tmp/issue-884-gradle-plugin.log 2>&1
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-dist:build > /tmp/issue-884-dist.log 2>&1
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:test > /tmp/issue-884-integration.log 2>&1
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew spotlessCheck > /tmp/issue-884-spotless.log 2>&1
+```
+
+Filter/read each log for `BUILD SUCCESSFUL`, `BUILD FAILED`, failures, and test summaries.  If the
+restricted environment has address-selection failures, add the repository-prescribed
+`JAVA_TOOL_OPTIONS` IPv4 options.
+
+After the distribution build, locally publish the exact-release `btrace` artifact plus the Gradle
+plugin implementation and both marker artifacts to the isolated test repository used by the
+hermetic/end-to-end consumer gate. Inspect `btrace.jar` with `jar tf`/`unzip -p` and verify the
+manifest entry points and `META-INF/btrace/` masked sections. Run the standalone build with a
+repository limited to those test publications; it must resolve Gradle plugins through locally
+published marker POMs using a normal `plugins {}` flow, never TestKit classpath injection or
+`includeBuild`, then build the fat agent and exercise it against the real target JVM/protocol fixture.
+The test must invoke the real client from the locally published masked artifact to attach/send a probe
+to that target and assert the probe's observable result; agent startup alone is insufficient.
+Inspect the Gradle implementation POM plus both marker POMs and verify their exact
+`-PbtraceVersion` release value. Finally run the focused `rg` deletion inventory described above. The final
+PR description must state the release version/property and repository used for the hermetic standalone
+consumer check, the post-release Central and Gradle Plugin Portal smoke results, the exact signed
+publication commands (including the included-build `publishPlugins` command), and the artifact
+availability checks. A real release additionally requires authenticated Central/Portal verification
+using the maintainer-held secrets; local verification cannot substitute for that external state.


### PR DESCRIPTION
Closes #884.

## Problem
The published Maven surface ships only `io.btrace:btrace` (a masked, self-contained distribution), yet the plugins and docs resolved coordinates that a released build never publishes — `btrace-core`, `btrace-client`, `io.btrace:btrace-kafka`, etc. That is an inaccurate public contract, not a request to publish those modules.

## Change
- **`BTraceExtensionPlugin`** — the external `@ExternalType` annotation-processor fallback now resolves `io.btrace:btrace:<btraceVersion>` instead of the withdrawn `btrace-core`.
- **`BTraceFatAgentPlugin`** — pins the `io.btrace:btrace` engine, seeds the fat-agent manifest from the masked engine JAR (no longer from the extension author's `project.version`), runs the masked loader for source-probe compilation, and validates the masked-engine contract. `bootJarTask` is now explicitly unsupported.
- **`BTraceVersion`** helper — resolves the pinned BTrace version (explicit `btraceVersion` → published plugin `Implementation-Version`) and rejects dynamic/range versions.
- **Publishing** — `io.btrace.extension` and `io.btrace.fat-agent` are published and signed to the Gradle Plugin Portal; the release workflow gains a `publish-gradle-plugins` job with a Plugin Portal smoke check.
- **Docs/tutorials** — embed extensions via `file(...)` ZIPs; all BTrace-owned unpublished coordinates removed.

## Verification
- `:btrace-gradle-plugin:test` (TestKit) — 28 tests, 0 failures, incl. pinned-version and fail-clear regressions
- `tests.Issue884PublishedFatAgentE2ETest` (`-Pintegration`) — publishes the plugins locally, builds a fat agent from the published markers, and performs a real dynamic attach (asserts `timer` output)
- `spotlessApply` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/917)
<!-- Reviewable:end -->
