### PR TITLE
fix(tests): make a stalled integration test fail fast instead of consuming the job

### DIFF
--- a/btrace-client/src/main/java/io/btrace/client/Client.java
+++ b/btrace-client/src/main/java/io/btrace/client/Client.java
@@ -1285,6 +1285,19 @@ public class Client {
     // Mark as disconnected to prevent shutdown hook from attempting further sends
     disconnected = true;
     IOException failure = null;
+    // Release a reader before closing the protocol. A command loop blocks in a read with no
+    // timeout -- V2 negotiation sets one and restores the previous value, which is unlimited -- so
+    // another thread may be inside a socket read when close() runs. Closing the protocol streams
+    // first means waiting on that reader to leave, which is the wrong order to depend on: shutting
+    // the input down makes the read return, and the stream closes below then have nothing to wait
+    // for.
+    try {
+      if (sock != null && !sock.isClosed() && !sock.isInputShutdown()) {
+        sock.shutdownInput();
+      }
+    } catch (IOException ignored) {
+      // Best effort: an already-reset connection is fine, the closes below still run.
+    }
     try {
       if (protocol != null) {
         protocol.close();

--- a/integration-tests/src/test/java/tests/BTraceFunctionalTests.java
+++ b/integration-tests/src/test/java/tests/BTraceFunctionalTests.java
@@ -37,7 +37,6 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -544,7 +543,7 @@ public class BTraceFunctionalTests extends RuntimeTest {
     assertNotNull(code, "BTrace compilation failed");
 
     CompletableFuture<String> probeIdFuture = new CompletableFuture<>();
-    ExecutorService executor = Executors.newSingleThreadExecutor();
+    ExecutorService executor = newDaemonExecutor("functional-probe-submit");
     Future<?> submitFuture =
         executor.submit(
             () -> {

--- a/integration-tests/src/test/java/tests/Issue888RuntimeHardeningIntegrationTest.java
+++ b/integration-tests/src/test/java/tests/Issue888RuntimeHardeningIntegrationTest.java
@@ -39,7 +39,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -84,7 +83,7 @@ public class Issue888RuntimeHardeningIntegrationTest extends RuntimeTest {
     assertNotNull(ready, "target did not report its PID");
     String pid = ready.substring("ready:".length());
     Client client = null;
-    ExecutorService executor = Executors.newSingleThreadExecutor();
+    ExecutorService executor = newDaemonExecutor("runtime-hardening-probe-submit");
     try (PrintWriter targetInput = new PrintWriter(target.getOutputStream(), true)) {
       try {
         File trace = locateTrace("btrace/Issue888RuntimeHardeningTest.java");

--- a/integration-tests/src/test/java/tests/PreparedModeAuthenticationFunctionalTest.java
+++ b/integration-tests/src/test/java/tests/PreparedModeAuthenticationFunctionalTest.java
@@ -33,7 +33,6 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
@@ -188,7 +187,7 @@ public class PreparedModeAuthenticationFunctionalTest extends RuntimeTest {
     File traceFile = locateTrace("btrace/OnTimerArgTest.java");
     assertNotNull(traceFile, "Test probe source is missing");
     Client client = createClient();
-    ExecutorService executor = Executors.newSingleThreadExecutor();
+    ExecutorService executor = newDaemonExecutor("prepared-mode-probe-submit");
     CompletableFuture<Void> started = new CompletableFuture<>();
     try {
       client.attach(String.valueOf(pid), null, getEventsClassPath());

--- a/integration-tests/src/test/java/tests/RuntimeTest.java
+++ b/integration-tests/src/test/java/tests/RuntimeTest.java
@@ -46,6 +46,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -140,6 +142,25 @@ public abstract class RuntimeTest {
     throw new IllegalStateException(
         "Cannot resolve a JDK for the integration tests: none of TEST_JAVA_HOME, JAVA_TEST_HOME,"
             + " JAVA_HOME or the java.home system property is set");
+  }
+
+  /**
+   * Creates a single-threaded executor whose thread is a daemon.
+   *
+   * <p>Tests submit probe work to a worker thread and tear it down with {@code shutdownNow}, which
+   * interrupts. A thread blocked in socket I/O does not answer an interrupt, and a non-daemon
+   * worker in that state keeps the test JVM alive after the class finishes, so the build stalls
+   * with nothing to report. A daemon thread cannot hold the JVM open.
+   *
+   * @param name thread name, to make a stuck worker identifiable in a dump
+   */
+  protected static ExecutorService newDaemonExecutor(String name) {
+    return Executors.newSingleThreadExecutor(
+        runnable -> {
+          Thread t = new Thread(runnable, name);
+          t.setDaemon(true);
+          return t;
+        });
   }
 
   public static void classSetup() {
@@ -916,6 +937,12 @@ public abstract class RuntimeTest {
   }
 
   public static final class TestApp {
+    /** How long a target gets to exit on its own after being told to stop. */
+    private static final int SHUTDOWN_TIMEOUT_SECONDS = 30;
+
+    /** How long it then gets after being destroyed forcibly. */
+    private static final int FORCED_SHUTDOWN_TIMEOUT_SECONDS = 10;
+
     private int pid;
     private final CountDownLatch testAppLatch = new CountDownLatch(1);
     private final Process process;
@@ -1000,7 +1027,13 @@ public abstract class RuntimeTest {
         PrintWriter pw = new PrintWriter(process.getOutputStream());
         pw.println("done");
         pw.flush();
-        process.waitFor();
+        // Bounded: a target that ignores "done" -- because the agent still holds it, or a probe
+        // never detached -- used to block the test here indefinitely, which surfaces as a job that
+        // burns its entire timeout with no failing assertion and leaves the JVM behind.
+        if (!process.waitFor(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+          process.destroyForcibly();
+          process.waitFor(FORCED_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        }
       }
     }
 


### PR DESCRIPTION
Addresses the diagnosability half of #932. Does not claim to fix the flake itself.

## Problem

A stalled integration test consumed the entire 30-minute CI budget and reported nothing — no
failing assertion, no stack trace, and seven orphaned JVMs at cleanup. Working out *which* test had
stalled meant reading the raw job log and comparing timestamps.

## Changes

~~**Per-method timeout, five minutes** (`junit-platform.properties`).~~ **Not in this diff — see
[this comment](https://github.com/btraceio/btrace/pull/934#issuecomment-5129138741).** The file was
written and verified locally, but `.gitignore:27`'s bare `junit*` pattern matches it at any depth,
so `git status` stayed clean and `git add -A` skipped it silently. #935 fixes the ignore rule and
carries the timeout (at eight minutes rather than five, for margin against `startupTimeoutMs`).

Everything below this line is in the diff and is unaffected.

**Bounded target shutdown.** `TestApp.stop()` waited on `process.waitFor()` with no limit, so a
target that ignores `done` blocked the test indefinitely. Now 30s, then `destroyForcibly()`. This
is also the only candidate that accounts for **seven** orphaned JVMs — one lingering worker thread
does not.

**Daemon threads for probe submission.** Tests submit to an executor and tear it down with
`shutdownNow()`, which interrupts; a thread blocked in socket I/O does not answer. A non-daemon
worker in that state keeps the test JVM alive after the class finishes, so the build stalls with
nothing to report. Threads are now named, so a stuck one is identifiable in a dump.

**Release the reader before closing the protocol** (`Client.close()`). The command loop blocks in a
read with no timeout — V2 negotiation sets one and restores the previous value, which is unlimited.
Closing the protocol streams first means waiting on that in-flight reader to exit.
`sock.shutdownInput()` makes the read return, so the closes that follow have nothing to wait on.

## Confidence

The first three are correct on their own merits and independent of root cause.

The fourth targets a mechanism inferred from code reading and the CI log shape, **not** from a
captured dump — 12 local reproduction attempts on macOS all passed, so the stall was never caught
in the act. It is safe regardless (`shutdownInput` is guarded and inert when no reader is active),
but it should not be considered a confirmed fix for #932 until a stall is caught with a thread
dump. The platform gap is the likely reason local reproduction failed: `NioSocketImpl`'s wake-up of
a blocked reader differs between Linux and macOS, which is precisely the implicated path.

## Verification

- Full integration suite: **58 tests pass**, 12m34s on 17.0.19-tem.
- ~~Timeout proven to actually fire: a temporary test sleeping for ten minutes failed at five with
  `TimeoutException` naming the stalled line.~~ This check did run and did pass, but against a
  working-tree file that never reached the commit, so it does not attest to anything in this diff.
  The verification was sound; what it verified is not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/934)
<!-- Reviewable:end -->

