### PR TITLE
fix(extensions): report loader-visible metadata and refresh API version docs

### DIFF
--- a/btrace-client/src/main/java/io/btrace/extcli/ExtensionInspector.java
+++ b/btrace-client/src/main/java/io/btrace/extcli/ExtensionInspector.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.*;
 import java.util.*;
+import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
@@ -178,6 +179,10 @@ final class ExtensionInspector {
           providers.add(line);
         }
       }
+      // Report what the loader will see: the API JAR manifest is the same source
+      // io.btrace.extension.impl.ExtensionMetadata parses when the extension is loaded, so
+      // inspection output cannot disagree with the runtime's own view of the extension.
+      Attributes manifestAttributes = mainAttributes(apiJar);
       URL[] urls = new URL[] {apiJar.toUri().toURL(), implJar.toUri().toURL()};
       try (URLClassLoader cl =
           new URLClassLoader(urls, ExtensionInspector.class.getClassLoader())) {
@@ -187,7 +192,7 @@ final class ExtensionInspector {
             if (Extension.class.isAssignableFrom(c)) {
               @SuppressWarnings("unchecked")
               Class<? extends Extension> ec = (Class<? extends Extension>) c;
-              result.add(ExtensionMeta.from(ec));
+              result.add(ExtensionMeta.from(ec, manifestAttributes));
             }
           } catch (Throwable t) {
             // skip faulty provider
@@ -291,5 +296,20 @@ final class ExtensionInspector {
     } catch (IOException ignored) {
     }
     return perms;
+  }
+
+  /**
+   * Reads the main manifest attributes of an extension JAR.
+   *
+   * @param jar the JAR to read
+   * @return the main attributes, or {@code null} when the JAR has no readable manifest
+   */
+  private static Attributes mainAttributes(Path jar) {
+    try (JarFile jf = new JarFile(jar.toFile())) {
+      Manifest manifest = jf.getManifest();
+      return manifest != null ? manifest.getMainAttributes() : null;
+    } catch (IOException e) {
+      return null;
+    }
   }
 }

