### PR TITLE
feat(dist): publish BTrace with the default extensions embedded

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -859,7 +859,7 @@ jobs:
         run: |
           TMPDIR="${RUNNER_TEMP}" scripts/release-smoke.sh \
             --distribution release-candidate \
-            --fat-agent btrace-dist/build/resources/main/v${RELEASE_VERSION}/libs/btrace-agent-fat.jar \
+            --fat-agent btrace-dist/build/fat-agent/btrace-agent-fat.jar \
             --version "${RELEASE_VERSION}" \
             --keep-work
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ jbang btrace <PID> <script.java>
 
 **Note:** Replace `<version>` with the desired BTrace version (e.g., `3.0.0`). See [releases](https://github.com/btraceio/btrace/releases) for available versions.
 
+**Extensions:** The published artifact bundles the default extensions, so scripts that inject
+services such as `MetricsService` or `PrinterService` work under jbang with nothing extra to
+install.
+
 **Benefits:** Zero installation, automatic version management, works everywhere (Windows/macOS/Linux/containers), perfect for CI/CD.
 
 **Agent JAR:** The client automatically discovers the masked agent JAR (`btrace.jar`) on its classpath — no extraction step is needed. If you want to use the agent JAR directly (e.g., with `-javaagent`), find it in the Maven local repository after the first jbang run:
@@ -241,7 +245,7 @@ As a last resort (discouraged), you may append a single jar to the system classp
 For environments where managing multiple JARs is impractical (Spark, Hadoop, Kubernetes), BTrace provides a fat agent JAR with embedded extensions:
 
 ```sh
-# Build fat agent with all extensions
+# Build fat agent with the default extensions
 ./gradlew :btrace-dist:fatAgentJar
 
 # Build with specific extensions only

--- a/btrace-client/src/main/java/io/btrace/client/Client.java
+++ b/btrace-client/src/main/java/io/btrace/client/Client.java
@@ -71,6 +71,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -329,10 +330,67 @@ public class Client {
           }
         }
       }
+      // 3) Fall back to extensions embedded in the agent JAR itself. A Maven or jbang user has no
+      // extensions directory at all; the published artifact carries the extensions inside it, with
+      // the API types stored as plain class entries at the root, so the JAR is its own API
+      // classpath. Without this a source probe that injects an extension service fails to compile
+      // even though the agent could load the extension perfectly well at runtime.
+      String embedded = embeddedExtensionApiClasspath();
+      if (!embedded.isEmpty()) {
+        return embedded;
+      }
     } catch (Exception e) {
       log.warn("Failed to scan extensions directory", e);
     }
     return "";
+  }
+
+  /**
+   * Returns the agent JAR as a compile classpath entry when it declares embedded extensions.
+   *
+   * @return the JAR path, or an empty string when no embedded extensions are declared
+   */
+  private String embeddedExtensionApiClasspath() {
+    // btrace.libs names the directory holding the engine, and is what a distribution or an
+    // explicitly configured client sets; findMaskedAgentJar covers the jbang case, where the
+    // engine locates itself from its own code source.
+    String libsProp = System.getProperty("btrace.libs");
+    if (libsProp != null && !libsProp.isEmpty()) {
+      File candidate = new File(libsProp, "btrace.jar");
+      if (candidate.isFile()) {
+        String cp = embeddedExtensionApiClasspath(candidate.getAbsolutePath());
+        if (!cp.isEmpty()) {
+          return cp;
+        }
+      }
+    }
+    String agentJar = findMaskedAgentJar();
+    return agentJar == null ? "" : embeddedExtensionApiClasspath(agentJar);
+  }
+
+  /**
+   * Returns {@code agentJar} when it declares embedded extensions, or an empty string otherwise.
+   *
+   * @param agentJar path to a masked BTrace engine JAR
+   */
+  private String embeddedExtensionApiClasspath(String agentJar) {
+    try (JarFile jar = new JarFile(agentJar)) {
+      Manifest manifest = jar.getManifest();
+      if (manifest == null) {
+        return "";
+      }
+      String embedded = manifest.getMainAttributes().getValue("BTrace-Embedded-Extensions");
+      if (embedded == null || embedded.trim().isEmpty()) {
+        return "";
+      }
+      if (log.isDebugEnabled()) {
+        log.debug("Using embedded extension APIs from {}: {}", agentJar, embedded);
+      }
+      return agentJar;
+    } catch (IOException e) {
+      log.debug("Could not read embedded extension metadata from {}", agentJar, e);
+      return "";
+    }
   }
 
   /**

--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -475,15 +475,33 @@ test {
  * Usage:
  *   ./gradlew :btrace-dist:fatAgentJar -PembedExtensions=btrace-spark,btrace-metrics
  */
+// The extensions that ship with a release. This drives both the distribution's extensions/
+// directory and the set the fat agent embeds by default, so the two cannot disagree about what
+// "default" means. Declared here because the btraceFatAgent block below reads it.
+def releaseExtensionProjects = [
+    ':btrace-extensions:btrace-contracts',
+    ':btrace-extensions:btrace-gpu-bridge',
+    ':btrace-extensions:btrace-llm-trace',
+    ':btrace-extensions:btrace-metrics',
+    ':btrace-extensions:btrace-rag-quality',
+    ':btrace-extensions:btrace-statsd',
+    ':btrace-extensions:btrace-utils'
+]
+
 btraceFatAgent {
     baseName = 'btrace-agent-fat'
-    outputDir = libsDir
+    // Deliberately outside distTarget. The distribution archives copy that tree wholesale, so a
+    // fat agent written into it rides along into every zip, tarball, deb and rpm whenever
+    // something happens to build it first.
+    outputDir = project.layout.buildDirectory.dir('fat-agent').get().asFile
 
     // Reference the single masked JAR (agent + boot merged into btraceJar)
     agentJarTask = 'btraceJar'
 
-    // Auto-discover extensions from subprojects
+    // Auto-discover extensions from subprojects, but embed only the released set unless the
+    // build explicitly asks for something else via -PembedExtensions.
     autoDiscover = true
+    defaultExtensions = releaseExtensionProjects
     filterProperty = 'embedExtensions'
 
     // Package relocations
@@ -519,16 +537,6 @@ task copyExtensions(type: Sync) {
     description 'Mirror the released extension ZIP archives into the extensions/ directory'
     into "${distTarget}/extensions/"
 }
-
-def releaseExtensionProjects = [
-    ':btrace-extensions:btrace-contracts',
-    ':btrace-extensions:btrace-gpu-bridge',
-    ':btrace-extensions:btrace-llm-trace',
-    ':btrace-extensions:btrace-metrics',
-    ':btrace-extensions:btrace-rag-quality',
-    ':btrace-extensions:btrace-statsd',
-    ':btrace-extensions:btrace-utils'
-]
 
 gradle.projectsEvaluated {
     tasks.named('copyExtensions').configure { t ->
@@ -648,8 +656,8 @@ buildDeb {
 }
 
 copyDtraceLib.dependsOn project(':btrace-dtrace').build
-fatAgentJar.mustRunAfter copyDtraceLib
-buildSdkmanZip.mustRunAfter fatAgentJar
+// No ordering needed against the distribution tasks: fatAgentJar writes outside distTarget and
+// only reads btraceJar's output.
 shadowJar.dependsOn btraceJar, copyDtraceLib, copyExtensions
 buildTgz.dependsOn btraceJar, fixPermissions, copyDtraceLib, processResources, explodeExtensions
 buildZip.dependsOn btraceJar, fixPermissions, copyDtraceLib, processResources, explodeExtensions
@@ -667,7 +675,7 @@ task releaseSmoke(type: Exec) {
     commandLine 'bash',
             rootProject.file('scripts/release-smoke.sh'),
             '--distribution', distTarget,
-            '--fat-agent', new File(libsDir, 'btrace-agent-fat.jar'),
+            '--fat-agent', fatAgentJar.archiveFile.get().asFile,
             '--version', project.version
 }
 
@@ -917,7 +925,13 @@ publishing {
         btrace(MavenPublication) {
             artifactId 'btrace'
             groupId 'io.btrace'
-            artifact btraceJar
+            // The fat agent, not the lean masked jar. A Maven or jbang user has no
+            // $BTRACE_HOME/extensions directory to discover, so publishing the lean engine left
+            // them with core tracing and none of the default extensions. Embedding costs about
+            // seven percent in size and nothing at runtime, since an extension is inert until a
+            // script injects it. The distribution is unaffected: it keeps shipping the lean
+            // libs/btrace.jar alongside its extensions directory.
+            artifact fatAgentJar
             pom.withXml {
                 addPomDetails(asNode(), 'btrace')
             }
@@ -928,7 +942,9 @@ publishing {
 def addPomDetails(node, name) {
     node.appendNode('name', name)
     node.appendNode('url', 'https://github.com/btraceio/btrace')
-    node.appendNode('description', 'BTrace: A safe, dynamic tracing tool for the Java platform')
+    node.appendNode('description',
+            'BTrace: A safe, dynamic tracing tool for the Java platform, with the default'
+                    + ' extensions embedded')
     def scmNode = node.appendNode('scm')
     scmNode.appendNode('url', 'https://github.com/btraceio/btrace')
     scmNode.appendNode('connection', 'scm:git:https://github.com/btraceio/btrace.git')

--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -666,6 +666,45 @@ buildDeb.dependsOn btraceJar, fixPermissions, copyDtraceLib, processResources, e
 buildRpm.dependsOn btraceJar, fixPermissions, copyDtraceLib, processResources, explodeExtensions
 build.dependsOn buildSdkmanZip, buildZip, buildTgz, buildDeb, buildRpm
 
+// The published artifact is the fat agent, so what it embeds is a release decision rather than a
+// build detail. -PembedExtensions still overrides the default set, and a stray property or an
+// ORG_GRADLE_PROJECT_embedExtensions in the publishing environment would put example extensions
+// on Maven Central, or none at all, with no way to take it back.
+//
+// The expected ids are spelled out rather than derived from releaseExtensionProjects: deriving
+// them would make this assert only that the list equals itself, and the ids and the project paths
+// are different identifier spaces.
+def publishedExtensionIds = [
+    'btrace-contracts', 'btrace-gpu-bridge', 'btrace-llm-trace', 'btrace-metrics',
+    'btrace-rag-quality', 'btrace-statsd', 'btrace-utils'
+]
+
+task verifyEmbeddedExtensions {
+    group 'Verification'
+    description 'Assert the published fat agent embeds exactly the released extension set'
+    dependsOn fatAgentJar
+
+    doLast {
+        def jar = fatAgentJar.archiveFile.get().asFile
+        def declared = new java.util.jar.JarFile(jar).withCloseable { j ->
+            j.manifest?.mainAttributes?.getValue('BTrace-Embedded-Extensions')
+        }
+        def actual = (declared ?: '').split(',').collect { it.trim() }.findAll { it }.sort()
+        def expected = publishedExtensionIds.sort()
+        if (actual != expected) {
+            throw new GradleException(
+                "${jar.name} embeds ${actual} but the release set is ${expected}. " +
+                'Publishing this would ship the wrong extensions. If the release set changed, ' +
+                'update releaseExtensionProjects and publishedExtensionIds together.')
+        }
+        logger.lifecycle("[dist] Verified embedded extensions: ${actual.join(', ')}")
+    }
+}
+
+tasks.matching { it.name.startsWith('publishBtracePublicationTo') }.configureEach {
+    dependsOn verifyEmbeddedExtensions
+}
+
 task releaseSmoke(type: Exec) {
     group = 'Verification'
     description = 'Run acquisition and first-trace smoke tests against the built distribution'

--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -656,8 +656,12 @@ buildDeb {
 }
 
 copyDtraceLib.dependsOn project(':btrace-dtrace').build
-// No ordering needed against the distribution tasks: fatAgentJar writes outside distTarget and
-// only reads btraceJar's output.
+// fatAgentJar reads btraceJar's output, which sits in the same libs directory copyDtraceLib
+// writes into, so Gradle sees it consuming that task's output. Moving the fat agent's own output
+// out of the distribution tree does not change that: this ordering is about what it reads.
+// buildSdkmanZip needs no such guard any more, because nothing writes the fat agent into the
+// tree the archives copy.
+fatAgentJar.mustRunAfter copyDtraceLib
 shadowJar.dependsOn btraceJar, copyDtraceLib, copyExtensions
 buildTgz.dependsOn btraceJar, fixPermissions, copyDtraceLib, processResources, explodeExtensions
 buildZip.dependsOn btraceJar, fixPermissions, copyDtraceLib, processResources, explodeExtensions

--- a/btrace-gradle-plugin/README.md
+++ b/btrace-gradle-plugin/README.md
@@ -153,6 +153,7 @@ btraceFatAgent {
     // Auto-discovery options
     autoDiscover = true              // find extensions with btrace.extension plugin
     filterProperty = 'embedExtensions'  // use -PembedExtensions=ext1,ext2 to filter
+    defaultExtensions = [':ext-a']   // embed just these when the property is absent
 }
 ```
 
@@ -219,6 +220,21 @@ Build with specific extensions:
 # Embed only specific extensions
 ./gradlew fatAgentJar -PembedExtensions=btrace-metrics,btrace-statsd
 ```
+
+To embed a fixed subset by default — useful when the build produces a published artifact and only
+some of the discovered extensions belong in it — set `defaultExtensions`:
+
+```groovy
+btraceFatAgent {
+    autoDiscover = true
+    defaultExtensions = [':btrace-extensions:btrace-metrics', ':btrace-extensions:btrace-utils']
+}
+```
+
+Entries match a subproject's name or its path. The filter property still wins when it is present,
+so `-PembedExtensions=...` can select anything discoverable, including extensions outside the
+default set. Leaving `defaultExtensions` unset embeds everything discovered; setting it to an
+empty list does the same, rather than embedding nothing.
 
 ### Standalone Project Usage
 
@@ -310,7 +326,7 @@ Then in your project, add `mavenLocal()` to repositories or pluginManagement.
 ./gradlew :btrace-dist:fatAgentJar -PembedExtensions=btrace-metrics
 
 # Verify output
-jar -tf btrace-dist/build/resources/main/v*/libs/btrace-agent-fat.jar | grep btrace-extensions
+jar -tf btrace-dist/build/fat-agent/btrace-agent-fat.jar | grep btrace-extensions
 ```
 
 ---

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceExtensionPlugin.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceExtensionPlugin.groovy
@@ -31,27 +31,32 @@ class BTraceExtensionPlugin implements Plugin<Project> {
         // Optionally apply maven-publish when available so we can publish artifacts easily
         try { project.plugins.apply('maven-publish') } catch (Throwable ignore) {}
 
-        // Try to ensure Shadow is available; if resolution is blocked, we will emit a clear
-        // error later with guidance. This is best-effort and safe when already applied.
-        try {
-            if (!project.pluginManager.hasPlugin('com.gradleup.shadow')) {
-                // Respect opt-out
-                def ext = project.extensions.findByType(BTraceExtensionMetadata)
-                boolean shouldAutoApply = (ext == null) ? true : (ext.autoApplyShadow != false)
-                if (shouldAutoApply) {
-                    project.logger.lifecycle("[BTRACE-EXT] Applying Shadow plugin automatically (com.gradleup.shadow) for ${project.path}")
-                    project.pluginManager.apply('com.gradleup.shadow')
-                } else {
-                    project.logger.lifecycle("[BTRACE-EXT] Shadow auto-apply disabled (btraceExtension.autoApplyShadow=false) for ${project.path}")
-                }
-            }
-        } catch (Throwable t) {
-            project.logger.warn("[BTRACE-EXT] Unable to auto-apply Shadow plugin: ${t.message}. Apply it explicitly via plugins { id 'com.gradleup.shadow' } or alias(libs.plugins.shadow), or set btraceExtension.autoApplyShadow=true.")
-        }
-
         // Create extension for metadata
         def extension = project.extensions.create('btraceExtension', BTraceExtensionMetadata)
         extension.version = project.version
+
+        // Try to ensure Shadow is available; if resolution is blocked, we will emit a clear
+        // error later with guidance. This is best-effort and safe when already applied.
+        //
+        // Deferred until the project is evaluated because autoApplyShadow is set from the
+        // btraceExtension block, which runs after this plugin is applied. Reading it here would
+        // always see the default and silently ignore the opt-out. Tasks that need Shadow attach
+        // through pluginManager.withPlugin, which fires whenever it is applied, so deferring
+        // costs nothing.
+        project.afterEvaluate {
+            try {
+                if (!project.pluginManager.hasPlugin('com.gradleup.shadow')) {
+                    if (extension.autoApplyShadow != false) {
+                        project.logger.lifecycle("[BTRACE-EXT] Applying Shadow plugin automatically (com.gradleup.shadow) for ${project.path}")
+                        project.pluginManager.apply('com.gradleup.shadow')
+                    } else {
+                        project.logger.lifecycle("[BTRACE-EXT] Shadow auto-apply disabled (btraceExtension.autoApplyShadow=false) for ${project.path}")
+                    }
+                }
+            } catch (Throwable t) {
+                project.logger.warn("[BTRACE-EXT] Unable to auto-apply Shadow plugin: ${t.message}. Apply it explicitly via plugins { id 'com.gradleup.shadow' } or alias(libs.plugins.shadow), or set btraceExtension.autoApplyShadow=true.")
+            }
+        }
         def authoredSourceSet = {
             project.sourceSets.main
         }

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentExtension.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentExtension.groovy
@@ -62,6 +62,15 @@ class BTraceFatAgentExtension {
     /** Property name for filtering extensions when autoDiscover is true */
     String filterProperty = 'embedExtensions'
 
+    /**
+     * Extensions auto-discovery embeds when the filter property is absent. Entries match a
+     * subproject's name or its path.
+     *
+     * <p>Null selects every discovered extension, which is the historical behaviour. An empty
+     * list means the same thing, not "none" - set the filter property to restrict a build.
+     */
+    List<String> defaultExtensions = null
+
     BTraceFatAgentExtension(Project project) {
         this.project = project
         this.outputDir = project.layout.buildDirectory.dir('libs').get().asFile

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy
@@ -249,10 +249,29 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
             }
 
             doFirst {
-                // Read embedded extensions list and add to manifest
+                // Read embedded extensions list and add to manifest.
+                //
+                // Merged with whatever the engine already declared rather than replacing it. The
+                // published BTrace engine embeds the default extensions, and its class data is
+                // copied into this jar wholesale; dropping its ids from the manifest would leave
+                // those extensions present as files but invisible to the loader, which reads this
+                // attribute to decide what exists. The result would be dead weight in every
+                // downstream fat agent.
+                def embedded = new LinkedHashSet<String>()
+                def seeded = manifest.attributes['BTrace-Embedded-Extensions']
+                if (seeded) {
+                    seeded.toString().split(',').each { id ->
+                        if (id.trim()) embedded << id.trim()
+                    }
+                }
                 def extListFile = new File(stagingDir, 'embedded-extensions.txt')
                 if (extListFile.exists() && extListFile.text.trim()) {
-                    manifest.attributes['BTrace-Embedded-Extensions'] = extListFile.text.trim()
+                    extListFile.text.trim().split(',').each { id ->
+                        if (id.trim()) embedded << id.trim()
+                    }
+                }
+                if (!embedded.isEmpty()) {
+                    manifest.attributes['BTrace-Embedded-Extensions'] = embedded.join(',')
                 }
 
                 // Add user-specified manifest attributes

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy
@@ -578,9 +578,23 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
             ? project.property(extension.filterProperty).toString().split(',').toList()
             : null
 
+        // Spelled out rather than written as a chain of elvis operators: an empty defaultExtensions
+        // is falsy, so `filterList ?: extension.defaultExtensions` would select nothing at all and
+        // silently produce an extension-free fat agent.
+        def selection
+        if (filterList != null) {
+            selection = filterList
+        } else if (extension.defaultExtensions) {
+            selection = extension.defaultExtensions
+        } else {
+            selection = null
+        }
+
         project.rootProject.subprojects.each { sp ->
             if (sp.plugins.hasPlugin('io.btrace.extension')) {
-                if (filterList == null || filterList.contains(sp.name)) {
+                // Consumers set the filter property using project names, while an in-build default
+                // list is naturally written with project paths. Accept either.
+                if (selection == null || selection.contains(sp.name) || selection.contains(sp.path)) {
                     // Add as project source if not already present
                     def alreadyAdded = extension.extensionSources.any { source ->
                         source instanceof ProjectExtensionSource && source.projectPath == sp.path

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceFatAgentPlugin.groovy
@@ -94,6 +94,15 @@ class BTraceFatAgentPlugin implements Plugin<Project> {
             group = 'BTrace Fat Agent'
             description = 'Resolves and stages extension content for fat agent JAR'
 
+            // Which extensions are staged is determined entirely by configuration - the DSL, the
+            // default set and the filter property - and none of it is a file Gradle can watch.
+            // Undeclared, this task is considered up to date whenever the staging directory
+            // exists, so a build that changes the selection silently reuses the previous
+            // extension set and produces a fat agent that does not match what was asked for.
+            inputs.property('extensionSources', project.provider {
+                extension.extensionSources.collect { it.toString() }.sort()
+            })
+
             outputs.dir(stagingDir)
 
             doLast {

--- a/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceExtensionPluginTest.java
+++ b/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceExtensionPluginTest.java
@@ -443,4 +443,63 @@ class BTraceExtensionPluginTest {
         Files.createDirectories(path.getParent());
         Files.writeString(path, content, StandardCharsets.UTF_8);
     }
+
+    /**
+     * Writes an extension project that does not apply Shadow itself, so auto-apply decides.
+     *
+     * @param autoApplyShadow value for the opt-out, or null to leave it at the default
+     */
+    private void writeAutoApplyProject(Boolean autoApplyShadow) throws IOException {
+        Path dir = projectDir.resolve("ext");
+        Files.createDirectories(dir.resolve("src/main/java/com/example/api"));
+        writeFile(
+                dir.resolve("build.gradle"),
+                "plugins {\n"
+                        + "  id 'java-library'\n"
+                        + "  id 'io.btrace.extension'\n"
+                        + "}\n"
+                        + "group = 'com.example'\n"
+                        + "version = '1.0'\n"
+                        + "btraceExtension {\n"
+                        + "  id = 'test.ext'\n"
+                        + "  name = 'Test Extension'\n"
+                        + (autoApplyShadow == null ? "" : "  autoApplyShadow = " + autoApplyShadow + "\n")
+                        + "}\n");
+    }
+
+    @Test
+    @DisplayName("autoApplyShadow = false suppresses the automatic Shadow apply")
+    void autoApplyShadowFalseIsHonoured() throws IOException {
+        // The flag is set from the btraceExtension block, which runs after the plugin is applied,
+        // so honouring it requires the decision to be deferred past project evaluation.
+        writeAutoApplyProject(false);
+
+        // Opting out without applying Shadow yourself is expected to fail: the plugin needs it and
+        // says so. That failure is the proof the opt-out was honoured - previously the flag was
+        // read before the extension existed, so Shadow was applied regardless and this build
+        // succeeded.
+        BuildResult result = createRunner().withArguments(":ext:tasks").buildAndFail();
+
+        assertTrue(
+                result.getOutput().contains("Shadow auto-apply disabled"),
+                "plugin should report the opt-out was honoured:\n" + result.getOutput());
+        assertFalse(
+                result.getOutput().contains("Applying Shadow plugin automatically"),
+                "Shadow must not be auto-applied when the opt-out is set:\n" + result.getOutput());
+        assertTrue(
+                result.getOutput().contains("Shadow plugin is required"),
+                "opting out should surface the documented guidance:\n" + result.getOutput());
+    }
+
+    @Test
+    @DisplayName("Shadow is auto-applied when the opt-out is not set")
+    void shadowIsAutoAppliedByDefault() throws IOException {
+        writeAutoApplyProject(null);
+
+        BuildResult result = createRunner().withArguments(":ext:tasks").build();
+
+        assertTrue(
+                result.getOutput().contains("Applying Shadow plugin automatically"),
+                "Shadow should still be auto-applied by default:\n" + result.getOutput());
+    }
 }

--- a/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceFatAgentPluginTest.java
+++ b/btrace-gradle-plugin/src/test/java/io/btrace/gradle/BTraceFatAgentPluginTest.java
@@ -829,4 +829,155 @@ class BTraceFatAgentPluginTest {
             writer.write(content);
         }
     }
+
+    // ---------------------------------------------------------------------------------------
+    // Auto-discovery selection.
+    //
+    // These assert which extensions auto-discovery picks, and nothing else. Selection happens in
+    // gradle.projectsEvaluated, before any task action, so `printSources` can read it without
+    // building an API jar for anything.
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Writes a root project applying the fat-agent plugin plus three extension subprojects, and a
+     * {@code printSources} task that reports the discovered selection.
+     *
+     * @param defaultExtensionsLiteral Groovy literal for {@code defaultExtensions}, or null to
+     *     leave the property unset
+     */
+    private void writeDiscoveryProject(String defaultExtensionsLiteral) throws IOException {
+        writeFile(
+                settingsFile,
+                "rootProject.name = 'test-project'\n" + "include 'ext-alpha', 'ext-beta', 'ext-gamma'\n");
+        // Gradle refuses to configure an included project whose directory does not exist.
+        for (String name : new String[] {"ext-alpha", "ext-beta", "ext-gamma"}) {
+            Files.createDirectories(projectDir.resolve(name));
+        }
+
+        // The extension plugin auto-applies Shadow during apply(), before it creates the extension
+        // holding autoApplyShadow, so the opt-out cannot be set from a build script in time. Supply
+        // a stub under both plugin ids instead - none of these projects is ever built, only
+        // inspected for which extensions auto-discovery selected.
+        writeBuildSrcShadowStub();
+
+        StringBuilder root = new StringBuilder();
+        root.append("plugins { id 'io.btrace.fat-agent' }\n");
+        root.append("subprojects {\n");
+        root.append("    apply plugin: 'io.btrace.extension'\n");
+        root.append("    btraceExtension { btraceVersion = '3.0.0' }\n");
+        root.append("}\n");
+        root.append("btraceFatAgent {\n");
+        root.append("    autoDiscover = true\n");
+        if (defaultExtensionsLiteral != null) {
+            root.append("    defaultExtensions = ").append(defaultExtensionsLiteral).append("\n");
+        }
+        root.append("}\n");
+        root.append("tasks.register('printSources') {\n");
+        root.append("    doLast {\n");
+        root.append("        def paths = btraceFatAgent.extensionSources.collect { it.projectPath }.sort()\n");
+        root.append("        println 'SELECTED=' + paths.join(',')\n");
+        root.append("    }\n");
+        root.append("}\n");
+        writeFile(buildFile, root.toString());
+    }
+
+    /** Minimal stand-in for the Shadow plugin, registered under both ids the extension plugin tries. */
+    private void writeBuildSrcShadowStub() throws IOException {
+        Path dir =
+                projectDir.resolve("buildSrc/src/main/groovy/com/github/jengelman/gradle/plugins/shadow");
+        Files.createDirectories(dir);
+        Path descriptors = projectDir.resolve("buildSrc/src/main/resources/META-INF/gradle-plugins");
+        Files.createDirectories(descriptors);
+        writeFile(
+                projectDir.resolve("buildSrc/build.gradle").toFile(),
+                "plugins { id 'groovy-gradle-plugin' }\nrepositories { mavenCentral() }\n");
+        writeFile(
+                dir.resolve("ShadowPlugin.groovy").toFile(),
+                "package com.github.jengelman.gradle.plugins.shadow\n"
+                        + "import org.gradle.api.Plugin\n"
+                        + "import org.gradle.api.Project\n"
+                        + "class ShadowPlugin implements Plugin<Project> {\n"
+                        + "  void apply(Project project) {\n"
+                        + "    project.tasks.register('shadowJar', ShadowJar)\n"
+                        + "  }\n"
+                        + "}\n");
+        writeFile(
+                dir.resolve("ShadowJar.groovy").toFile(),
+                "package com.github.jengelman.gradle.plugins.shadow\n"
+                        + "import org.gradle.api.tasks.Internal\n"
+                        + "import org.gradle.api.tasks.bundling.Jar\n"
+                        + "abstract class ShadowJar extends Jar {\n"
+                        + "  @Internal Object configurations\n"
+                        + "  void relocate(String from, String to) {}\n"
+                        + "  void minimize() {}\n"
+                        + "}\n");
+        String descriptor =
+                "implementation-class=com.github.jengelman.gradle.plugins.shadow.ShadowPlugin\n";
+        writeFile(descriptors.resolve("com.gradleup.shadow.properties").toFile(), descriptor);
+        writeFile(
+                descriptors.resolve("com.github.johnrengelman.shadow.properties").toFile(), descriptor);
+    }
+
+    private String selectionOf(BuildResult result) {
+        for (String line : result.getOutput().split("\\R")) {
+            if (line.startsWith("SELECTED=")) {
+                return line.substring("SELECTED=".length()).trim();
+            }
+        }
+        throw new AssertionError("printSources did not report a selection:\n" + result.getOutput());
+    }
+
+    @Test
+    @DisplayName("Auto-discovery embeds every extension when nothing constrains it")
+    void autoDiscoveryEmbedsEverythingByDefault() throws IOException {
+        writeDiscoveryProject(null);
+
+        BuildResult result = createRunner().withArguments("printSources").build();
+
+        assertEquals(":ext-alpha,:ext-beta,:ext-gamma", selectionOf(result));
+    }
+
+    @Test
+    @DisplayName("defaultExtensions restricts auto-discovery when the filter property is absent")
+    void defaultExtensionsRestrictsDiscovery() throws IOException {
+        writeDiscoveryProject("[':ext-alpha', ':ext-gamma']");
+
+        BuildResult result = createRunner().withArguments("printSources").build();
+
+        assertEquals(":ext-alpha,:ext-gamma", selectionOf(result));
+    }
+
+    @Test
+    @DisplayName("The filter property overrides defaultExtensions")
+    void filterPropertyOverridesDefaultExtensions() throws IOException {
+        writeDiscoveryProject("[':ext-alpha']");
+
+        BuildResult result =
+                createRunner().withArguments("printSources", "-PembedExtensions=ext-beta").build();
+
+        assertEquals(":ext-beta", selectionOf(result));
+    }
+
+    @Test
+    @DisplayName("defaultExtensions accepts project names as well as paths")
+    void defaultExtensionsAcceptsProjectNames() throws IOException {
+        writeDiscoveryProject("['ext-beta']");
+
+        BuildResult result = createRunner().withArguments("printSources").build();
+
+        assertEquals(":ext-beta", selectionOf(result));
+    }
+
+    @Test
+    @DisplayName("An empty defaultExtensions embeds everything rather than nothing")
+    void emptyDefaultExtensionsEmbedsEverything() throws IOException {
+        // Groovy treats an empty list as falsy. Were the selection written as a chain of elvis
+        // operators, this would silently yield an extension-free fat agent for every consumer that
+        // had not set the property.
+        writeDiscoveryProject("[]");
+
+        BuildResult result = createRunner().withArguments("printSources").build();
+
+        assertEquals(":ext-alpha,:ext-beta,:ext-gamma", selectionOf(result));
+    }
 }

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -78,6 +78,11 @@ jbang catalog add --name btraceio https://raw.githubusercontent.com/btraceio/jba
 jbang btrace@btraceio <PID> <script.java>
 ```
 
+**Extensions:** The published artifact bundles the default extensions, so a script that injects a
+service such as `MetricsService` or `PrinterService` works under jbang without a separate
+BTrace installation. A distribution install resolves extensions from `$BTRACE_HOME/extensions/`
+instead; those take precedence over the embedded copies when both are present.
+
 **Agent JAR:** The client automatically discovers the masked agent JAR (`btrace.jar`) on its classpath — no extraction step is needed. If you want to use the agent JAR directly (e.g., with `-javaagent`), find it in the Maven local repository (default `~/.m2`) after jbang downloads BTrace:
 ```bash
 # The masked agent JAR is cached at:
@@ -743,7 +748,7 @@ The fat agent bundles everything into a single JAR that works without `$BTRACE_H
 ./gradlew :btrace-dist:fatAgentJar -PembedExtensions=btrace-metrics,btrace-statsd
 
 # Output location
-ls btrace-dist/build/resources/main/v*/libs/btrace-agent-fat.jar
+ls btrace-dist/build/fat-agent/btrace-agent-fat.jar
 ```
 
 ### Using the Fat Agent

--- a/docs/Migration-2.x-to-3.0.md
+++ b/docs/Migration-2.x-to-3.0.md
@@ -54,7 +54,7 @@ scripts/migrate-btrace-script.sh -r scripts-dir/
 
 ## Maven and Gradle Coordinates
 
-The group id changed from `org.openjdk.btrace` to `io.btrace`, and BTrace now publishes a single artifact containing the agent, client, and compiler:
+The group id changed from `org.openjdk.btrace` to `io.btrace`, and BTrace now publishes a single artifact containing the agent, client, compiler, and the default extensions:
 
 ```xml
 <dependency>

--- a/docs/architecture/fat-agent-plugin.md
+++ b/docs/architecture/fat-agent-plugin.md
@@ -161,10 +161,17 @@ project.gradle.projectsEvaluated {
 }
 ```
 
-Filtering via property:
+The selection is narrowed in two ways. `defaultExtensions` names the subset to embed when the
+filter property is absent, matching either a subproject's name or its path; the filter property
+overrides it and can select anything discoverable:
+
 ```bash
 ./gradlew fatAgentJar -PembedExtensions=btrace-metrics,btrace-statsd
 ```
+
+`btrace-dist` sets `defaultExtensions` to the released extension set, so an ordinary
+`fatAgentJar` build embeds exactly what a release ships rather than every extension in the
+repository — the test fixture and the Spark and Hadoop examples are excluded.
 
 ### ShadowJar Integration
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -129,7 +129,7 @@ The workflow does **not** auto-release - you must manually publish from the Cent
 ```
 
 Available artifacts:
-- `io.btrace:btrace` — the single masked JAR (agent + client + boot merged; see [Masked JAR Architecture](architecture/MaskedJarArchitecture.md))
+- `io.btrace:btrace` — the single masked JAR (agent + client + boot merged; see [Masked JAR Architecture](architecture/MaskedJarArchitecture.md)), with the default extensions embedded so that Maven and jbang users get the same capability a distribution install has
 
 The release workflow publishes only the `:btrace-dist` publications (`./gradlew :btrace-dist:publishAllPublicationsToSonatypeRepository`); the legacy `btrace-agent`/`btrace-client`/`btrace-boot` artifacts are no longer published.
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -62,6 +62,43 @@ task stageExternalTypeClientHome {
     }
 }
 
+// Homes for the embedded-extension test. Each holds a single libs/btrace.jar and deliberately no
+// sibling extensions/ directory: the client derives the extension API classpath from btrace.libs'
+// parent, so staging next to the real distribution would let its extensions satisfy the probe and
+// the test would pass without ever exercising the embedded copies.
+def embeddedExtHome = layout.buildDirectory.dir('embedded-extension-home')
+def embeddedExtLibs = embeddedExtHome.map { it.dir('libs') }
+def leanEngineHome = layout.buildDirectory.dir('lean-engine-home')
+def leanEngineLibs = leanEngineHome.map { it.dir('libs') }
+def publishedFatAgent = project(':btrace-dist').layout.buildDirectory.file('fat-agent/btrace-agent-fat.jar')
+
+task stageEmbeddedExtensionHomes {
+    dependsOn ':btrace-dist:btraceJar', ':btrace-dist:fatAgentJar'
+    inputs.file releaseBtraceJar
+    inputs.file publishedFatAgent
+    outputs.dir embeddedExtHome
+    outputs.dir leanEngineHome
+
+    doLast {
+        // The published artifact is the fat agent; the client locates the engine by the
+        // btrace.jar name, so stage it under that name.
+        File withExtensions = embeddedExtHome.get().asFile
+        project.delete(withExtensions)
+        project.copy {
+            from publishedFatAgent
+            into new File(withExtensions, 'libs')
+            rename { 'btrace.jar' }
+        }
+
+        File withoutExtensions = leanEngineHome.get().asFile
+        project.delete(withoutExtensions)
+        project.copy {
+            from releaseBtraceJar
+            into new File(withoutExtensions, 'libs')
+        }
+    }
+}
+
 task compileTestProbes {
     dependsOn compileTestJava, ':btrace-agent:jar', ':btrace-compiler:jar'
     // Wire all extension buildApiJar tasks dynamically (parent aggregator dissolved)
@@ -130,7 +167,8 @@ test {
     dependsOn cleanTest, buildEventsJar, compileTestProbes,
              ':btrace-dist:btraceJar',
              ':btrace-dist:explodeExtensions',
-             stageExternalTypeClientHome
+             stageExternalTypeClientHome,
+             stageEmbeddedExtensionHomes
     dependsOn gradle.includedBuild('btrace-gradle-plugin').task(':jar')
 
     testLogging.showStandardStreams = true
@@ -212,6 +250,8 @@ test {
     def libsPath = "${projectDir}/../btrace-dist/build/resources/main/v${project.version}/libs/"
     systemProperty 'btrace.externalType.client.libs', externalTypeClientLibs.get().asFile.absolutePath
     systemProperty 'btrace.externalType.extensions', externalTypeExtensions.get().asFile.absolutePath
+    systemProperty 'btrace.embedded.libs', embeddedExtLibs.get().asFile.absolutePath
+    systemProperty 'btrace.embedded.lean.libs', leanEngineLibs.get().asFile.absolutePath
     def isJava8 = props.getProperty("JAVA_VERSION")?.contains("1.8")
     if (isJava8) {
         jvmArgs "-Dproject.dir=${projectDir}", "-Dproject.version=${project.version}", "-Dbtrace.libs=${libsPath}"

--- a/integration-tests/src/test/btrace/EmbeddedExtensionTest.java
+++ b/integration-tests/src/test/btrace/EmbeddedExtensionTest.java
@@ -1,0 +1,26 @@
+package btrace;
+
+import io.btrace.core.annotations.BTrace;
+import io.btrace.core.annotations.Injected;
+import io.btrace.core.annotations.OnMethod;
+import io.btrace.utils.PrinterService;
+
+import static io.btrace.core.BTraceUtils.exit;
+
+/**
+ * Integration probe for extensions embedded in the published artifact.
+ *
+ * Injects a service from one of the default extensions and prints through it. The output is
+ * emitted by the extension rather than by BTraceUtils on purpose: printing directly would produce
+ * the expected line even if the service had never resolved, which is the whole thing under test.
+ */
+@BTrace
+public class EmbeddedExtensionTest {
+  @Injected private static PrinterService printer;
+
+  @OnMethod(clazz = "resources.Main", method = "callA")
+  public static void onCall() {
+    printer.println("embedded-extension-linked");
+    exit(0);
+  }
+}

--- a/integration-tests/src/test/java/tests/EmbeddedExtensionIntegrationTest.java
+++ b/integration-tests/src/test/java/tests/EmbeddedExtensionIntegrationTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2008, 2024, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tests.harness.Completion;
+
+/**
+ * End-to-end coverage for the extensions embedded in the published artifact.
+ *
+ * <p>A Maven or jbang user has no {@code $BTRACE_HOME/extensions} directory to discover, so the
+ * published artifact carries the default extensions inside it. This drives a probe that injects one
+ * of them against an engine staged the way such a user would have it: a lone {@code btrace.jar}
+ * with no sibling {@code extensions/} directory.
+ *
+ * <p>The paired lean case is what makes the first meaningful. Both stages are identical apart from
+ * which engine is present, so a passing embedded case that is not actually resolving anything from
+ * inside the jar would show up as the lean case passing too.
+ */
+public class EmbeddedExtensionIntegrationTest extends RuntimeTest {
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    classSetup();
+  }
+
+  @BeforeEach
+  @Override
+  public void reset() {
+    super.reset();
+    try (ServerSocket ss = new ServerSocket(0)) {
+      btracePort = ss.getLocalPort();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to find a free port", e);
+    }
+  }
+
+  /**
+   * Resolves a staged engine home and asserts it is isolated from the real distribution.
+   *
+   * @param property system property naming the staged {@code libs} directory
+   * @return the staged directory
+   */
+  private static Path stagedLibs(String property) {
+    Path libs = Paths.get(System.getProperty(property)).toAbsolutePath().normalize();
+    assertTrue(Files.isRegularFile(libs.resolve("btrace.jar")), "staged engine missing: " + libs);
+    // The client derives the extension API classpath from btrace.libs' parent. A sibling
+    // extensions/ directory here would let filesystem extensions satisfy the probe and both cases
+    // below would pass regardless of what the engine contains.
+    assertFalse(
+        Files.exists(libs.getParent().resolve("extensions")),
+        "staged engine must have no sibling extensions directory: " + libs.getParent());
+    return libs;
+  }
+
+  @Test
+  public void embeddedExtensionLinksWithoutADistribution() throws Exception {
+    clientBtraceLibs = stagedLibs("btrace.embedded.libs").toString();
+    attachDelayMs = 500;
+
+    testDynamic(
+        "resources.Main",
+        "btrace/EmbeddedExtensionTest.java",
+        Completion.untilContains("embedded-extension-linked"),
+        (stdout, stderr, retcode, args) ->
+            assertTrue(
+                stdout.contains("embedded-extension-linked"),
+                "probe should link the embedded extension and print through it:\n" + stdout));
+  }
+
+  @Test
+  public void leanEngineCannotLinkTheSameProbe() throws Exception {
+    clientBtraceLibs = stagedLibs("btrace.embedded.lean.libs").toString();
+    attachDelayMs = 500;
+
+    testDynamic(
+        "resources.Main",
+        "btrace/EmbeddedExtensionTest.java",
+        // The compile fails, so the probe's output never appears. The diagnostic goes to stderr,
+        // which a stdout-only condition would ignore, leaving the harness to sit until its timeout.
+        Completion.untilEitherContains("BTrace compilation failed"),
+        (stdout, stderr, retcode, args) ->
+            assertFalse(
+                stdout.contains("embedded-extension-linked"),
+                "an engine without embedded extensions must not satisfy the injection:\n"
+                    + stdout));
+  }
+}

--- a/integration-tests/src/test/java/tests/RuntimeTest.java
+++ b/integration-tests/src/test/java/tests/RuntimeTest.java
@@ -1407,6 +1407,10 @@ public abstract class RuntimeTest {
 
   private void configureTargetEnvironment(ProcessBuilder processBuilder) {
     processBuilder.environment().remove("JAVA_TOOL_OPTIONS");
+    // Filesystem extensions register at a higher priority than embedded ones, so a developer with
+    // a distribution install exported would silently have BTRACE_HOME satisfy anything a probe
+    // injects. Tests would then pass without exercising what they name.
+    processBuilder.environment().remove("BTRACE_HOME");
     if (targetExtensionPath != null) {
       processBuilder.environment().put("BTRACE_EXT_PATH", targetExtensionPath);
     }

--- a/integration-tests/src/test/java/tests/harness/Completion.java
+++ b/integration-tests/src/test/java/tests/harness/Completion.java
@@ -81,6 +81,45 @@ public interface Completion {
     };
   }
 
+  /**
+   * Satisfied once every marker substring has appeared across stdout <em>or</em> stderr.
+   *
+   * <p>Needed for conditions the client reports as diagnostics rather than probe output: compiler
+   * errors and {@code errorExit} messages go to stderr, which {@link #untilContains} ignores, so
+   * waiting for one of those with a stdout-only condition sits until the harness times out.
+   */
+  static Completion untilEitherContains(final String... markers) {
+    return new Completion() {
+      private final boolean[] found = new boolean[markers.length];
+      private int remaining = markers.length;
+
+      private boolean offer(String line) {
+        for (int i = 0; i < markers.length; i++) {
+          if (!found[i] && line.contains(markers[i])) {
+            found[i] = true;
+            remaining--;
+          }
+        }
+        return remaining <= 0;
+      }
+
+      @Override
+      public boolean onStdout(String line) {
+        return offer(line);
+      }
+
+      @Override
+      public boolean onStderr(String line) {
+        return offer(line);
+      }
+
+      @Override
+      public String describe() {
+        return "all of " + Arrays.toString(markers) + " (stdout or stderr)";
+      }
+    };
+  }
+
   /** Satisfied once {@code n} stdout lines match {@code pattern}. */
   static Completion untilMatches(final Pattern pattern, final int n) {
     return new Completion() {

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -123,13 +123,22 @@ wait_for_text() {
   return 1
 }
 
+# Set NO_BTRACE_HOME=1 for a single call to launch the target with BTRACE_HOME unset. Only the
+# embedded-extension legs want this: it stops a developer's SDKMAN install from satisfying an
+# @Injected service from $BTRACE_HOME/extensions/, which would leave the embedded copy untested.
+# It is defence-in-depth for local runs rather than the CI mechanism, since this script never
+# exports BTRACE_HOME - it passes it as a per-command prefix assignment.
 start_patient() {
   local label=$1
   shift
   stop_process "$TARGET_PID"
   TARGET_PID=""
   local log="$WORK/logs/${label}-target.log"
-  "$JAVA_HOME/bin/java" "$@" "$WORK/DemoApp.java" >"$log" 2>&1 &
+  if [ "${NO_BTRACE_HOME:-}" = "1" ]; then
+    env -u BTRACE_HOME "$JAVA_HOME/bin/java" "$@" "$WORK/DemoApp.java" >"$log" 2>&1 &
+  else
+    "$JAVA_HOME/bin/java" "$@" "$WORK/DemoApp.java" >"$log" 2>&1 &
+  fi
   TARGET_PID=$!
   wait_for_text "$log" "[demo] order service running" 30 || fail "$label target did not become ready"
 }
@@ -274,14 +283,24 @@ for mode in v1 v2 auto; do
 done
 
 echo "[smoke] embedded non-privileged and privileged extensions"
+# No allowExtensions entry: the policy only consults it on the privileged branch, so listing a
+# non-privileged extension asserts nothing. allowPrivileged=false is the meaningful constraint.
 cat >"$WORK/permissions.properties" <<'EOF'
-allowExtensions=btrace-hadoop-example
 allowPrivileged=false
 EOF
-start_patient embedded-non-privileged \
+NO_BTRACE_HOME=1 start_patient embedded-non-privileged \
   "-Dbtrace.permissions=$WORK/permissions.properties" \
   "-javaagent:$FAT_AGENT=port=0,debug=true"
 run_doctor embedded-non-privileged 0 "READY"
+# Prove the extension came from the fat agent rather than $BTRACE_HOME/extensions/. Every
+# release extension is also exploded into the distribution, so without this the leg would pass
+# on the filesystem copy and never exercise the embedded one.
+wait_for_text "$WORK/logs/embedded-non-privileged-target.log" \
+  "BTRACE_HOME not set; using embedded extensions only" 30 \
+  || fail "embedded-non-privileged target resolved a BTRACE_HOME instead of embedded extensions"
+wait_for_text "$WORK/logs/embedded-non-privileged-target.log" \
+  "Scanning repository: embedded:META-INF/btrace-extensions/" 30 \
+  || fail "embedded-non-privileged target did not scan the embedded extension repository"
 start_trace embedded-non-privileged "release-smoke: non-privileged extension" "" \
   "$TARGET_PID" NonPrivilegedExtensionProbe.java
 finish_trace
@@ -292,7 +311,7 @@ cat >"$WORK/permissions.properties" <<'EOF'
 allowExtensions=btrace-metrics
 allowPrivileged=true
 EOF
-start_patient embedded-privileged \
+NO_BTRACE_HOME=1 start_patient embedded-privileged \
   "-Dbtrace.permissions=$WORK/permissions.properties" \
   "-javaagent:$FAT_AGENT=port=0,debug=true"
 run_doctor embedded-privileged 0 "READY"

--- a/scripts/release-smoke/NonPrivilegedExtensionProbe.java
+++ b/scripts/release-smoke/NonPrivilegedExtensionProbe.java
@@ -1,17 +1,17 @@
-import static io.btrace.core.BTraceUtils.println;
-
 import io.btrace.core.annotations.BTrace;
 import io.btrace.core.annotations.Injected;
 import io.btrace.core.annotations.OnMethod;
-import org.example.btrace.hadoop.api.HadoopApi;
+import io.btrace.utils.PrinterService;
 
 @BTrace
 public class NonPrivilegedExtensionProbe {
-  @Injected private static HadoopApi hadoop;
+  @Injected private static PrinterService printer;
 
   @OnMethod(clazz = "OrderService", method = "processOrder")
   public static void onOrder() {
-    hadoop.onOpen(null, null);
-    println("release-smoke: non-privileged extension");
+    // Emitted through the injected service on purpose. Printing via BTraceUtils instead would
+    // make this probe produce the asserted line even when the service never resolved, which is
+    // exactly the failure the embedded-extension leg exists to catch.
+    printer.println("release-smoke: non-privileged extension");
   }
 }


### PR DESCRIPTION
Closes #901.

## Summary

`jbang io.btrace:btrace` gave users core tracing and none of the default extensions, while a
distribution install got both. `BTRACE_HOME` resolves by looking for a jar named `btrace.jar`
inside a directory named `libs`; under jbang the artifact sits in the local Maven repository
under neither name, so filesystem discovery finds nothing — and the published lean jar carried
nothing embedded either.

This publishes the fat agent under the existing `io.btrace:btrace` coordinates rather than
adding a second artifact.

**One artifact, not two.** The issue proposed a separate `btrace-all` alongside a lean
`io.btrace:btrace`. Measured against real jars, embedding the seven released extensions costs
**+6.6%** (4,477,111 vs 4,200,429 bytes), and an extension is inert until a script injects it.
A single batteries-included artifact is simpler for consumers, docs and the release pipeline
than a lean/full split, so the split was dropped by agreement. A slim API/SPI artifact can be
introduced later if a need appears.

It also means the `btrace@btraceio` jbang alias gains extensions with **no catalog change**,
keeping its `--add-modules=jdk.attach` options intact.

The distribution is unchanged: it still ships the lean `libs/btrace.jar` beside its
`extensions/` directory.

## What changed

**Auto-discovery could not express a released set.** It embedded every subproject applying
`io.btrace.extension` whenever the filter property was absent — ten of them, where only seven
belong in a release. `btraceFatAgent.defaultExtensions` names the subset to embed when the
filter property is absent; the property still wins when present, so custom builds that select
an example extension keep working, and a build setting neither keeps today's behaviour.

Entries match a subproject's **name or path**: consumers pass names via `-PembedExtensions`,
while an in-build list is naturally written with paths, and matching only one silently ships the
wrong extensions.

The selection is an `if`/`else` rather than an elvis chain on purpose — an empty list is falsy in
Groovy, so the compact form would read `defaultExtensions = []` as "embed nothing" and hand every
consumer that had not set the property an extension-free fat agent. A test pins that empty means
everything.

**The fat agent left the distribution staging tree.** Every distribution archive copies that tree
wholesale, so a fat agent written into it rides along into every zip, tarball, deb and rpm
whenever something builds it first. Only `buildSdkmanZip` was guarded; publishing made the hazard
reachable from the publish graph. A dedicated output directory removes it for all of them, and
both `mustRunAfter` workarounds go with it.

**Embedded extensions are merged, not replaced.** Building a fat agent on the published engine
copies its extension class data wholesale, so dropping its ids from the manifest would leave those
extensions present as files but invisible to the loader, which consults the manifest to decide
what exists.

## The embedded artifact could not compile a source probe

Embedding the extensions was not sufficient on its own. `Client.getExtensionApiClasspath()`
derived the compile classpath solely from a filesystem `extensions/` directory — beside
`btrace.libs`, or beside `btrace-client` on the classpath. A Maven or jbang user has no such
directory, which is the entire reason for embedding, so a source probe injecting an extension
service failed with `package io.btrace.utils does not exist` while the agent would have loaded
that same extension at runtime without trouble.

That is the documented primary flow — `jbang io.btrace:btrace <PID> <script.java>`. Without this
the artifact would have shipped able to run precompiled probes and unable to compile the
one-liner the README leads with, with the manifest, coordinates, publish gate and release-smoke
leg all green: every one of them exercises a distribution that *has* an `extensions/` directory,
which is the one configuration this feature exists to replace.

The agent JAR now serves as its own API classpath when it declares `BTrace-Embedded-Extensions`;
the API types are plain class entries at its root. Both ways of locating it are consulted —
`btrace.libs` for a distribution or explicitly configured client, and the engine's own code
source for jbang.

## Two pre-existing bugs found and fixed

**`stageExtensions` had no declared inputs.** The selection comes entirely from configuration,
which Gradle cannot watch, so the task was up to date whenever its output directory existed.
Following the documented workflow was enough to hit it: after any earlier build,
`fatAgentJar -PembedExtensions=btrace-spark` produced the *earlier* build's extensions with no
indication anything was ignored.

**`btraceExtension.autoApplyShadow` never took effect.** The flag was read during `apply()` via
`findByType`, but the extension holding it is created later in the same method, so the lookup
always returned null and Shadow was applied unconditionally. Reading it there could not work in
any case — `apply()` runs before the `btraceExtension` block. The decision is now deferred to
project evaluation.

## Verification

- Published `io.btrace:btrace:3.0.0-SNAPSHOT` locally and confirmed the manifest declares exactly
  the seven released extensions, with correct unclassified coordinates.
- `:btrace-dist:build` green, with `btrace-agent-fat.jar` absent from the distribution zip.
- Plugin suite green. The `defaultExtensions` tests were checked non-vacuous by reverting only
  the selection logic: exactly the two behavioural cases fail, while the preserved-behaviour cases
  still pass.
- The `autoApplyShadow` test was checked the same way — reverting only the plugin fix fails
  exactly that test.
- The publish gate was verified in **both** directions. It initially passed against a stale jar
  when given a deliberately wrong selection, which is what exposed the staleness bug above.
- `EmbeddedExtensionIntegrationTest` drives a probe injecting a default extension's service
  against an engine staged as a lone `btrace.jar` with no sibling `extensions/`. The lean engine
  is staged identically as the paired case, so an embedded case passing without resolving
  anything from inside the JAR would show up as both cases passing. Observed:

  ```
  [btrace out] embedded-extension-linked                       <- embedded engine
  [btrace err] package io.btrace.utils does not exist          <- lean engine
  ```

Two harness gaps closed to make that meaningful: `RuntimeTest` never cleared `BTRACE_HOME`, so a
developer with a distribution install exported would have had filesystem extensions silently
satisfy the injection; and `Completion.untilContains` reads stdout only while the compiler
diagnostic goes to stderr, so the lean case would have waited out the timeout instead of failing.

**Review note:** the embedded-API-classpath fallback in `Client` is the newest and
least-exercised path here. It is verified in both directions by the test above, but it has a
single test behind it.

Depends on #927, which repairs the release-smoke embedded-extension leg that exercises this
artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/928)
<!-- Reviewable:end -->
