### PR TITLE
fix(release): repair the release-smoke embedded-extension leg

### DIFF
--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -123,13 +123,22 @@ wait_for_text() {
   return 1
 }
 
+# Set NO_BTRACE_HOME=1 for a single call to launch the target with BTRACE_HOME unset. Only the
+# embedded-extension legs want this: it stops a developer's SDKMAN install from satisfying an
+# @Injected service from $BTRACE_HOME/extensions/, which would leave the embedded copy untested.
+# It is defence-in-depth for local runs rather than the CI mechanism, since this script never
+# exports BTRACE_HOME - it passes it as a per-command prefix assignment.
 start_patient() {
   local label=$1
   shift
   stop_process "$TARGET_PID"
   TARGET_PID=""
   local log="$WORK/logs/${label}-target.log"
-  "$JAVA_HOME/bin/java" "$@" "$WORK/DemoApp.java" >"$log" 2>&1 &
+  if [ "${NO_BTRACE_HOME:-}" = "1" ]; then
+    env -u BTRACE_HOME "$JAVA_HOME/bin/java" "$@" "$WORK/DemoApp.java" >"$log" 2>&1 &
+  else
+    "$JAVA_HOME/bin/java" "$@" "$WORK/DemoApp.java" >"$log" 2>&1 &
+  fi
   TARGET_PID=$!
   wait_for_text "$log" "[demo] order service running" 30 || fail "$label target did not become ready"
 }
@@ -274,14 +283,24 @@ for mode in v1 v2 auto; do
 done
 
 echo "[smoke] embedded non-privileged and privileged extensions"
+# No allowExtensions entry: the policy only consults it on the privileged branch, so listing a
+# non-privileged extension asserts nothing. allowPrivileged=false is the meaningful constraint.
 cat >"$WORK/permissions.properties" <<'EOF'
-allowExtensions=btrace-hadoop-example
 allowPrivileged=false
 EOF
-start_patient embedded-non-privileged \
+NO_BTRACE_HOME=1 start_patient embedded-non-privileged \
   "-Dbtrace.permissions=$WORK/permissions.properties" \
   "-javaagent:$FAT_AGENT=port=0,debug=true"
 run_doctor embedded-non-privileged 0 "READY"
+# Prove the extension came from the fat agent rather than $BTRACE_HOME/extensions/. Every
+# release extension is also exploded into the distribution, so without this the leg would pass
+# on the filesystem copy and never exercise the embedded one.
+wait_for_text "$WORK/logs/embedded-non-privileged-target.log" \
+  "BTRACE_HOME not set; using embedded extensions only" 30 \
+  || fail "embedded-non-privileged target resolved a BTRACE_HOME instead of embedded extensions"
+wait_for_text "$WORK/logs/embedded-non-privileged-target.log" \
+  "Scanning repository: embedded:META-INF/btrace-extensions/" 30 \
+  || fail "embedded-non-privileged target did not scan the embedded extension repository"
 start_trace embedded-non-privileged "release-smoke: non-privileged extension" "" \
   "$TARGET_PID" NonPrivilegedExtensionProbe.java
 finish_trace
@@ -292,7 +311,7 @@ cat >"$WORK/permissions.properties" <<'EOF'
 allowExtensions=btrace-metrics
 allowPrivileged=true
 EOF
-start_patient embedded-privileged \
+NO_BTRACE_HOME=1 start_patient embedded-privileged \
   "-Dbtrace.permissions=$WORK/permissions.properties" \
   "-javaagent:$FAT_AGENT=port=0,debug=true"
 run_doctor embedded-privileged 0 "READY"

--- a/scripts/release-smoke/NonPrivilegedExtensionProbe.java
+++ b/scripts/release-smoke/NonPrivilegedExtensionProbe.java
@@ -1,17 +1,17 @@
-import static io.btrace.core.BTraceUtils.println;
-
 import io.btrace.core.annotations.BTrace;
 import io.btrace.core.annotations.Injected;
 import io.btrace.core.annotations.OnMethod;
-import org.example.btrace.hadoop.api.HadoopApi;
+import io.btrace.utils.PrinterService;
 
 @BTrace
 public class NonPrivilegedExtensionProbe {
-  @Injected private static HadoopApi hadoop;
+  @Injected private static PrinterService printer;
 
   @OnMethod(clazz = "OrderService", method = "processOrder")
   public static void onOrder() {
-    hadoop.onOpen(null, null);
-    println("release-smoke: non-privileged extension");
+    // Emitted through the injected service on purpose. Printing via BTraceUtils instead would
+    // make this probe produce the asserted line even when the service never resolved, which is
+    // exactly the failure the embedded-extension leg exists to catch.
+    printer.println("release-smoke: non-privileged extension");
   }
 }


### PR DESCRIPTION
## Summary

The release-smoke embedded-extension leg has never passed. It fails at probe-compile time:

```
NonPrivilegedExtensionProbe.java:6: error: package org.example.btrace.hadoop.api does not exist
BTrace compilation failed
```

`NonPrivilegedExtensionProbe` injects `org.example.btrace.hadoop.api.HadoopApi`, but the client
compiles probes against `$BTRACE_HOME/extensions/*/*-api.jar`
(`Client.getExtensionApiClasspath`), and `copyExtensions` mirrors only the release allow-list —
which does not include the Hadoop *example*. The API is therefore never present in a
distribution, no matter what the fat agent embeds.

Nobody has hit this because the `release-smoke` job is gated on `dry_run != true` and 3.0.0 has
not shipped. That is also why it matters: the job `needs: wait-for-maven`, so it runs **after**
the operator has manually published to Central, and `finalize-tag` needs it. A failure there
leaves artifacts on Central with no final tag, no GitHub release and no SDKMAN update.

Found while designing #901; independent of it, so it lands separately and first.

## Changes

- **Retarget the probe** to `io.btrace.utils.PrinterService` (`btrace-utils`), which is
  allow-listed, ships its API jar in the distribution, and declares no permissions — so the
  `allowPrivileged=false` leg still tests what it is named for.
- **Emit the asserted line through the injected service.** The old probe printed it via
  `BTraceUtils.println`, so it would have passed even if the service never resolved. Merely
  swapping the field type would have preserved that hole.
- **Add embedded-provenance assertions.** Unlike the Hadoop example, every allow-listed
  extension is *also* exploded into `$DIST/extensions/`, so after the retarget the filesystem
  copy could satisfy the injection and leave the fat agent untested. The leg now asserts the
  agent logged `BTRACE_HOME not set; using embedded extensions only` and
  `Scanning repository: embedded:META-INF/btrace-extensions/`.
- **Add a `NO_BTRACE_HOME=1` opt-in** to `start_patient`, applied to the two `embedded-*` legs
  only. It is deliberately not global: the `prepared` leg runs `-javaagent:$DIST/libs/btrace.jar`,
  from which `Main.getBTraceHome` derives home via the `libs/` parent regardless of the
  environment, so an "embedded only" assertion there would fail.
- **Drop `allowExtensions=btrace-hadoop-example`.** It is inert — `ExtensionBridgeImpl` consults
  `isExplicitlyAllowed` only on the privileged branch — and after the retarget it was a dangling
  id. `allowPrivileged=false` is the constraint that actually means something here.

The privileged leg is untouched: it uses `btrace-metrics`, which is allow-listed and declares
`THREADS`.

## Verification

Red/green against the same built distribution: the leg fails on `develop` with the compile error
above, and passes with this change, including both new provenance assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/927)
<!-- Reviewable:end -->