--- a/btrace-core/src/main/java/io/btrace/core/extensions/ExtensionDescriptor.java
+++ b/btrace-core/src/main/java/io/btrace/core/extensions/ExtensionDescriptor.java
@@ -35,14 +35,14 @@ public @interface ExtensionDescriptor {
    *
    * @return extension name
    */
-  String name();
+  String name() default "";
 
   /**
    * The version of this extension.
    *
    * @return version string (e.g., "1.0", "2.1.0")
    */
-  String version();
+  String version() default "";
 
   /**
    * Human-readable description of this extension.

--- a/btrace-core/src/main/java/io/btrace/core/extensions/ExtensionMeta.java
+++ b/btrace-core/src/main/java/io/btrace/core/extensions/ExtensionMeta.java
@@ -19,14 +19,25 @@ package io.btrace.core.extensions;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.jar.Attributes;
 
 /**
- * Metadata extracted from an extension class.
+ * Metadata describing an extension, as reported by extension inspection tooling.
  *
- * <p>This class holds immutable metadata parsed from package-level {@link ExtensionDescriptor} (if
- * available).
+ * <p>Values come from the extension JAR's manifest, which the Gradle plugin writes and the
+ * extension loader reads, so what is reported matches what the runtime will enforce. A
+ * package-level {@link ExtensionDescriptor} fills any gap the manifest leaves.
  */
 public final class ExtensionMeta {
+  // Manifest attribute names, mirroring what the Gradle plugin emits and what the extension loader
+  // reads. Kept in step with io.btrace.extension.impl.ExtensionMetadata.
+  private static final String ATTR_ID = "BTrace-Extension-Id";
+  private static final String ATTR_NAME = "BTrace-Extension-Name";
+  private static final String ATTR_VERSION = "BTrace-Extension-Version";
+  private static final String ATTR_DESCRIPTION = "BTrace-Extension-Description";
+  private static final String ATTR_API_VERSION = "BTrace-API-Version";
+  private static final String ATTR_PERMISSIONS = "BTrace-Extension-Permissions";
+
   private final Class<? extends Extension> extensionClass;
   private final String name;
   private final String version;
@@ -53,37 +64,59 @@ public final class ExtensionMeta {
   }
 
   /**
-   * Extracts metadata from an extension class.
+   * Extracts metadata from an extension class alone.
+   *
+   * <p>Only the package-level {@link ExtensionDescriptor} is available through this overload, and
+   * that annotation is optional - most extensions declare their identity and permissions through
+   * the Gradle plugin, which records them in the extension JAR's manifest. Prefer {@link
+   * #from(Class, Attributes)} wherever the manifest can be reached, so that what is reported
+   * matches what the extension loader will actually enforce.
    *
    * @param extensionClass the extension class
-   * @return extracted metadata Builds metadata from package-level {@link ExtensionDescriptor} when
-   *     present.
+   * @return metadata derived from the package descriptor, with the class's simple name as the
+   *     fallback identity
    */
   public static ExtensionMeta from(Class<? extends Extension> extensionClass) {
-    // Prefer package-level descriptor for identity and extension-level permissions
+    return from(extensionClass, null);
+  }
+
+  /**
+   * Extracts metadata from an extension class and its JAR manifest.
+   *
+   * <p>The manifest wins. It is what the Gradle plugin emits and what {@code ExtensionMetadata}
+   * reads when the runtime loads and permission-checks an extension, so it is the only description
+   * that is guaranteed to match the extension's real behaviour. The package-level {@link
+   * ExtensionDescriptor} is consulted only to fill gaps: it is optional, several shipped extensions
+   * do not carry one, and those that do may state a version that the build never propagates.
+   *
+   * @param extensionClass the extension class
+   * @param manifestAttributes main attributes of the extension's API JAR manifest, or {@code null}
+   *     when unavailable
+   * @return metadata preferring manifest values over the package descriptor
+   */
+  public static ExtensionMeta from(
+      Class<? extends Extension> extensionClass, Attributes manifestAttributes) {
     Package pkg = extensionClass.getPackage();
     ExtensionDescriptor pkgDesc = pkg != null ? pkg.getAnnotation(ExtensionDescriptor.class) : null;
 
     String name =
-        (pkgDesc != null && !pkgDesc.name().isEmpty())
-            ? pkgDesc.name()
-            : extensionClass.getSimpleName();
-    String version = (pkgDesc != null) ? pkgDesc.version() : "";
-    String description = (pkgDesc != null) ? pkgDesc.description() : "";
-    String minBTraceVersion = (pkgDesc != null) ? pkgDesc.minBTraceVersion() : "";
-
-    // Extract required permissions (pkg-level)
-    Set<Permission> permissions = new HashSet<>();
-    if (pkgDesc != null) {
-      for (Permission p : pkgDesc.permissions()) {
-        if (p != null) permissions.add(p);
-      }
-    }
-
-    PermissionSet permissionSet =
-        permissions.isEmpty()
-            ? PermissionSet.empty()
-            : PermissionSet.of(permissions.toArray(new Permission[0]));
+        firstNonBlank(
+            attribute(manifestAttributes, ATTR_NAME),
+            attribute(manifestAttributes, ATTR_ID),
+            pkgDesc != null ? pkgDesc.name() : null,
+            extensionClass.getSimpleName());
+    String version =
+        firstNonBlank(
+            attribute(manifestAttributes, ATTR_VERSION),
+            pkgDesc != null ? pkgDesc.version() : null);
+    String description =
+        firstNonBlank(
+            attribute(manifestAttributes, ATTR_DESCRIPTION),
+            pkgDesc != null ? pkgDesc.description() : null);
+    String minBTraceVersion =
+        firstNonBlank(
+            attribute(manifestAttributes, ATTR_API_VERSION),
+            pkgDesc != null ? pkgDesc.minBTraceVersion() : null);
 
     return new ExtensionMeta(
         extensionClass,
@@ -91,8 +124,51 @@ public final class ExtensionMeta {
         version,
         description,
         minBTraceVersion,
-        permissionSet,
+        resolvePermissions(manifestAttributes, pkgDesc),
         Collections.emptySet());
+  }
+
+  /**
+   * Resolves the permissions to report.
+   *
+   * <p>The manifest is authoritative when it declares the attribute at all - the Gradle plugin
+   * already fails the build if a package descriptor requires a permission the manifest omits, so a
+   * present manifest entry is the merged, verified set. The annotation is used only when no
+   * manifest is available.
+   */
+  private static PermissionSet resolvePermissions(
+      Attributes manifestAttributes, ExtensionDescriptor pkgDesc) {
+    String declared = attribute(manifestAttributes, ATTR_PERMISSIONS);
+    if (declared != null) {
+      return PermissionSet.parse(declared);
+    }
+    if (pkgDesc == null) {
+      return PermissionSet.empty();
+    }
+    Set<Permission> permissions = new HashSet<>();
+    for (Permission p : pkgDesc.permissions()) {
+      if (p != null) permissions.add(p);
+    }
+    return permissions.isEmpty()
+        ? PermissionSet.empty()
+        : PermissionSet.of(permissions.toArray(new Permission[0]));
+  }
+
+  private static String attribute(Attributes attributes, String name) {
+    if (attributes == null) {
+      return null;
+    }
+    String value = attributes.getValue(name);
+    return (value == null || value.trim().isEmpty()) ? null : value;
+  }
+
+  private static String firstNonBlank(String... candidates) {
+    for (String candidate : candidates) {
+      if (candidate != null && !candidate.trim().isEmpty()) {
+        return candidate;
+      }
+    }
+    return "";
   }
 
   /**

--- a/btrace-core/src/main/java/io/btrace/core/extensions/PermissionSet.java
+++ b/btrace-core/src/main/java/io/btrace/core/extensions/PermissionSet.java
@@ -106,6 +106,33 @@ public final class PermissionSet implements Iterable<Permission> {
   }
 
   /**
+   * Parses a permission set from its textual form.
+   *
+   * <p>Accepts the comma- or whitespace-separated list used by the {@code
+   * BTrace-Extension-Permissions} manifest attribute and the {@code requires.permissions} property.
+   * Unknown names are ignored rather than rejected, so an extension built against a newer BTrace
+   * that names a permission this runtime does not know still loads with the permissions it does
+   * understand.
+   *
+   * @param value the textual permission list; may be {@code null} or blank
+   * @return the parsed set, empty if nothing recognisable was found
+   */
+  public static PermissionSet parse(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return EMPTY;
+    }
+    EnumSet<Permission> set = EnumSet.noneOf(Permission.class);
+    for (String part : value.split("[,\\s]+")) {
+      try {
+        set.add(Permission.valueOf(part.trim()));
+      } catch (IllegalArgumentException ignored) {
+        // lenient by design - see javadoc
+      }
+    }
+    return set.isEmpty() ? EMPTY : new PermissionSet(set);
+  }
+
+  /**
    * Checks if this set contains the specified permission.
    *
    * @param permission the permission to check

--- a/btrace-core/src/main/java/io/btrace/extension/impl/ExtensionMetadata.java
+++ b/btrace-core/src/main/java/io/btrace/extension/impl/ExtensionMetadata.java
@@ -16,7 +16,6 @@
  */
 package io.btrace.extension.impl;
 
-import io.btrace.core.extensions.Permission;
 import io.btrace.core.extensions.PermissionSet;
 import io.btrace.extension.ExtensionDescriptorDTO;
 import io.btrace.extension.ExtensionRepository;
@@ -28,7 +27,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
@@ -291,21 +289,6 @@ final class ExtensionMetadata {
 
   /** Parses a comma/whitespace-separated permission list. Shared with the embedded repository. */
   static PermissionSet parsePermissions(String value) {
-    if (value == null || value.trim().isEmpty()) {
-      return PermissionSet.empty();
-    }
-    String[] parts = value.split("[,\\s]+");
-    EnumSet<Permission> set = EnumSet.noneOf(Permission.class);
-    for (String p : parts) {
-      try {
-        set.add(Permission.valueOf(p.trim()));
-      } catch (IllegalArgumentException iae) {
-        // ignore unknown permission names to be lenient
-      }
-    }
-    if (set.isEmpty()) {
-      return PermissionSet.empty();
-    }
-    return PermissionSet.of(set.toArray(new Permission[0]));
+    return PermissionSet.parse(value);
   }
 }

--- a/btrace-core/src/test/java/io/btrace/core/extensions/ExtensionMetaTest.java
+++ b/btrace-core/src/test/java/io/btrace/core/extensions/ExtensionMetaTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2008, 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.btrace.core.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.jar.Attributes;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Extension inspection must report what the loader will enforce.
+ *
+ * <p>Metadata used to be read only from a package-level {@code @ExtensionDescriptor}, which is
+ * optional: extensions without one were reported under their implementation class's simple name,
+ * with no version and - more importantly - an empty permission set, while extensions with one
+ * reported a hand-written version the build never propagated. The manifest is what the Gradle
+ * plugin emits and what the runtime parses, so it is what inspection reports.
+ */
+class ExtensionMetaTest {
+
+  private static final String ID = "BTrace-Extension-Id";
+  private static final String NAME = "BTrace-Extension-Name";
+  private static final String VERSION = "BTrace-Extension-Version";
+  private static final String DESCRIPTION = "BTrace-Extension-Description";
+  private static final String API_VERSION = "BTrace-API-Version";
+  private static final String PERMISSIONS = "BTrace-Extension-Permissions";
+
+  /** An extension carrying no package-level descriptor, like most of the shipped ones. */
+  public static final class UndescribedExtension extends Extension {}
+
+  @Test
+  @DisplayName("manifest supplies identity, version and permissions")
+  void manifestSuppliesMetadata() {
+    Attributes attributes = new Attributes();
+    attributes.putValue(ID, "btrace-metrics");
+    attributes.putValue(NAME, "BTrace Metrics");
+    attributes.putValue(VERSION, "3.0.0");
+    attributes.putValue(DESCRIPTION, "High-performance metrics");
+    attributes.putValue(API_VERSION, "3.0+");
+    attributes.putValue(PERMISSIONS, "THREADS,NETWORK");
+
+    ExtensionMeta meta = ExtensionMeta.from(UndescribedExtension.class, attributes);
+
+    assertEquals("BTrace Metrics", meta.getName());
+    assertEquals("3.0.0", meta.getVersion());
+    assertEquals("High-performance metrics", meta.getDescription());
+    assertEquals("3.0+", meta.getMinBTraceVersion());
+    assertTrue(meta.getRequiredPermissions().has(Permission.THREADS));
+    assertTrue(meta.getRequiredPermissions().has(Permission.NETWORK));
+  }
+
+  @Test
+  @DisplayName("the extension id names the extension when no display name is set")
+  void idIsUsedWhenNameAbsent() {
+    Attributes attributes = new Attributes();
+    attributes.putValue(ID, "btrace-contracts");
+    attributes.putValue(VERSION, "3.0.0");
+
+    assertEquals(
+        "btrace-contracts", ExtensionMeta.from(UndescribedExtension.class, attributes).getName());
+  }
+
+  @Test
+  @DisplayName("permissions are reported for extensions with no package descriptor")
+  void permissionsReportedWithoutPackageDescriptor() {
+    Attributes attributes = new Attributes();
+    attributes.putValue(ID, "btrace-statsd");
+    attributes.putValue(VERSION, "3.0.0");
+    attributes.putValue(PERMISSIONS, "NETWORK");
+
+    ExtensionMeta meta = ExtensionMeta.from(UndescribedExtension.class, attributes);
+
+    assertTrue(
+        meta.getRequiredPermissions().has(Permission.NETWORK),
+        "an extension without @ExtensionDescriptor must still report its manifest permissions");
+  }
+
+  @Test
+  @DisplayName("without a manifest the class name identifies the extension")
+  void fallsBackToClassNameWithoutManifest() {
+    ExtensionMeta meta = ExtensionMeta.from(UndescribedExtension.class, null);
+
+    assertEquals("UndescribedExtension", meta.getName());
+    assertEquals("", meta.getVersion());
+    assertTrue(meta.getRequiredPermissions().isEmpty(), "expected no permissions");
+  }
+
+  @Test
+  @DisplayName("the single-argument overload behaves as no manifest")
+  void singleArgumentOverloadMatchesNullManifest() {
+    ExtensionMeta withoutManifest = ExtensionMeta.from(UndescribedExtension.class);
+    ExtensionMeta nullManifest = ExtensionMeta.from(UndescribedExtension.class, null);
+
+    assertEquals(nullManifest.getName(), withoutManifest.getName());
+    assertEquals(nullManifest.getVersion(), withoutManifest.getVersion());
+  }
+
+  @Test
+  @DisplayName("blank manifest values do not mask the fallback")
+  void blankManifestValuesAreIgnored() {
+    Attributes attributes = new Attributes();
+    attributes.putValue(NAME, "   ");
+    attributes.putValue(VERSION, "");
+
+    ExtensionMeta meta = ExtensionMeta.from(UndescribedExtension.class, attributes);
+
+    assertEquals("UndescribedExtension", meta.getName());
+    assertEquals("", meta.getVersion());
+  }
+}

--- a/btrace-core/src/test/java/io/btrace/core/extensions/PermissionSetParseTest.java
+++ b/btrace-core/src/test/java/io/btrace/core/extensions/PermissionSetParseTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008, 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.btrace.core.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Parsing of the textual permission list shared by the manifest attribute, the legacy properties
+ * file and extension inspection. It lives here rather than being restated by each caller so the
+ * three cannot disagree about what a permission list means.
+ */
+class PermissionSetParseTest {
+
+  @Test
+  @DisplayName("comma separated names are parsed")
+  void parsesCommaSeparated() {
+    PermissionSet set = PermissionSet.parse("NETWORK,THREADS");
+
+    assertTrue(set.has(Permission.NETWORK));
+    assertTrue(set.has(Permission.THREADS));
+    assertEquals(2, set.size());
+  }
+
+  @Test
+  @DisplayName("whitespace and mixed separators are tolerated")
+  void parsesWhitespaceSeparated() {
+    PermissionSet set = PermissionSet.parse("NETWORK ,  THREADS");
+
+    assertTrue(set.has(Permission.NETWORK));
+    assertTrue(set.has(Permission.THREADS));
+  }
+
+  @ParameterizedTest(name = "\"{0}\" parses to the empty set")
+  @ValueSource(strings = {"", "   ", ","})
+  @DisplayName("blank input yields no permissions")
+  void blankInputIsEmpty(String value) {
+    assertTrue(PermissionSet.parse(value).isEmpty());
+  }
+
+  @Test
+  @DisplayName("null input yields no permissions")
+  void nullInputIsEmpty() {
+    assertTrue(PermissionSet.parse(null).isEmpty());
+  }
+
+  @Test
+  @DisplayName("an unknown name is skipped rather than failing the whole list")
+  void unknownNamesAreIgnored() {
+    // An extension built against a newer BTrace may name a permission this runtime has never heard
+    // of; the permissions it does understand must still be honoured.
+    PermissionSet set = PermissionSet.parse("NETWORK,TIME_TRAVEL");
+
+    assertTrue(set.has(Permission.NETWORK));
+    assertEquals(1, set.size());
+  }
+
+  @Test
+  @DisplayName("a list of only unknown names yields no permissions")
+  void allUnknownNamesYieldEmpty() {
+    assertTrue(PermissionSet.parse("TIME_TRAVEL,TELEPATHY").isEmpty());
+  }
+}

--- a/btrace-extensions/btrace-metrics/src/main/java/io/btrace/metrics/package-info.java
+++ b/btrace-extensions/btrace-metrics/src/main/java/io/btrace/metrics/package-info.java
@@ -1,6 +1,5 @@
 @ExtensionDescriptor(
     name = "btrace-metrics",
-    version = "1.0",
     description = "High-performance metrics APIs",
     permissions = {Permission.THREADS})
 package io.btrace.metrics;

--- a/btrace-extensions/btrace-statsd/src/main/java/io/btrace/statsd/package-info.java
+++ b/btrace-extensions/btrace-statsd/src/main/java/io/btrace/statsd/package-info.java
@@ -1,6 +1,5 @@
 @ExtensionDescriptor(
     name = "btrace-statsd",
-    version = "1.0",
     description = "StatsD metrics APIs",
     permissions = {Permission.NETWORK})
 package io.btrace.statsd;

--- a/btrace-extensions/btrace-utils/src/main/java/io/btrace/utils/package-info.java
+++ b/btrace-extensions/btrace-utils/src/main/java/io/btrace/utils/package-info.java
@@ -1,7 +1,4 @@
-@ExtensionDescriptor(
-    name = "btrace-utils",
-    version = "1.0",
-    description = "Utility helper APIs for BTrace scripts")
+@ExtensionDescriptor(name = "btrace-utils", description = "Utility helper APIs for BTrace scripts")
 package io.btrace.utils;
 
 import io.btrace.core.extensions.ExtensionDescriptor;

--- a/docs/BTraceExtensionDevelopmentGuide.md
+++ b/docs/BTraceExtensionDevelopmentGuide.md
@@ -102,11 +102,12 @@ btraceExtension {
 }
 ```
 
-Alternative to the DSL:
-- You can document extension details via the `@ExtensionDescriptor` annotation in your API package’s `package-info.java`.
-- Annotation source: `btrace-core/src/main/java/io/btrace/core/extensions/ExtensionDescriptor.java`.
+Optional companion to the DSL — `@ExtensionDescriptor`:
+- Declared on your API package’s `package-info.java`. Source: `btrace-core/src/main/java/io/btrace/core/extensions/ExtensionDescriptor.java`.
 - Fields: `name`, `version`, `description`, `minBTraceVersion`, `dependencies`, `permissions`.
-- The `btraceExtension` block remains the canonical source for manifest values; `@ExtensionDescriptor` mainly assists tooling and validates that declared `permissions` are covered by scanning or `requiredPermissions`.
+- **`permissions` is the field that does work.** The plugin scans it and fails the build when the annotation requires a permission the manifest does not grant, so it is a useful assertion that the code's needs and the shipped manifest agree.
+- **The other fields are not propagated.** The `btraceExtension` block is the single source of the manifest, and the manifest is what the runtime loads and what `btrace ext inspect` reports. A `version` stated only in the annotation describes nothing the build or the runtime will use — leave it unset rather than let it drift from the real artifact version.
+- The annotation is entirely optional; most of the extensions shipped with BTrace do not declare one.
 
 Outputs produced by the plugin:
 - API JAR: `build/libs/<name>-<version>-api.jar` (manifest + properties with extension metadata)

--- a/docs/architecture/ExtensionManifestFormat.md
+++ b/docs/architecture/ExtensionManifestFormat.md
@@ -21,7 +21,7 @@ extension.id=btrace-metrics
 extension.version=3.0.0
 extension.name=BTrace Metrics
 extension.description=High-performance metrics...
-btrace.api.version=2.3+
+btrace.api.version=3.0+
 java.version=8+
 services=io.btrace.metrics.MetricsService
 requires.extensions=btrace-core
@@ -36,7 +36,7 @@ BTrace-Extension-Version: 3.0.0
 BTrace-Extension-Name: BTrace Metrics
 BTrace-Extension-Description: High-performance metrics with HdrHistogram
  for percentiles and lock-free statistics
-BTrace-API-Version: 2.3+
+BTrace-API-Version: 3.0+
 BTrace-Java-Version: 8+
 BTrace-Extension-Services: io.btrace.metrics.MetricsService
 BTrace-Extension-Requires: btrace-core
@@ -74,7 +74,7 @@ BTrace-Extension-Permissions: NETWORK,THREADS
 
 **BTrace-API-Version**
 - Format: version range (major.minor+)
-- Example: `2.3+` (requires BTrace API 2.3 or higher)
+- Example: `3.0+` (requires BTrace API 3.0 or higher)
 - Description: Required BTrace API version
 
 **BTrace-Java-Version**
@@ -158,7 +158,7 @@ jar {
       'BTrace-Extension-Version': project.version,
       'BTrace-Extension-Name': 'BTrace Metrics',
       'BTrace-Extension-Description': 'High-performance metrics...',
-      'BTrace-API-Version': '2.3+',
+      'BTrace-API-Version': '3.0+',
       'BTrace-Java-Version': '8+',
       'BTrace-Extension-Services': 'io.btrace.metrics.MetricsService',
       'BTrace-Shaded-Packages': 'org.HdrHistogram->io.btrace.metrics.shaded.hdrhistogram'

--- a/docs/architecture/ExtensionStorageDesign.md
+++ b/docs/architecture/ExtensionStorageDesign.md
@@ -83,7 +83,7 @@ extension.name=BTrace Metrics
 extension.description=High-performance metrics with HdrHistogram
 
 # API compatibility
-btrace.api.version=2.3+
+btrace.api.version=3.0+
 java.version=8+
 
 # Service providers (optional, can also use META-INF/services)
@@ -228,7 +228,7 @@ Create `META-INF/btrace-extension.properties`:
 ```properties
 extension.id=my-extension
 extension.version=1.0.0
-btrace.api.version=2.3+
+btrace.api.version=3.0+
 ```
 
 4. **Build JAR**:

--- a/docs/tutorials/06-write-your-own-extension.md
+++ b/docs/tutorials/06-write-your-own-extension.md
@@ -77,9 +77,10 @@ service interface and its implementation, no separate `api`/`impl` subpackages r
 
 ```sh
 cat > src/main/java/com/example/orderstats/package-info.java <<'EOF'
+// Optional. `permissions` is checked against the manifest at build time; identity and version
+// come from the btraceExtension block, so they are deliberately not restated here.
 @ExtensionDescriptor(
     name = "order-counter",
-    version = "3.0.0",
     description = "Counts order outcomes observed by BTrace probes",
     permissions = {Permission.THREADS})
 package com.example.orderstats;


### PR DESCRIPTION
## What does this change do?

Makes `ExtensionMeta` report the metadata the extension loader actually uses, removes a duplicated permission parser, and documents which parts of `@ExtensionDescriptor` do work.

**Please read the severity note before reviewing** — this is public-API hygiene and documentation, not a user-facing defect. #919 as originally filed overstated the impact and has been [corrected](https://github.com/btraceio/btrace/issues/919#issuecomment-5084430261).

### The metadata fix

`ExtensionMeta` derived identity, version, description and permissions solely from a package-level `@ExtensionDescriptor`. That annotation is optional — four of the seven shipped extensions carry none, so metadata degraded to the implementation class's simple name with an empty version and an **empty permission set**, while the three that carry one state `version = "1.0"` for artifacts that are `3.0.0`.

It now prefers the JAR manifest — the same source `io.btrace.extension.impl.ExtensionMetadata` parses when the runtime loads and permission-checks an extension — and consults the annotation only to fill gaps.

### Severity: no observable behaviour changes

`ExtensionInspector` already read the manifest directly for the version and permissions it prints (`readVersionFromJar`, `readPermissionsFromManifestOrProps` on both JARs) and uses `ExtensionMeta` only as an additional permission contributor. `ExtensionReport` never prints `ExtensionMeta`'s name or version.

Verified rather than assumed: packaged `btrace-statsd` (has a descriptor stating `1.0`) and `btrace-contracts` (has none) were inspected **with and without this change** — output is byte-identical in both cases (`Version: 3.0.0-SNAPSHOT`, `Required: [NETWORK]` / `[THREADS]`).

`ExtensionMeta.getName()`, `getVersion()`, `getDescription()` and `getMinBTraceVersion()` have **no callers in the codebase**, which is why the wrong values were never noticed. The fix matters for external callers of this public API and for anyone who wires these accessors up in future.

### Shared permission parsing

The permission-list parser existed twice, in different packages. It is promoted to `PermissionSet.parse(String)`; the manifest path, the legacy properties path and inspection now share one definition.

### `@ExtensionDescriptor` keeps its real job

The Gradle plugin reads its `permissions` member and **fails the build** when the manifest does not cover what the annotation requires (`BTraceExtensionPlugin.groovy`: *"Manifest permissions missing annotated requirements"*). That is a genuine assertion and is untouched. Its remaining members are propagated nowhere, so `name()` and `version()` gain defaults and the three package descriptors drop the version they were misstating.

There was never a three-way conflict over authority: the manifest is authoritative, the annotation is a build-time permission assertion, and the third "format" was dead metadata.

### Docs

`BTraceExtensionDevelopmentGuide.md` and `tutorials/06-write-your-own-extension.md` now state which annotation member does work and which do not. The six remaining `BTrace-API-Version: 2.3+` examples across `ExtensionManifestFormat.md` and `ExtensionStorageDesign.md` are updated to `3.0+`, matching what the plugin emits (#918).

## Related issue

Closes #918
Addresses #919

## Scope and compatibility

- [x] I identified the affected module(s) and kept unrelated changes out of this PR.
- [x] This preserves the supported Java/runtime compatibility tiers, or the change is documented below.
- [x] This does not change the masked-JAR layout, class-loader boundary, or wire protocol.
- [ ] If it does, I updated the relevant architecture documentation and verification plan.

**Compatibility or migration notes:**

`@ExtensionDescriptor.name()` and `version()` gain defaults, which is source- and binary-compatible; existing extensions that set them continue to compile. `ExtensionMeta.from(Class)` is retained and unchanged in signature, delegating to the new `from(Class, Attributes)` overload. No CLI, probe, protocol or packaging change.

## Testing

```
./gradlew :btrace-core:test :btrace-client:test :btrace-agent:test spotlessCheck
./gradlew :btrace-extensions:btrace-metrics:test :btrace-extensions:btrace-statsd:test \
    :btrace-extensions:btrace-utils:test
./gradlew -p btrace-gradle-plugin test        # covers the permission-alignment check
```

Plus `ext inspect` run against packaged `btrace-statsd` and `btrace-contracts` archives, before and after, to confirm the output is unchanged.

New tests: `ExtensionMetaTest` (manifest precedence, id-as-name fallback, permissions for extensions with no package descriptor, blank-value handling, overload equivalence) and `PermissionSetParseTest` (separators, blank and null input, unknown names skipped rather than failing the list).

## Notes for reviewers

- The lenient handling of unknown permission names is deliberate and now tested: an extension built against a newer BTrace naming an unknown permission still loads with the permissions this runtime understands.
- Unrelated oddity noticed while verifying, deliberately not touched: `ext inspect` reports `Services: org.slf4j.spi.SLF4JServiceProvider,javax.annotation.processing.Processor` for both extensions, which looks like unrelated `META-INF/services` entries leaking into the report. Worth a separate issue if that is not intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/922)
<!-- Reviewable:end -->
