### PR TITLE
fix(extensions): make the Spark example resolvable, and fail the build when a service has no implementation

### DIFF
--- a/btrace-extensions/examples/btrace-spark/src/main/resources/META-INF/services/org.example.btrace.spark.api.SparkApi
+++ b/btrace-extensions/examples/btrace-spark/src/main/resources/META-INF/services/org.example.btrace.spark.api.SparkApi
@@ -1,0 +1,1 @@
+org.example.btrace.spark.impl.SparkApiImpl

--- a/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceExtensionPlugin.groovy
+++ b/btrace-gradle-plugin/src/main/groovy/io/btrace/gradle/BTraceExtensionPlugin.groovy
@@ -260,6 +260,39 @@ class BTraceExtensionPlugin implements Plugin<Project> {
                     throw new GradleException("[BTRACE-EXT] Found ${extDescCount} package-level @ExtensionDescriptor annotations. Only one is allowed per extension project (place it in API package-info.java).")
                 }
 
+                // Enforce: every declared service must have an implementation the runtime can find.
+                // Resolution is ServiceLoader first, then the exact name <serviceFqcn>Impl, so an
+                // implementation placed in a separate package without a provider file resolves to
+                // nothing. That extension still builds, packages, installs and loads; it fails only
+                // when a probe injects the service, at the probe's call site, which is a long way
+                // from the cause.
+                def classFileExists = { String fqcn ->
+                    String rel = fqcn.replace('.', '/') + '.class'
+                    return authoredClassesDirs().any { File dir -> dir != null && new File(dir, rel).isFile() }
+                }
+                def providerNamesAnImpl = { String service ->
+                    def srcDirs = authoredSourceSet().resources.srcDirs as Set
+                    return srcDirs.any { File resDir ->
+                        File providerFile = new File(resDir, 'META-INF/services/' + service)
+                        if (!providerFile.isFile()) return false
+                        return providerFile.readLines().any { String raw ->
+                            String name = raw.replaceAll(/#.*/, '').trim()
+                            return !name.isEmpty() && classFileExists(name)
+                        }
+                    }
+                }
+                def unresolvedServices = explicitServiceTypes().findAll { String service ->
+                    service != null && !service.isEmpty() &&
+                        !classFileExists(service + 'Impl') && !providerNamesAnImpl(service)
+                }
+                if (!unresolvedServices.isEmpty()) {
+                    throw new GradleException(
+                        "[BTRACE-EXT] No implementation found for declared service(s): ${unresolvedServices}. " +
+                        "Name the implementation <service>Impl in the service's own package, or add " +
+                        "META-INF/services/<service> naming the implementing class. Without one of those the " +
+                        "extension builds and installs, then injection fails at the probe call site.")
+                }
+
                 // Prefer explicitly configured services; otherwise, detect via @ServiceDescriptor annotations
                 def services = extension.services as List<String>
                 if (!services || services.isEmpty()) {


### PR DESCRIPTION
Found while analysing #907.

## The Spark example cannot resolve its own service

`ExtensionBridgeImpl.findImplementationClass` tries `ServiceLoader` first, then falls back to
**literal FQN concatenation** — `ifaceName + "Impl"`.

| Example | Interface | Implementation | Provider file | Resolves |
|---|---|---|---|---|
| `btrace-hadoop` | `…hadoop.api.HadoopApi` | `…hadoop.impl.HadoopApiImpl` | present | yes |
| `btrace-spark` | `…spark.api.SparkApi` | `…spark.impl.SparkApiImpl` | **none** | **no** |

With no provider file the convention resolves `…spark.api.SparkApiImpl`, which does not exist, so
lookup returns null and injection fails. The two examples have the identical `api`/`impl` layout;
the only difference is that Hadoop declares its provider.

Adds the equivalent declaration for Spark.

## Nothing caught it, so the build now does

The extension compiles, packages, installs and loads. Only injection fails, at the probe call
site, a long way from the cause — the same failure mode observed live while walking the migration
for #906.

`validateServiceApis` now verifies that every declared service has an implementation the runtime
can actually find, and fails the build naming the service when it does not.

The check accepts either route the runtime accepts — the exact `<serviceFqcn>Impl` name, or a
provider file naming a class that exists — and fires only when both are absent. It deliberately
does not express a preference between them: an `api`/`impl` package split is legitimate and is
what the extension guidance encourages, it simply requires the provider declaration.

## Verification

Both directions, since a gate that cannot fail is worse than no gate:

- Fails on `btrace-spark` before the fix:
  `No implementation found for declared service(s): [org.example.btrace.spark.api.SparkApi]`
- Passes on `btrace-hadoop`, whose only difference is the provider file.
- Passes on all eight shipped extensions and `btrace-ext-test`.
- `:btrace-gradle-plugin:test` and `spotlessCheck` pass.
- The provider declaration is present in the packaged impl jar, where the runtime looks for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/930)
<!-- Reviewable:end -->
