### PR TITLE
docs: correct the libs/profiles migration row and point at the migration skill

### DIFF
--- a/docs/Migration-2.x-to-3.0.md
+++ b/docs/Migration-2.x-to-3.0.md
@@ -11,7 +11,7 @@ Good news first: for most users, migrating to BTrace 3.0 requires **no action at
 | Mixed 2.x/3.0 client and agent | **Nothing** — the wire protocol auto-negotiates |
 | Maven/Gradle dependencies | Update coordinates to `io.btrace:btrace` |
 | Launch scripts referencing multiple BTrace jars | Point to the single `btrace.jar` |
-| `libs=` / profiles agent options | Migrate to extensions (deprecated but still working) |
+| `libs=` / profiles agent options | **Migrate to extensions** — removed, loads nothing |
 | Target JVMs on Java 8–16 | **Nothing** — deprecated, but fully supported throughout 3.x |
 
 ## Compiled and Persisted Probes: No Action Needed
@@ -74,7 +74,7 @@ Internally the jar uses *classdata masking*: only a small core API is visible to
 
 ## `libs` and Profiles: Removed in Favor of Extensions
 
-The `libs=<profile>` agent option has been removed. The agent logs an error naming the profile and loads nothing, so classes that used to reach probes through `btrace-libs/<profile>/` no longer resolve — typically surfacing as a probe failing on a type it previously saw. Extensions are the replacement — they provide isolation, permissions, and per-extension enable/disable instead of mutating the global classpath. See [Migrating from libs/profiles to Extensions](architecture/migrating-from-libs-profiles.md) for a step-by-step guide.
+The `libs=<profile>` agent option has been removed. The agent logs an error naming the profile and loads nothing, so classes that used to reach probes through `btrace-libs/<profile>/` no longer resolve — typically surfacing as a probe failing on a type it previously saw. Extensions are the replacement — they provide isolation, permissions, and per-extension enable/disable instead of mutating the global classpath. See [Migrating from libs/profiles to Extensions](architecture/migrating-from-libs-profiles.md) for a step-by-step guide, or the [`btrace-legacy-libs-migration`](https://github.com/btraceio/agent-plugins/blob/main/plugins/btrace-observability/skills/btrace-legacy-libs-migration/SKILL.md) skill to walk it with an assistant.
 
 ## Wire Protocol: Mixed Versions Keep Working
 


### PR DESCRIPTION
Closes #906.

## Summary

#929 documented `libs=`/profiles as removed and, once agent-plugins#2 published the skill, added
the assisted-migration cross-references to `docs/architecture/migrating-from-libs-profiles.md` and
`docs/BTraceExtensionDevelopmentGuide.md`. Both linked `SKILL.md` paths were confirmed present on
`btraceio/agent-plugins@main`, so acceptance criterion 8 is met for those two documents.

One row was missed.

## The TL;DR table still described the removed mechanism as working

`docs/Migration-2.x-to-3.0.md:14` read:

> \`libs=\` / profiles agent options | Migrate to extensions (deprecated but still working)

That contradicts `## libs and Profiles: Removed in Favor of Extensions` sixty lines below in the
same file, and it is the first thing a migrating user reads. It is also the precise claim #929 was
opened to retract: the option parsed, emitted a deprecation warning implying it still worked, and
loaded no jars.

A reader who trusts the table upgrades, sees the agent start cleanly, and discovers the breakage
later when a probe fails on a type it previously saw.

## Changes

- State the removal in the table row, matching the body section.
- Link the published `btrace-legacy-libs-migration` skill beside the step-by-step guide in the
  `libs` section, so the document users actually land on offers both the manual and the assisted
  route rather than requiring a hop through the architecture guide.

No other document needed a reference added.

## Verification

`spotlessCheck` passes. The change is confined to one markdown file; both external links resolve to
files present on `agent-plugins@main`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/933)
<!-- Reviewable:end -->
