### PR TITLE
test(integration): dump both JVMs when an integration test stalls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ btrace-benchmark/target
 btrace-benchmark/build
 benchmark/*.iml
 junit*
+# ... but the JUnit platform config is source, not build output
+!**/junit-platform.properties
 /btrace-statsd/target/
 *.iml
 .gradle

--- a/docs/superpowers/plans/2026-07-29-issue-932-stall-watchdog-plan.md
+++ b/docs/superpowers/plans/2026-07-29-issue-932-stall-watchdog-plan.md
@@ -224,3 +224,29 @@ Driven through the in-memory seam, scoped with `@StallTimeout`, output under `@T
 ## Order
 
 1 → 2 → 3 → 7 (tests for 1–3) → 6 → 4 → 5 → 8.
+
+
+## Revision 3 — corrections found by adversarial review of the implementation
+
+Two defects would have shipped silently, and both were confirmed by direct measurement rather than
+argument:
+
+1. **The per-test timeout was never committed.** `.gitignore`'s bare `junit*` pattern matches
+   `integration-tests/src/test/resources/junit-platform.properties` at any depth, so the file existed
+   locally, passed every local run, and was absent from the commit. `.gitignore` now carries a
+   negation, placed *after* the pattern it overrides, since the last matching pattern wins.
+2. **Test-JVM stacks were truncated to eight frames.** `ThreadInfo.toString()` caps output at
+   `MAX_FRAMES = 8`; a 44-frame stack rendered as 8. The dump is now rendered frame by frame with
+   locked monitors and synchronizers, and a test asserts the rendered depth exceeds eight.
+
+Also corrected: the stdout echo was the one unbounded wait in a class that bounds everything else,
+and it ran on one of only two scheduler threads — it now runs on a throwaway thread with a bounded
+join. The registry is pruned on disarm, so a late stall does not spend its capture budget on
+`jcmd` calls against processes from earlier classes. Dump filenames are truncated from the tail, not
+the head, because a parameterised unique id is identical up to its invocation index, and carry a
+sequence number so two teardown stalls in one class cannot collide on one path. The derived deadline
+is clamped below the per-test timeout, since `btrace.test.timeoutMs` is an operator knob that could
+otherwise push the watchdog past it. The four btrace client JVM launch sites are registered — the
+client is the side the surviving issue-932 hypothesis implicates. `budgetIsSharedAcrossTargets`
+passed against a per-target budget and now does not; `capturesTargetJvmThreads` would have failed a
+build rather than skipped when `jcmd` cannot attach on a loaded runner.

--- a/docs/superpowers/plans/2026-07-29-issue-932-stall-watchdog-plan.md
+++ b/docs/superpowers/plans/2026-07-29-issue-932-stall-watchdog-plan.md
@@ -1,0 +1,226 @@
+# Implementation plan — stall watchdog for integration tests
+
+Design: `docs/superpowers/specs/2026-07-29-issue-932-client-close-deadlock-design.md`.
+Branch: `agent/issue-932-client-close-deadlock`, worktree `.worktrees/issue-932-client-close`.
+Base: `origin/develop` @ `840564e9`. Independent of PR #934.
+
+Revision 2. Adversarial review of revision 1 found that the SIGQUIT fallback would have written a
+thread dump into the target stdout buffer that test validators assert on (`RuntimeTest.java:858` →
+`ManifestLibsTests.java:81`), turning a diagnostic into a test failure. That is removed, along with
+the echo flag that existed only to serve it. Other corrections are noted where they apply.
+
+Every command below runs from this worktree, prefixed `GRADLE_USER_HOME=$(pwd)/.gradle-user`, with
+output redirected to a log before filtering, per `AGENTS.md`.
+
+## Constraints
+
+- **Java 8 source level** for `integration-tests` tests (`build.gradle:15-18`). No `var`, no
+  `List.of`, no direct `Process.pid()`. Note this is enforced by convention only, and CI actually
+  runs the harness on Java 24 — the matrix JDK is the *target* JVM via `TEST_JAVA_HOME`.
+- **One worker JVM for all ten test classes.** No `forkEvery`, `maxParallelForks`, or
+  `junit-platform.properties` exists today. Static state is shared for the whole run, and a system
+  property set by one test leaks into every class after it.
+- Test knobs arrive via `-P` (`build.gradle:274` forwards project properties beginning with
+  `btrace.`).
+- The watchdog must never become the hang it diagnoses, and must never perturb the system under
+  test. Every wait is bounded; every internal failure is recorded as text, not thrown.
+
+## Task 1 — `TargetRegistry`
+
+New: `integration-tests/src/test/java/tests/harness/TargetRegistry.java`
+
+- `static Handle register(Process process, String label, String jcmdPath)` — called at launch,
+  before a pid is known. **`jcmdPath` is passed in at registration**, not resolved centrally:
+  `resolveTestJavaHome()` is `protected static` in package `tests` (`RuntimeTest.java:128`) and is
+  unreachable from `tests.harness`, and targets do not all come from the same JDK —
+  `Issue888RuntimeHardeningIntegrationTest.java:172` launches with the *build* JDK while the
+  `RuntimeTest` paths use `resolveTestJavaHome()`.
+- `Handle.setPid(String)` — called where a launch site parses `ready:`.
+- `static List<Snapshot> liveTargets()` — entries where `process.isAlive()`. Registering at launch
+  and filtering on liveness at capture removes any need for deregistration hooks, and makes the
+  never-stopped `TestApp` at `BTraceFunctionalTests.java:535` harmless.
+- Pid resolution when `ready:` never arrived — the startup-stall case, which is exactly when the
+  registry must still be useful: fall back to `Process.pid()` **via reflection**, cached, guarded,
+  returning null on failure. Reflection keeps the Java 8 source level while working on the Java 24
+  worker CI actually uses.
+- `Snapshot` is an immutable `(label, pid, process, jcmdPath)`.
+- Backed by `CopyOnWriteArrayList`.
+
+## Task 2 — `StallCapture`
+
+New: `integration-tests/src/test/java/tests/harness/StallCapture.java`
+
+`static void capture(Appendable sink, String label, long elapsedMs, int frame, List<Snapshot> targets, long budgetMs)`
+— writes the report and never throws.
+
+- Sections in order: banner (label, elapsed, frame index); test-JVM threads; then each live target.
+- **The sink is flushed after every section.** Revision 1 built the whole report as a `String` and
+  wrote it at the end, so a hang in any section produced zero bytes — the precise failure being
+  designed against.
+- The test-JVM dump is `ThreadMXBean.dumpAllThreads(true, true)` (lock owners and monitors, which
+  `Thread.getAllStackTraces()` omits) computed **on a throwaway thread with a bounded join**. It
+  requires a safepoint, and a JVM that cannot reach one is a live possibility here. On overrun the
+  section reads `test-JVM dump timed out`.
+- Per target: `jcmd <pid> Thread.print -l` using the snapshot's own `jcmdPath`, with output
+  redirected to a temp file — **never a pipe**. `Thread.print -l` on an instrumented target exceeds
+  the 64 KB pipe buffer, and a jcmd blocked on a full pipe would be killed by the bound having
+  produced nothing.
+- `budgetMs` spans all targets together, checked before each; a skipped target says so.
+- **No SIGQUIT fallback.** A HotSpot SIGQUIT dump goes to the target's stdout, and for
+  `testStartup` targets that stream is accumulated by `OutputPump` (`OutputPump.java:67`) into the
+  buffer `v.validate(stdout.toString(), …)` asserts on (`RuntimeTest.java:858`). It would corrupt
+  the system under test. A jcmd that fails or overruns is recorded as text and that is the end of it.
+- Every line is prefixed `[stall-dump] ` so a capture interleaved with the `[traced app]` and
+  `[btrace out]` reader threads is recoverable with one `grep`.
+
+## Task 3 — `StallWatchdog` and `@StallTimeout`
+
+New: `integration-tests/src/test/java/tests/harness/StallWatchdog.java`,
+`integration-tests/src/test/java/tests/harness/StallTimeout.java`
+
+`BeforeAllCallback` + `BeforeEachCallback` + `AfterEachCallback` + `AfterAllCallback`.
+
+- Arms on `beforeAll` — JUnit fires extension `beforeAll` before the class's own `@BeforeAll`, and
+  every subclass calls `classSetup()` from one, so that path is covered — and re-arms per
+  `beforeEach`.
+- Deadline: `@StallTimeout(millis=…)` on method or class, else `-Pbtrace.test.stallTimeoutMs`, else
+  `btrace.test.timeoutMs * 6` (six minutes at the default). The annotation exists because a system
+  property cannot be scoped to a single test in a single-JVM run. A shorter default is not safe:
+  `RuntimeTest.java:784` already allows a target `timeout * 4` = 240 s for startup alone.
+- **Targets are snapshotted once, at fire time**, and both frames capture those exact `Process`
+  objects. Revision 1 re-read the live registry for frame two, so a test that unwedged during the
+  gap would have had the *next* test's target captured.
+- Frame two is a **separately scheduled task** at +30 s, not a sleep inside frame one, and it
+  re-checks the disarm flag and skips if the test has finished. Two frames because one cannot
+  distinguish "wedged" from "slow"; the diff is the evidence. Scheduler pool size 2 so one fire
+  cannot defer another test's deadline.
+- Disarm: `ScheduledFuture.cancel(false)` plus an `AtomicBoolean`; `afterEach` never blocks on an
+  in-flight capture.
+- Output dir comes from the absolute path in `btrace.test.stallDumpDir` (task 4). A relative path
+  would resolve against `Test.workingDir`, which defaults to the *project* directory, yielding
+  `integration-tests/integration-tests/build/...` — outside the upload glob.
+- Filenames: sanitised JUnit unique id truncated to 120 chars plus a short hash of the full id.
+  The full id of a parameterised invocation exceeds the 255-byte filename limit, and the motivating
+  test is a `@ParameterizedTest` whose four rows share one method name.
+- Sink order is **file first, stdout second**. `if: always()` upload steps do run after a
+  `timeout-minutes` cancellation, whereas a cancelled job tears down the worker→daemon→console
+  pipeline, and the release path redirects all test output into a file it only summarises after the
+  command exits (`scripts/run-release-gate.sh:52`). Stdout is a shared synchronised `PrintStream`
+  that a stalled pipeline can itself block on.
+- Stale dumps from earlier runs are cleared once per JVM on first arm; `cleanTest` does not cover
+  this directory.
+
+## Task 4 — build wiring
+
+Modify: `integration-tests/build.gradle` — in the `test` block (`:163`), add
+
+```
+systemProperty 'btrace.test.stallDumpDir',
+    layout.buildDirectory.dir('reports/stall-dumps').get().asFile.absolutePath
+```
+
+Its own line, because the `-P` forwarding loop at `:274` forwards project properties only.
+`build/reports/**/*` is what both `if: always()` upload steps already collect
+(`continuous.yml:171`, `release.yml:377`), so no workflow change is needed. Confirm that during
+task 8 rather than assuming it.
+
+`options.release = 8` is **not** attempted: `Issue884PublishedFatAgentE2ETest` already calls
+`Files.writeString` (JDK 11) at seven sites (`:173, :187, :239, :245, :279, :285, :289`), so the
+module cannot compile at release 8 today. Recorded as a pre-existing violation, not fixed here.
+
+## Task 5 — a per-test timeout, because nothing else provides one
+
+New: `integration-tests/src/test/resources/junit-platform.properties`
+
+```
+junit.jupiter.execution.timeout.testable.method.default = 8m
+junit.jupiter.execution.timeout.thread.mode.default = SEPARATE_THREAD
+```
+
+PR #934's commit message describes exactly this and **its diff contains neither** — verified with
+`git show 44f2c25d`. Without it the watchdog's outcome is "30 minutes still burned, now with
+evidence". With it, a stall becomes a failing test at 8 minutes.
+
+Eight minutes, not five: a passing `test()` invocation runs `testDynamic` then `testStartup` in one
+method, and `startupTimeoutMs` alone is 240 s, so five minutes risks failing green tests on slow
+lanes. Eight sits above that and below `release.yml`'s 15-minute integration job (`:271`).
+`SEPARATE_THREAD` is required because the default mode interrupts the test thread, and a thread
+blocked in socket I/O ignores an interrupt.
+
+Ordering: watchdog captures at 6:00 and 6:30, timeout fails the test at 8:00.
+
+This mode change affects every integration test, so task 8's full-suite run is what qualifies it.
+
+## Task 6 — wire the registry into the launch sites
+
+Modify: `integration-tests/src/test/java/tests/RuntimeTest.java`
+
+- `@ExtendWith(StallWatchdog.class)` on the class; `@ExtendWith` is `@Inherited` and all eight
+  subclasses pick it up.
+- Register at launch, set the pid where `ready:` is parsed. Corrected line numbers, all verified:
+
+  | site | launch | pid parsed |
+  |---|---|---|
+  | `testDynamic` raw path | `:348` | `:367` |
+  | `testDynamicOneliner` raw path | `:540` | `:559` |
+  | `testStartup` raw path | `:745` | `:765` (in the `readyAwareCompletion` decorator, not a reader thread) |
+  | `TestApp` | constructor, `:1067` caller | `:937` |
+
+  `TestApp.pid` is a private `int` whose only accessor `getPid()` (`:1007`) blocks up to 30 s, so the
+  hook goes at `:937` directly.
+- No echo-flag changes anywhere: the SIGQUIT fallback that needed them is gone.
+
+Modify: `integration-tests/src/test/java/tests/Issue888RuntimeHardeningIntegrationTest.java` —
+register the target built at `:172-189`; the pid is parsed by the *caller* at `:83-85`, so
+`startTarget()` must return the handle alongside the process rather than a bare `Process`.
+
+Client-JVM spawns (`RuntimeTest.java:1109, :1255, :1380, :1493`) are registered too where a handle
+can be threaded without restructuring; where it cannot, the omission is recorded in the commit
+message rather than left silent. `:254` (`hasJaxbProbeDescriptorSupport`) stays unregistered — it is
+bounded at 10 s and cannot stall a job.
+
+## Task 7 — tests
+
+New: `integration-tests/src/test/java/tests/harness/StallCaptureTest.java`,
+`integration-tests/src/test/java/tests/harness/StallWatchdogTest.java`
+
+Driven through the in-memory seam, scoped with `@StallTimeout`, output under `@TempDir`.
+
+1. **Captures the test JVM.** Park a distinctively named thread; assert banner, label, thread name
+   and stack all appear.
+2. **Captures a target JVM.** Launch a JVM that blocks until told to exit (not "short-lived" — a
+   target that exits mid-attach makes jcmd nondeterministic), launched from the same JDK whose
+   `jcmd` is used. Assert a `Thread.print` section for its pid appears. Degrade with an assumption
+   rather than a failure if attach is unavailable in the environment.
+3. **Degrades rather than hangs.** A bogus pid: capture returns inside its budget, records the
+   failure inline, still contains the test-JVM dump.
+4. **Budget is shared.** Several unreachable targets: capture returns in roughly the budget, not
+   budget × N, and names what it skipped.
+5. **Silent when green.** A fast test with the watchdog armed writes nothing into the `@TempDir`
+   output dir.
+6. **Fires end to end, with a target.** `@StallTimeout(millis=1500)` on a test that registers a real
+   blocking target and then sleeps ~3 s; assert the dump names both the sleeping thread and the
+   target's `Thread.print` section. This replaces revision 1's throwaway "add a test, run it, delete
+   it" verification step, which produced evidence nobody could re-verify.
+7. **Two frames.** A test that stays parked past the 30 s gap produces two dump files whose thread
+   sections differ in elapsed time — the frame-two mechanism is otherwise never exercised.
+   Uses a shortened inter-frame gap via the same annotation so it runs in seconds.
+
+## Task 8 — verification
+
+1. `GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew spotlessApply`, commit any formatting change.
+2. `GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:compileTestJava`.
+3. `GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew -Pintegration :integration-tests:test --tests 'tests.harness.*'`
+   — note this also runs the pre-existing `CompletionTest` and `OutputPumpTest`, and still triggers
+   the full dist/probe build chain (`build.gradle:167-172`), so it is not a cheap check.
+4. Full suite as CI runs it:
+   `GRADLE_USER_HOME=$(pwd)/.gradle-user TEST_JAVA_HOME=<jdk> ./gradlew -Pintegration -PCI :integration-tests:test`.
+   This is the gate for task 5's `SEPARATE_THREAD` change. Record the duration and confirm no
+   watchdog file is produced. Docker-tagged tests are included whenever a Docker host is reachable
+   (`build.gradle:176-241`), so hold Docker state constant between baseline and after.
+5. Confirm `build/reports/stall-dumps/` is inside the upload glob by listing what a run leaves in
+   `integration-tests/build/reports/`.
+
+## Order
+
+1 → 2 → 3 → 7 (tests for 1–3) → 6 → 4 → 5 → 8.

--- a/docs/superpowers/specs/2026-07-29-issue-932-client-close-deadlock-design.md
+++ b/docs/superpowers/specs/2026-07-29-issue-932-client-close-deadlock-design.md
@@ -1,0 +1,152 @@
+# Issue 932 — make an integration-test stall self-diagnosing
+
+Design document.
+
+## Symptom
+
+`PreparedModeAuthenticationFunctionalTest` intermittently stalls on its V2/V2 parameterisations,
+consumes the full 30-minute CI budget, reports no assertion failure and no stack trace, and leaves
+several orphaned `java` processes behind. Last line before the silence is
+`Successfully started BTrace probe`, with no `PASSED` line for the parameterisation.
+
+## Why this design is not a root-cause fix
+
+An earlier revision argued the stall was `Client.close()` deadlocking against its own parked reader,
+fixable with `sock.shutdownInput()`. **That was refuted by measurement** and is recorded here so it
+is not proposed a third time.
+
+`NioSocketImpl.close()` does not wait for an in-flight reader. It pre-closes the descriptor and
+*signals* the blocked thread; the deferred close completes on the reader's own thread. Measured on
+macOS across JDK 11/17/24/26, descriptor in both blocking and non-blocking mode:
+
+| action, with a reader parked in an unbounded `read()` | duration | reader observes |
+|---|---|---|
+| `socket.close()` | 0–1 ms | `SocketException: Socket closed` |
+| `socket.getOutputStream().close()` | 0 ms | `SocketException: Socket closed` |
+| `socket.shutdownInput()` | 0 ms | `read()` returns `-1` |
+
+`Client.close()` is bounded and cannot be a 25-minute stall.
+
+The supporting evidence was also misread. `log.info("Successfully started BTrace probe")` is emitted
+at `Client.java:1284`, inside `submit`'s wrapping listener, *before* `listener.onCommand(cmd)` at
+`Client.java:1292` reaches the test's `handleStatus`. It proves only that the worker reached line
+1284 — not that `started.get(20, SECONDS)` returned. Every elimination argument rested on that
+misreading.
+
+What the evidence does support: `started.get(20, SECONDS)` may have thrown `TimeoutException`, and
+that exception was then *lost*, because the enclosing `finally` runs `TestApp.stop()` →
+`process.waitFor()` with no bound (`RuntimeTest.java:1006`). A pending exception whose `finally`
+never returns is never delivered to JUnit. That reproduces the observed shape exactly — no assertion
+failure, no `PASSED` line, orphaned JVMs — and means the 25 minutes were spent waiting on a target
+JVM that never exited.
+
+The remaining product-side defect is whatever wedged the **target** JVM. Nothing in the available
+evidence identifies it; two mechanisms have now been proposed and refuted, both by reasoning
+backwards from a log shape that several mechanisms explain equally well. The next attempt starts
+from a thread dump, which is what this design delivers.
+
+## What PR #934 does and does not provide
+
+Verified against `git show 44f2c25d`: the branch bounds `TestApp.stop()`, makes the submit executors
+daemon threads, and adds a speculative `shutdownInput()` in `Client.close()`. Its commit message also
+describes a five-minute per-test timeout in `SEPARATE_THREAD` mode — **that annotation is not in the
+diff**, and the branch carries no `junit-platform.properties`. This design therefore assumes no
+per-test timeout exists, and must not rely on one to bound the capture.
+
+## Goal
+
+> When an integration test stalls, the CI artifacts and (where available) the job log name the
+> blocked thread in the test JVM and in every live target JVM, without anyone re-running anything.
+
+## Design
+
+A **stall watchdog** in the integration-test harness. Evidence only: it does not kill anything and
+does not fail a test.
+
+**1. `StallWatchdog`, a JUnit 5 extension.** Registered with `@ExtendWith` on the abstract
+`RuntimeTest`; JUnit searches the superclass hierarchy, so all eight subclasses inherit it with no
+boilerplate. `BeforeAllCallback` arms first (so a stall in `classSetup()` is covered), `beforeEach`
+re-arms per invocation, `afterEach`/`afterAll` disarm. Disarm uses `ScheduledFuture.cancel(false)`
+plus an `AtomicBoolean` so an in-flight capture is never attributed to the next test and `afterEach`
+never blocks waiting for one.
+
+**2. The deadline is derived, not hard-coded.** `RuntimeTest` already allows a target up to
+`startupTimeoutMs = timeout * 4` (`RuntimeTest.java:784`), i.e. 240 s at the default
+`btrace.test.timeoutMs = 60000`. A four-minute watchdog would fire on legitimately slow green tests.
+The deadline is `btrace.test.timeoutMs * 6` (six minutes by default), overridable with
+`-Pbtrace.test.stallTimeoutMs`. **`-P`, not `-D`**: `integration-tests/build.gradle:274` forwards
+only Gradle project properties beginning with `btrace.` into the test JVM.
+
+**3. Two captures, thirty seconds apart, then stop.** A single frame cannot distinguish "wedged"
+from "slow" — a thread parked in `SocketInputStream.read` looks identical either way. The diff
+between two frames is the evidence. Capturing twice and stopping bounds the log cost on a job that
+is already lost.
+
+**4. Each capture contains:** a banner with the test's unique id and elapsed time; the test JVM's
+threads via `ThreadMXBean.dumpAllThreads(true, true)` (lock-owner and monitor information, which
+`Thread.getAllStackTraces()` omits and a deadlock diagnosis needs); and for every live registered
+target, `jcmd <pid> Thread.print -l`.
+
+**5. File first, stdout second.** The file is the reliable sink: `if: always()` upload steps do run
+after a `timeout-minutes` cancellation, whereas a cancelled job tears down the worker→daemon→console
+pipeline, and the release path redirects all test output into a file it only summarises *after* the
+command exits (`scripts/run-release-gate.sh:52`). Dumps are written to
+`integration-tests/build/reports/stall-dumps/`, which the existing `if: always()` glob
+`integration-tests/build/reports/**/*` (`continuous.yml:171`) already uploads — no workflow change.
+The stdout copy is best-effort and written second, because `System.out` is a shared synchronised
+`PrintStream` that a stalled pipeline can itself block on. Every line carries a `[stall-dump] `
+prefix so one `grep` recovers a capture interleaved with the `[traced app]` reader threads.
+Filenames derive from the sanitised JUnit unique id, not `<class>.<method>` — the motivating test is
+a `@ParameterizedTest` whose four rows share one method name.
+
+**6. `jcmd` is treated as untrustworthy.** Its output goes to a file via `redirectOutput`, never to a
+pipe: `Thread.print -l` on an instrumented target exceeds the 64 KB pipe buffer, and a blocked jcmd
+would then be killed by the bound having produced nothing — losing precisely the dump we want. The
+call is bounded and `destroyForcibly`-ed on overrun. If it fails or times out — the jammed
+Attach Listener case, which is plausible here — the watchdog falls back to `kill -QUIT`, which the
+VM's Signal Dispatcher handles independently of the attach mechanism. That dump goes to the target's
+stdout, which `RuntimeTest` echoes only when `debug` is set (`RuntimeTest.java:940`), so requesting a
+capture also flips a flag that makes the reader threads echo unconditionally.
+
+**7. Target registry.** A static registry holds the `Process` plus a lazily-resolved pid, registered
+at launch rather than at `ready:`, so a target that dies before reporting a pid is still known.
+Entries with `!process.isAlive()` are skipped at capture time, which removes the need for
+deregistration hooks and covers the leak at `BTraceFunctionalTests.java:536`, where a `TestApp` is
+launched and never stopped. Four launch sites register: `TestApp`, the three raw `ProcessBuilder`
+paths in `RuntimeTest` (`:348`, `:540`, `:745`), and
+`Issue888RuntimeHardeningIntegrationTest.java:184`. The whole capture shares one overall time budget
+rather than 10 s per target, so accumulated stale entries cannot stretch it.
+
+**Java 8 source level.** `integration-tests` compiles tests with `sourceCompatibility = 8`, but
+without `options.release`, so javac 24 happily compiles JDK 9+ APIs that then fail on a JDK 8
+worker. No `var`, no `List.of`, no `ProcessHandle`/`Process.pid()`. Adding
+`compileTestJava { options.release = 8 }` to enforce this is attempted; if existing test code
+already violates it the change is dropped and the violation reported rather than fixed here.
+
+## Testing
+
+The extension's own tests drive it through an in-memory seam rather than scraping stdout, and take
+their deadline from a `@StallTimeout` annotation read from the `ExtensionContext` rather than a
+system property — with no `forkEvery` configured anywhere in the build, one worker JVM runs all ten
+test classes, so a system property set by a test leaks into every class that follows it.
+
+1. **Captures the test JVM.** A parked thread with a recognisable name; assert the capture contains
+   the banner, the unique id, and that thread's stack.
+2. **Captures a target JVM.** Launch a target, assert the capture contains a `Thread.print` section
+   for its pid and a thread name only the target has.
+3. **Degrades rather than hangs.** With a bogus registered pid, the capture completes within its
+   budget, reports the failure inline, and still contains the test-JVM dump.
+4. **Stays silent when green.** A fast test writes no dump; the assertion targets a `@TempDir`-rooted
+   output directory so a file left by an earlier Gradle invocation cannot make it pass or fail
+   spuriously.
+
+## Out of scope
+
+- Product code. Nothing in `btrace-client`, `btrace-core`, `btrace-agent` changes.
+- `JBangAttachDockerTest` and `Issue884PublishedFatAgentE2ETest` do not extend `RuntimeTest` and are
+  not covered. They must not be covered by registering the extension globally: their targets run
+  inside containers, and a container pid handed to a host `jcmd` would attach to an unrelated host
+  process.
+- Bounding `TestApp.stop()`, daemon submit executors, and the missing per-test timeout — PR #934's
+  territory, whatever that PR ends up containing.
+- Killing or failing a stalled test.

--- a/docs/superpowers/specs/2026-07-29-issue-932-client-close-deadlock-design.md
+++ b/docs/superpowers/specs/2026-07-29-issue-932-client-close-deadlock-design.md
@@ -60,8 +60,20 @@ per-test timeout exists, and must not rely on one to bound the capture.
 
 ## Design
 
-A **stall watchdog** in the integration-test harness. Evidence only: it does not kill anything and
-does not fail a test.
+A **stall watchdog** in the integration-test harness. Evidence first, and then — only once the
+evidence is on disk — it releases the stall.
+
+The evidence-only design this document originally specified turned out not to reach the goal.
+Adversarial review of the implementation established, and `javap` on `junit-jupiter-api-5.14.4`
+confirmed, that `AssertTimeoutPreemptively$TimeoutThreadFactory` builds its thread with
+`new Thread(Runnable, String)` and never calls `setDaemon(true)`. So when the per-test timeout below
+fires, JUnit marks the test failed, interrupts the test thread — an interrupt a thread blocked in
+socket I/O ignores, which is why `SEPARATE_THREAD` was chosen in the first place — and abandons it.
+That surviving non-daemon thread keeps the Gradle worker JVM alive, and the job burns its whole
+budget regardless. Killing the stalled test's registered targets closes the sockets the thread is
+blocked on, which is what actually ends the stall; it also clears the orphaned JVMs the issue
+reports. This happens only after both frames are captured, and only to targets registered by the
+stalled test.
 
 **1. `StallWatchdog`, a JUnit 5 extension.** Registered with `@ExtendWith` on the abstract
 `RuntimeTest`; JUnit searches the superclass hierarchy, so all eight subclasses inherit it with no
@@ -81,6 +93,10 @@ only Gradle project properties beginning with `btrace.` into the test JVM.
 from "slow" — a thread parked in `SocketInputStream.read` looks identical either way. The diff
 between two frames is the evidence. Capturing twice and stopping bounds the log cost on a job that
 is already lost.
+
+**3b. The dump is rendered frame by frame,** not with `ThreadInfo.toString()`, which stops after
+eight frames — and the frame that explains a stall is rarely in the top eight of a test-harness
+stack. Measured: a 44-frame stack renders as 8 through `toString()`.
 
 **4. Each capture contains:** a banner with the test's unique id and elapsed time; the test JVM's
 threads via `ThreadMXBean.dumpAllThreads(true, true)` (lock-owner and monitor information, which

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -173,6 +173,13 @@ test {
 
     testLogging.showStandardStreams = true
 
+    // Where StallWatchdog writes a thread dump when a test stops making progress. Absolute, because
+    // a relative path would resolve against the test task's working directory (the project dir),
+    // and under build/reports because that is what the workflows' `if: always()` steps upload -- the
+    // sink that survives a job cancelled at its timeout.
+    systemProperty 'btrace.test.stallDumpDir',
+            layout.buildDirectory.dir('reports/stall-dumps').get().asFile.absolutePath
+
     def dockerAvailable = false
     if (project.hasProperty("integration")) {
         String dockerHost = System.getenv("DOCKER_HOST")

--- a/integration-tests/src/test/java/tests/Issue888RuntimeHardeningIntegrationTest.java
+++ b/integration-tests/src/test/java/tests/Issue888RuntimeHardeningIntegrationTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import tests.harness.Completion;
+import tests.harness.TargetRegistry;
 
 /** Real staged-JAR client/agent/target lifecycle coverage for #888. */
 public class Issue888RuntimeHardeningIntegrationTest extends RuntimeTest {
@@ -82,6 +83,7 @@ public class Issue888RuntimeHardeningIntegrationTest extends RuntimeTest {
     String ready = awaitLine(targetOutput, "ready:", 10L);
     assertNotNull(ready, "target did not report its PID");
     String pid = ready.substring("ready:".length());
+    targetHandle.setPid(pid);
     Client client = null;
     ExecutorService executor = newDaemonExecutor("runtime-hardening-probe-submit");
     try (PrintWriter targetInput = new PrintWriter(target.getOutputStream(), true)) {
@@ -166,6 +168,8 @@ public class Issue888RuntimeHardeningIntegrationTest extends RuntimeTest {
         });
   }
 
+  private TargetRegistry.Handle targetHandle;
+
   private Process startTarget() throws Exception {
     List<String> args = new ArrayList<>();
     args.add(Paths.get(javaHome, "bin", "java").toString());
@@ -184,7 +188,12 @@ public class Issue888RuntimeHardeningIntegrationTest extends RuntimeTest {
     // The child is an uninstrumented target; inherited test-only options must not alter agent
     // discovery or the target's own networking configuration.
     builder.environment().remove("JAVA_TOOL_OPTIONS");
-    return builder.start();
+    Process target = builder.start();
+    // Registered so a stalled test dumps this target's threads alongside the test JVM's.
+    // The jcmd comes from the JDK this target was launched with, which is the build JDK
+    // here rather than TEST_JAVA_HOME.
+    targetHandle = TargetRegistry.register(target, "issue-888 target", jcmdFor(javaHome));
+    return target;
   }
 
   private static byte[] readProbeClass() throws Exception {

--- a/integration-tests/src/test/java/tests/RuntimeTest.java
+++ b/integration-tests/src/test/java/tests/RuntimeTest.java
@@ -1170,6 +1170,10 @@ public abstract class RuntimeTest {
 
     pb.environment().remove("JAVA_TOOL_OPTIONS");
     Process p = pb.start();
+    // The btrace client runs in its own JVM; a stall on the client side is the shape this
+    // watchdog exists for, so its threads must be dumpable too. No ready: line to parse --
+    // TargetRegistry falls back to Process.pid().
+    TargetRegistry.register(p, "runBTrace client", jcmdFor(javaHome));
 
     AtomicBoolean done = new AtomicBoolean(false);
 
@@ -1316,6 +1320,10 @@ public abstract class RuntimeTest {
 
     pb.environment().remove("JAVA_TOOL_OPTIONS");
     Process p = pb.start();
+    // The btrace client runs in its own JVM; a stall on the client side is the shape this
+    // watchdog exists for, so its threads must be dumpable too. No ready: line to parse --
+    // TargetRegistry falls back to Process.pid().
+    TargetRegistry.register(p, "runBTrace client", jcmdFor(javaHome));
 
     OutputPump.run(
         p,
@@ -1441,6 +1449,10 @@ public abstract class RuntimeTest {
 
     pb.environment().remove("JAVA_TOOL_OPTIONS");
     Process p = pb.start();
+    // The btrace client runs in its own JVM; a stall on the client side is the shape this
+    // watchdog exists for, so its threads must be dumpable too. No ready: line to parse --
+    // TargetRegistry falls back to Process.pid().
+    TargetRegistry.register(p, "attach client", jcmdFor(javaHome));
 
     boolean completed =
         OutputPump.run(
@@ -1554,6 +1566,10 @@ public abstract class RuntimeTest {
 
     pb.environment().remove("JAVA_TOOL_OPTIONS");
     Process p = pb.start();
+    // The btrace client runs in its own JVM; a stall on the client side is the shape this
+    // watchdog exists for, so its threads must be dumpable too. No ready: line to parse --
+    // TargetRegistry falls back to Process.pid().
+    TargetRegistry.register(p, "attachOneliner client", jcmdFor(javaHome));
 
     boolean completed =
         OutputPump.run(

--- a/integration-tests/src/test/java/tests/RuntimeTest.java
+++ b/integration-tests/src/test/java/tests/RuntimeTest.java
@@ -53,13 +53,17 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tests.harness.Completion;
 import tests.harness.OutputPump;
+import tests.harness.StallWatchdog;
+import tests.harness.TargetRegistry;
 
 /**
  * @author Jaroslav Bachorik
  */
 @SuppressWarnings("ConstantConditions")
+@ExtendWith(StallWatchdog.class)
 public abstract class RuntimeTest {
   private static String cp = null;
   private static String targetAppCp = null;
@@ -161,6 +165,16 @@ public abstract class RuntimeTest {
           t.setDaemon(true);
           return t;
         });
+  }
+
+  /**
+   * The {@code jcmd} able to attach to a target launched from {@code javaHome}.
+   *
+   * <p>Resolved per launch site rather than once: targets do not all come from the same JDK, and a
+   * mismatched-major {@code jcmd} cannot attach to one.
+   */
+  protected static String jcmdFor(String javaHome) {
+    return javaHome != null ? Paths.get(javaHome, "bin", "jcmd").toString() : "jcmd";
   }
 
   public static void classSetup() {
@@ -367,6 +381,8 @@ public abstract class RuntimeTest {
     configureTargetEnvironment(pb);
 
     Process p = pb.start();
+    TargetRegistry.Handle stallHandle =
+        TargetRegistry.register(p, "testDynamic target", jcmdFor(testJavaHome));
     PrintWriter pw = new PrintWriter(p.getOutputStream());
 
     StringBuilder stdout = new StringBuilder();
@@ -386,6 +402,7 @@ public abstract class RuntimeTest {
                 while ((l = stdoutReader.readLine()) != null) {
                   if (l.startsWith("ready:")) {
                     pidStringRef.set(l.split(":")[1]);
+                    stallHandle.setPid(pidStringRef.get());
                     testAppLatch.countDown();
                   }
                   if (debugTestApp) {
@@ -559,6 +576,8 @@ public abstract class RuntimeTest {
     configureTargetEnvironment(pb);
 
     Process p = pb.start();
+    TargetRegistry.Handle stallHandle =
+        TargetRegistry.register(p, "testDynamicOneliner target", jcmdFor(testJavaHome));
     PrintWriter pw = new PrintWriter(p.getOutputStream());
 
     StringBuilder stdout = new StringBuilder();
@@ -578,6 +597,7 @@ public abstract class RuntimeTest {
                 while ((l = stdoutReader.readLine()) != null) {
                   if (l.startsWith("ready:")) {
                     pidStringRef.set(l.split(":")[1]);
+                    stallHandle.setPid(pidStringRef.get());
                     testAppLatch.countDown();
                   }
                   if (debugTestApp) {
@@ -764,6 +784,8 @@ public abstract class RuntimeTest {
     configureTargetEnvironment(pb);
 
     Process p = pb.start();
+    TargetRegistry.Handle stallHandle =
+        TargetRegistry.register(p, "testStartup target", jcmdFor(testJavaHome));
     PrintWriter pw = new PrintWriter(p.getOutputStream());
 
     StringBuilder stdout = new StringBuilder();
@@ -784,6 +806,7 @@ public abstract class RuntimeTest {
           public boolean onStdout(String line) {
             if (line.startsWith("ready:")) {
               pidStringRef.set(line.split(":")[1]);
+              stallHandle.setPid(pidStringRef.get());
               return false;
             }
             return completion.onStdout(line);
@@ -948,7 +971,7 @@ public abstract class RuntimeTest {
     private final Process process;
     private final StringBuilder startupStderr = new StringBuilder();
 
-    public TestApp(Process process, boolean debug) {
+    public TestApp(Process process, boolean debug, TargetRegistry.Handle stallHandle) {
       this.process = process;
 
       BufferedReader stdoutReader =
@@ -962,6 +985,7 @@ public abstract class RuntimeTest {
                   while ((l = stdoutReader.readLine()) != null) {
                     if (l.startsWith("ready:")) {
                       pid = Integer.parseInt(l.split(":")[1]);
+                      stallHandle.setPid(String.valueOf(pid));
                       testAppLatch.countDown();
                     }
                     if (debug) {
@@ -1100,7 +1124,10 @@ public abstract class RuntimeTest {
     ProcessBuilder pb = new ProcessBuilder(args);
     configureTargetEnvironment(pb);
 
-    return new TestApp(pb.start(), debugTestApp);
+    Process target = pb.start();
+    TargetRegistry.Handle stallHandle =
+        TargetRegistry.register(target, "TestApp target", jcmdFor(testJavaHome));
+    return new TestApp(target, debugTestApp, stallHandle);
   }
 
   public interface ProcessOutputProcessor {

--- a/integration-tests/src/test/java/tests/harness/StallCapture.java
+++ b/integration-tests/src/test/java/tests/harness/StallCapture.java
@@ -69,6 +69,31 @@ public final class StallCapture {
       int frame,
       List<TargetRegistry.Snapshot> targets,
       long budgetMs) {
+    capture(sink, label, elapsedMs, frame, targets, budgetMs, JCMD);
+  }
+
+  /**
+   * How one target is dumped.
+   *
+   * <p>A seam, so that the shared-budget behaviour can be tested against a dumper of known
+   * duration. Asserting it through {@code jcmd} means asserting on how long a failing attach takes,
+   * which differs by platform -- it is slow enough on macOS to exhaust a budget and fast enough on
+   * Linux not to.
+   */
+  interface TargetDumper {
+    void dump(Appendable sink, TargetRegistry.Snapshot target);
+  }
+
+  private static final TargetDumper JCMD = StallCapture::writeTargetThreads;
+
+  static void capture(
+      Appendable sink,
+      String label,
+      long elapsedMs,
+      int frame,
+      List<TargetRegistry.Snapshot> targets,
+      long budgetMs,
+      TargetDumper dumper) {
     long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(budgetMs);
 
     writeBanner(sink, label, elapsedMs, frame, targets.size());
@@ -85,7 +110,7 @@ public final class StallCapture {
       if (System.nanoTime() >= deadline) {
         line(sink, "skipped, capture budget exhausted");
       } else {
-        writeTargetThreads(sink, target);
+        dumper.dump(sink, target);
       }
       flush(sink);
     }

--- a/integration-tests/src/test/java/tests/harness/StallCapture.java
+++ b/integration-tests/src/test/java/tests/harness/StallCapture.java
@@ -19,7 +19,9 @@ package tests.harness;
 import java.io.File;
 import java.io.Flushable;
 import java.io.IOException;
+import java.lang.management.LockInfo;
 import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.nio.charset.StandardCharsets;
@@ -73,14 +75,18 @@ public final class StallCapture {
     flush(sink);
 
     writeTestJvmThreads(sink);
+    // Charged against the same budget as the targets below: the join above can take up to
+    // THREAD_DUMP_TIMEOUT_MS, and a frame that overruns its budget delays the next one.
     flush(sink);
 
     for (TargetRegistry.Snapshot target : targets) {
+      // The header goes out for every target, dumped or not, so one grep pattern finds them all.
+      line(sink, "---- target " + target.getLabel() + " (pid " + target.getPid() + ") ----");
       if (System.nanoTime() >= deadline) {
-        line(sink, "target " + target.getLabel() + ": skipped, capture budget exhausted");
-        continue;
+        line(sink, "skipped, capture budget exhausted");
+      } else {
+        writeTargetThreads(sink, target);
       }
-      writeTargetThreads(sink, target);
       flush(sink);
     }
 
@@ -135,6 +141,13 @@ public final class StallCapture {
         dump != null ? dump : "test-JVM dump timed out after " + THREAD_DUMP_TIMEOUT_MS + "ms");
   }
 
+  /**
+   * Renders a full dump.
+   *
+   * <p>Rendered frame by frame rather than with {@link ThreadInfo#toString()}, which stops after
+   * eight frames -- and the frame that explains a stall is rarely in the top eight of a
+   * test-harness stack.
+   */
   private static String renderThreadDump() {
     ThreadMXBean threads = ManagementFactory.getThreadMXBean();
     ThreadInfo[] infos = threads.dumpAllThreads(true, true);
@@ -143,7 +156,40 @@ public final class StallCapture {
       if (info == null) {
         continue;
       }
-      sb.append(info.toString());
+      sb.append('"').append(info.getThreadName()).append('"');
+      sb.append(" Id=").append(info.getThreadId());
+      sb.append(' ').append(info.getThreadState());
+      if (info.getLockName() != null) {
+        sb.append(" on ").append(info.getLockName());
+      }
+      if (info.getLockOwnerName() != null) {
+        sb.append(" owned by \"").append(info.getLockOwnerName());
+        sb.append("\" Id=").append(info.getLockOwnerId());
+      }
+      if (info.isSuspended()) {
+        sb.append(" (suspended)");
+      }
+      if (info.isInNative()) {
+        sb.append(" (in native)");
+      }
+      sb.append('\n');
+      StackTraceElement[] stack = info.getStackTrace();
+      for (int i = 0; i < stack.length; i++) {
+        sb.append("\tat ").append(stack[i]).append('\n');
+        for (MonitorInfo monitor : info.getLockedMonitors()) {
+          if (monitor.getLockedStackDepth() == i) {
+            sb.append("\t-  locked ").append(monitor).append('\n');
+          }
+        }
+      }
+      LockInfo[] synchronizers = info.getLockedSynchronizers();
+      if (synchronizers.length > 0) {
+        sb.append("\tNumber of locked synchronizers = ").append(synchronizers.length).append('\n');
+        for (LockInfo synchronizer : synchronizers) {
+          sb.append("\t-  ").append(synchronizer).append('\n');
+        }
+      }
+      sb.append('\n');
     }
     return sb.toString();
   }
@@ -157,7 +203,6 @@ public final class StallCapture {
    */
   private static void writeTargetThreads(Appendable sink, TargetRegistry.Snapshot target) {
     String pid = target.getPid();
-    line(sink, "---- target " + target.getLabel() + " (pid " + pid + ") ----");
     if (pid == null) {
       line(sink, "no pid known for this target; it never reported one");
       return;

--- a/integration-tests/src/test/java/tests/harness/StallCapture.java
+++ b/integration-tests/src/test/java/tests/harness/StallCapture.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.harness;
+
+import java.io.File;
+import java.io.Flushable;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Writes a diagnostic snapshot of the test JVM and every live target JVM.
+ *
+ * <p>This runs only when a test has already stopped making progress, so it is written to survive a
+ * hostile environment: nothing it does can throw, every wait is bounded, and each section is
+ * flushed as it is produced so that a section which hangs still leaves the earlier ones on disk.
+ *
+ * <p>It also must not perturb the system under test. In particular it does not send {@code SIGQUIT}
+ * to a target: HotSpot writes that dump to the target's stdout, and for {@code testStartup} targets
+ * that stream is accumulated by {@link OutputPump} into the buffer the test validators assert on. A
+ * diagnostic that fails the test it is diagnosing is worse than no diagnostic.
+ */
+public final class StallCapture {
+  /** Prefix on every line, so a capture interleaved with the target reader threads greps out. */
+  static final String PREFIX = "[stall-dump] ";
+
+  private static final long JCMD_TIMEOUT_MS = 10_000L;
+  private static final long THREAD_DUMP_TIMEOUT_MS = 15_000L;
+
+  private StallCapture() {}
+
+  /**
+   * Writes one capture frame.
+   *
+   * @param sink where the report goes; flushed after each section if it is {@link Flushable}
+   * @param label identifies the stalled test
+   * @param elapsedMs how long the test had been running when the watchdog fired
+   * @param frame 1-based frame number; frames are compared to tell "wedged" from "slow"
+   * @param targets the targets to dump, snapshotted when the watchdog fired
+   * @param budgetMs an overall budget for all targets together, so accumulated targets cannot
+   *     stretch a capture without bound
+   */
+  public static void capture(
+      Appendable sink,
+      String label,
+      long elapsedMs,
+      int frame,
+      List<TargetRegistry.Snapshot> targets,
+      long budgetMs) {
+    long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(budgetMs);
+
+    writeBanner(sink, label, elapsedMs, frame, targets.size());
+    flush(sink);
+
+    writeTestJvmThreads(sink);
+    flush(sink);
+
+    for (TargetRegistry.Snapshot target : targets) {
+      if (System.nanoTime() >= deadline) {
+        line(sink, "target " + target.getLabel() + ": skipped, capture budget exhausted");
+        continue;
+      }
+      writeTargetThreads(sink, target);
+      flush(sink);
+    }
+
+    line(sink, "==== end of stall dump frame " + frame + " ====");
+    flush(sink);
+  }
+
+  private static void writeBanner(
+      Appendable sink, String label, long elapsedMs, int frame, int targetCount) {
+    line(sink, "");
+    line(sink, "======================================================================");
+    line(sink, "STALL DUMP frame " + frame + " -- test made no progress");
+    line(sink, "test:     " + label);
+    line(sink, "elapsed:  " + (elapsedMs / 1000L) + "s");
+    line(sink, "targets:  " + targetCount);
+    line(sink, "======================================================================");
+  }
+
+  /**
+   * Dumps this JVM's threads.
+   *
+   * <p>Done on a throwaway thread with a bounded join: {@code dumpAllThreads} needs a safepoint,
+   * and a JVM that cannot reach one is exactly the sort of thing being diagnosed. Losing this
+   * section to a timeout is survivable; losing the whole capture to it is not.
+   */
+  private static void writeTestJvmThreads(Appendable sink) {
+    line(sink, "---- test JVM threads ----");
+    final AtomicReference<String> result = new AtomicReference<>();
+    Thread dumper =
+        new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  result.set(renderThreadDump());
+                } catch (Throwable t) {
+                  result.set("test-JVM dump failed: " + t);
+                }
+              }
+            },
+            "btrace-stall-thread-dump");
+    dumper.setDaemon(true);
+    dumper.start();
+    try {
+      dumper.join(THREAD_DUMP_TIMEOUT_MS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    String dump = result.get();
+    line(
+        sink,
+        dump != null ? dump : "test-JVM dump timed out after " + THREAD_DUMP_TIMEOUT_MS + "ms");
+  }
+
+  private static String renderThreadDump() {
+    ThreadMXBean threads = ManagementFactory.getThreadMXBean();
+    ThreadInfo[] infos = threads.dumpAllThreads(true, true);
+    StringBuilder sb = new StringBuilder();
+    for (ThreadInfo info : infos) {
+      if (info == null) {
+        continue;
+      }
+      sb.append(info.toString());
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Dumps one target's threads with {@code jcmd}.
+   *
+   * <p>Output is redirected to a file rather than left on a pipe: {@code Thread.print -l} on an
+   * instrumented target easily exceeds the 64 KB pipe buffer, and a jcmd blocked on a full pipe
+   * would be killed by the timeout below having produced nothing.
+   */
+  private static void writeTargetThreads(Appendable sink, TargetRegistry.Snapshot target) {
+    String pid = target.getPid();
+    line(sink, "---- target " + target.getLabel() + " (pid " + pid + ") ----");
+    if (pid == null) {
+      line(sink, "no pid known for this target; it never reported one");
+      return;
+    }
+    File output = null;
+    Process jcmd = null;
+    try {
+      output = File.createTempFile("btrace-stall-", ".txt");
+      ProcessBuilder pb =
+          new ProcessBuilder(target.getJcmdPath(), pid, "Thread.print", "-l")
+              .redirectErrorStream(true)
+              .redirectOutput(output);
+      jcmd = pb.start();
+      if (!jcmd.waitFor(JCMD_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+        jcmd.destroyForcibly();
+        line(sink, "jcmd did not complete within " + JCMD_TIMEOUT_MS + "ms (attach jammed?)");
+      }
+      byte[] captured = Files.readAllBytes(output.toPath());
+      if (captured.length == 0) {
+        line(sink, "jcmd produced no output");
+      } else {
+        line(sink, new String(captured, StandardCharsets.UTF_8));
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      line(sink, "interrupted while waiting for jcmd");
+    } catch (Throwable t) {
+      line(sink, "jcmd failed: " + t);
+    } finally {
+      if (jcmd != null && jcmd.isAlive()) {
+        jcmd.destroyForcibly();
+      }
+      if (output != null && !output.delete()) {
+        output.deleteOnExit();
+      }
+    }
+  }
+
+  /** Appends {@code text} with every line prefixed. Never throws. */
+  static void line(Appendable sink, String text) {
+    try {
+      for (String part : text.split("\n", -1)) {
+        sink.append(PREFIX).append(part).append('\n');
+      }
+    } catch (Throwable ignored) {
+      // A capture that cannot write is still better than a capture that throws out of a
+      // scheduler thread.
+    }
+  }
+
+  private static void flush(Appendable sink) {
+    if (sink instanceof Flushable) {
+      try {
+        ((Flushable) sink).flush();
+      } catch (IOException ignored) {
+        // Best effort.
+      }
+    }
+  }
+}

--- a/integration-tests/src/test/java/tests/harness/StallCaptureTest.java
+++ b/integration-tests/src/test/java/tests/harness/StallCaptureTest.java
@@ -16,7 +16,6 @@
  */
 package tests.harness;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -72,6 +71,11 @@ public class StallCaptureTest {
     assertTrue(
         report.contains("stall-capture-test-parked-thread"),
         "parked thread missing from dump:\n" + report);
+    // ThreadInfo.toString() stops after eight frames, and the frame that explains a stall is
+    // rarely in the top eight of a test-harness stack. Assert the dump is not rendered that way.
+    assertTrue(
+        deepestStack(report) > 8,
+        "stacks must not be truncated, deepest was " + deepestStack(report) + ":\n" + report);
     for (String reportLine : report.split("\n")) {
       assertTrue(
           reportLine.startsWith(StallCapture.PREFIX),
@@ -93,8 +97,8 @@ public class StallCaptureTest {
     String report = sink.toString();
 
     assertTrue(report.contains("blocking-target"), "target section missing:\n" + report);
-    Assumptions.assumeFalse(
-        report.contains("jcmd failed") || report.contains("jcmd produced no output"),
+    Assumptions.assumeTrue(
+        report.contains("Full thread dump") || report.contains("\"main\""),
         "jcmd could not attach in this environment; skipping the content assertion");
     assertTrue(report.contains("\"main\""), "target's main thread missing:\n" + report);
   }
@@ -130,16 +134,37 @@ public class StallCaptureTest {
 
     StringBuilder sink = new StringBuilder();
     long startedAt = System.nanoTime();
-    // A budget below one jcmd timeout, so the first target consumes it and the rest are skipped.
-    StallCapture.capture(sink, "budget-test", 1_000L, 1, TargetRegistry.liveTargets(), 1L);
+    // Enough for roughly one jcmd attempt. A per-target budget would let all four run and take
+    // four times as long, which is exactly what this asserts against.
+    StallCapture.capture(sink, "budget-test", 1_000L, 1, TargetRegistry.liveTargets(), 12_000L);
     long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
 
     String report = sink.toString();
     assertTrue(
-        elapsedMs < 30_000L,
+        elapsedMs < 40_000L,
         "shared budget must not be spent per target, took " + elapsedMs + "ms");
+    assertTrue(
+        report.contains("---- target unreachable-0"),
+        "the first target must still be attempted:\n" + report);
     assertTrue(report.contains("capture budget exhausted"), "skips must be recorded:\n" + report);
-    assertFalse(report.contains("STALL DUMP frame 2"), "only one frame was requested:\n" + report);
+    assertTrue(
+        report.contains("---- target unreachable-3"),
+        "a skipped target must still be named:\n" + report);
+  }
+
+  /** Frames in the longest single-thread stack of a rendered dump. */
+  private static int deepestStack(String report) {
+    int deepest = 0;
+    int current = 0;
+    for (String line : report.split("\n")) {
+      if (line.startsWith(StallCapture.PREFIX + "\t")) {
+        current++;
+        deepest = Math.max(deepest, current);
+      } else {
+        current = 0;
+      }
+    }
+    return deepest;
   }
 
   private static void awaitQuietly(CountDownLatch latch) {
@@ -158,14 +183,22 @@ public class StallCaptureTest {
         Paths.get(
                 StallCaptureTest.class.getProtectionDomain().getCodeSource().getLocation().toURI())
             .toString();
+    File marker = File.createTempFile("btrace-blocking-target-", ".log");
     ProcessBuilder pb = new ProcessBuilder(java, "-cp", classpath, BlockingMain.NAME);
     pb.redirectErrorStream(true);
-    pb.redirectOutput(new File(System.getProperty("java.io.tmpdir"), "btrace-blocking-target.log"));
+    pb.redirectOutput(marker);
     Process process = pb.start();
     spawned.add(process);
-    // Give it time to reach main() so that jcmd has something to attach to.
-    Thread.sleep(2_000L);
-    return process;
+    // Wait for main() to announce itself rather than guessing: a fixed sleep is either wasted time
+    // or, on a loaded runner, an attach against a JVM that has not started listening yet.
+    long deadline = System.currentTimeMillis() + 30_000L;
+    while (System.currentTimeMillis() < deadline) {
+      if (marker.isFile() && marker.length() > 0) {
+        return process;
+      }
+      Thread.sleep(50L);
+    }
+    throw new AssertionError("the blocking target JVM never started");
   }
 
   /** A live process that is not a JVM, for the cases where the dump is expected to fail. */
@@ -196,6 +229,8 @@ public class StallCaptureTest {
     static final String NAME = "tests.harness.StallCaptureTest$BlockingMain";
 
     public static void main(String[] args) throws Exception {
+      System.out.println("started");
+      System.out.flush();
       new CountDownLatch(1).await();
     }
   }

--- a/integration-tests/src/test/java/tests/harness/StallCaptureTest.java
+++ b/integration-tests/src/test/java/tests/harness/StallCaptureTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.harness;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Covers the diagnostic snapshot itself, without the JUnit plumbing that schedules it. */
+public class StallCaptureTest {
+  private final List<Process> spawned = new ArrayList<>();
+
+  @BeforeEach
+  public void clearRegistry() {
+    TargetRegistry.clear();
+  }
+
+  @AfterEach
+  public void stopTargets() {
+    TargetRegistry.clear();
+    for (Process process : spawned) {
+      process.destroyForcibly();
+    }
+    spawned.clear();
+  }
+
+  @Test
+  @DisplayName("Capture names a parked thread in the test JVM")
+  public void capturesTestJvmThreads() throws Exception {
+    CountDownLatch release = new CountDownLatch(1);
+    Thread parked = new Thread(() -> awaitQuietly(release), "stall-capture-test-parked-thread");
+    parked.setDaemon(true);
+    parked.start();
+
+    StringBuilder sink = new StringBuilder();
+    try {
+      StallCapture.capture(sink, "some-test-label", 12_000L, 1, Collections.emptyList(), 10_000L);
+    } finally {
+      release.countDown();
+    }
+
+    String report = sink.toString();
+    assertTrue(report.contains("STALL DUMP frame 1"), "banner missing:\n" + report);
+    assertTrue(report.contains("some-test-label"), "label missing:\n" + report);
+    assertTrue(report.contains("elapsed:  12s"), "elapsed time missing:\n" + report);
+    assertTrue(
+        report.contains("stall-capture-test-parked-thread"),
+        "parked thread missing from dump:\n" + report);
+    for (String reportLine : report.split("\n")) {
+      assertTrue(
+          reportLine.startsWith(StallCapture.PREFIX),
+          "every line must be greppable, but found: " + reportLine);
+    }
+  }
+
+  @Test
+  @DisplayName("Capture dumps the threads of a live target JVM")
+  public void capturesTargetJvmThreads() throws Exception {
+    // A target that blocks until killed. A short-lived one would race jcmd's attach and make the
+    // assertion nondeterministic.
+    Process target = startBlockingJvm();
+    TargetRegistry.Handle handle = TargetRegistry.register(target, "blocking-target", jcmd());
+    handle.setPid(pidOf(target));
+
+    StringBuilder sink = new StringBuilder();
+    StallCapture.capture(sink, "target-test", 1_000L, 1, TargetRegistry.liveTargets(), 30_000L);
+    String report = sink.toString();
+
+    assertTrue(report.contains("blocking-target"), "target section missing:\n" + report);
+    Assumptions.assumeFalse(
+        report.contains("jcmd failed") || report.contains("jcmd produced no output"),
+        "jcmd could not attach in this environment; skipping the content assertion");
+    assertTrue(report.contains("\"main\""), "target's main thread missing:\n" + report);
+  }
+
+  @Test
+  @DisplayName("A target that cannot be dumped degrades to a note, not a hang")
+  public void degradesOnUnreachableTarget() throws Exception {
+    // A live process that is not a JVM: isAlive() is true, and jcmd cannot attach to it.
+    Process target = startNonJvmProcess();
+    TargetRegistry.Handle handle = TargetRegistry.register(target, "bogus-pid-target", jcmd());
+    handle.setPid("999999999");
+
+    StringBuilder sink = new StringBuilder();
+    long startedAt = System.nanoTime();
+    StallCapture.capture(sink, "degrade-test", 1_000L, 1, TargetRegistry.liveTargets(), 30_000L);
+    long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+
+    String report = sink.toString();
+    assertTrue(
+        elapsedMs < 30_000L, "capture must stay inside its budget, took " + elapsedMs + "ms");
+    assertTrue(report.contains("bogus-pid-target"), "target section missing:\n" + report);
+    assertTrue(report.contains("---- test JVM threads ----"), "test JVM dump lost:\n" + report);
+    assertTrue(report.contains("==== end of stall dump frame 1 ===="), "truncated:\n" + report);
+  }
+
+  @Test
+  @DisplayName("The capture budget covers all targets together")
+  public void budgetIsSharedAcrossTargets() throws Exception {
+    for (int i = 0; i < 4; i++) {
+      Process target = startNonJvmProcess();
+      TargetRegistry.register(target, "unreachable-" + i, jcmd()).setPid("99999999" + i);
+    }
+
+    StringBuilder sink = new StringBuilder();
+    long startedAt = System.nanoTime();
+    // A budget below one jcmd timeout, so the first target consumes it and the rest are skipped.
+    StallCapture.capture(sink, "budget-test", 1_000L, 1, TargetRegistry.liveTargets(), 1L);
+    long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+
+    String report = sink.toString();
+    assertTrue(
+        elapsedMs < 30_000L,
+        "shared budget must not be spent per target, took " + elapsedMs + "ms");
+    assertTrue(report.contains("capture budget exhausted"), "skips must be recorded:\n" + report);
+    assertFalse(report.contains("STALL DUMP frame 2"), "only one frame was requested:\n" + report);
+  }
+
+  private static void awaitQuietly(CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private Process startBlockingJvm() throws Exception {
+    String java = Paths.get(javaHome(), "bin", "java").toString();
+    // The code source rather than java.class.path: a Gradle worker may present its classpath
+    // through a manifest-only jar, which a child JVM launched with -cp cannot resolve.
+    String classpath =
+        Paths.get(
+                StallCaptureTest.class.getProtectionDomain().getCodeSource().getLocation().toURI())
+            .toString();
+    ProcessBuilder pb = new ProcessBuilder(java, "-cp", classpath, BlockingMain.NAME);
+    pb.redirectErrorStream(true);
+    pb.redirectOutput(new File(System.getProperty("java.io.tmpdir"), "btrace-blocking-target.log"));
+    Process process = pb.start();
+    spawned.add(process);
+    // Give it time to reach main() so that jcmd has something to attach to.
+    Thread.sleep(2_000L);
+    return process;
+  }
+
+  /** A live process that is not a JVM, for the cases where the dump is expected to fail. */
+  private Process startNonJvmProcess() throws Exception {
+    Process process = new ProcessBuilder("sleep", "120").start();
+    spawned.add(process);
+    return process;
+  }
+
+  private static String javaHome() {
+    // Deliberately the JVM running these tests, so that jcmd and the target are the same major
+    // version; a mismatched-major jcmd cannot attach.
+    return System.getProperty("java.home");
+  }
+
+  private static String jcmd() {
+    return Paths.get(javaHome(), "bin", "jcmd").toString();
+  }
+
+  private static String pidOf(Process process) throws Exception {
+    // Source level here is 8, so Process.pid() is reached reflectively -- the same route
+    // TargetRegistry uses for a target that never reported a pid.
+    return String.valueOf(Process.class.getMethod("pid").invoke(process));
+  }
+
+  /** Entry point for the blocking target JVM. */
+  public static final class BlockingMain {
+    static final String NAME = "tests.harness.StallCaptureTest$BlockingMain";
+
+    public static void main(String[] args) throws Exception {
+      new CountDownLatch(1).await();
+    }
+  }
+}

--- a/integration-tests/src/test/java/tests/harness/StallCaptureTest.java
+++ b/integration-tests/src/test/java/tests/harness/StallCaptureTest.java
@@ -16,6 +16,7 @@
  */
 package tests.harness;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -134,19 +135,30 @@ public class StallCaptureTest {
 
     StringBuilder sink = new StringBuilder();
     long startedAt = System.nanoTime();
-    // Enough for roughly one jcmd attempt. A per-target budget would let all four run and take
-    // four times as long, which is exactly what this asserts against.
-    StallCapture.capture(sink, "budget-test", 1_000L, 1, TargetRegistry.liveTargets(), 12_000L);
+    // A dumper of known duration rather than a real jcmd: how long a failing attach takes differs
+    // by platform, and this must assert on the budget, not on the platform.
+    StallCapture.TargetDumper slow =
+        (dumpSink, target) -> {
+          try {
+            Thread.sleep(2_000L);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+          StallCapture.line(dumpSink, "dumped " + target.getLabel());
+        };
+    // Enough for one dump. A per-target budget would let all four run and take four times as long.
+    StallCapture.capture(
+        sink, "budget-test", 1_000L, 1, TargetRegistry.liveTargets(), 2_500L, slow);
     long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
 
     String report = sink.toString();
     assertTrue(
-        elapsedMs < 40_000L,
-        "shared budget must not be spent per target, took " + elapsedMs + "ms");
-    assertTrue(
-        report.contains("---- target unreachable-0"),
-        "the first target must still be attempted:\n" + report);
+        elapsedMs < 6_000L, "shared budget must not be spent per target, took " + elapsedMs + "ms");
+    assertTrue(report.contains("dumped unreachable-0"), "first target not dumped:\n" + report);
     assertTrue(report.contains("capture budget exhausted"), "skips must be recorded:\n" + report);
+    assertFalse(
+        report.contains("dumped unreachable-3"),
+        "a target past the shared budget must not be dumped:\n" + report);
     assertTrue(
         report.contains("---- target unreachable-3"),
         "a skipped target must still be named:\n" + report);

--- a/integration-tests/src/test/java/tests/harness/StallTimeout.java
+++ b/integration-tests/src/test/java/tests/harness/StallTimeout.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.harness;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Overrides how long {@link StallWatchdog} waits before deciding a test has stopped making
+ * progress.
+ *
+ * <p>An annotation rather than a system property because all integration test classes share one
+ * worker JVM: a property set by one test would leak into every class that follows it. Its main use
+ * is the watchdog's own tests, which must fire in seconds rather than minutes.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
+public @interface StallTimeout {
+  /** How long a test may run before the first dump is taken. */
+  long millis();
+
+  /** How long after the first dump the second one is taken. */
+  long gapMillis() default 30_000L;
+}

--- a/integration-tests/src/test/java/tests/harness/StallWatchdog.java
+++ b/integration-tests/src/test/java/tests/harness/StallWatchdog.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.harness;
+
+import java.io.File;
+import java.io.Flushable;
+import java.io.IOException;
+import java.io.Writer;
+import java.lang.reflect.AnnotatedElement;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Dumps the threads of the test JVM and of every live target JVM when a test stops making progress.
+ *
+ * <p>An integration test that wedges used to produce nothing at all: no assertion failure, no stack
+ * trace, and a job cancelled at its timeout twenty-five minutes later. Localising one meant reading
+ * raw job logs and comparing timestamps, and the resulting hypotheses could not be confirmed
+ * because no dump was ever captured. This closes that gap: the next stall names the blocked thread
+ * on both sides of the connection.
+ *
+ * <p>It reports and does not intervene. Failing a stalled test is the job of the per-test timeout
+ * in {@code junit-platform.properties}, which is set above this watchdog's deadline so that a dump
+ * is always taken while the stall is still live.
+ *
+ * <p>Two frames are captured, thirty seconds apart. One frame cannot distinguish a wedged thread
+ * from a slow one -- both look identical parked in a socket read -- so the difference between two
+ * frames is the actual evidence.
+ */
+public class StallWatchdog
+    implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+
+  /** Absolute path, supplied by the build. See the {@code test} block in build.gradle. */
+  private static final String DUMP_DIR_PROPERTY = "btrace.test.stallDumpDir";
+
+  private static final String STALL_TIMEOUT_PROPERTY = "btrace.test.stallTimeoutMs";
+
+  /**
+   * The watchdog deadline defaults to six times the harness timeout. It cannot be much tighter:
+   * {@code RuntimeTest} already allows a target four times that value for startup alone, so a
+   * shorter deadline would fire on tests that are merely slow.
+   */
+  private static final long DEFAULT_TIMEOUT_MULTIPLIER = 6L;
+
+  private static final long DEFAULT_GAP_MS = 30_000L;
+
+  /** All targets together, so accumulated targets cannot stretch a capture without bound. */
+  private static final long CAPTURE_BUDGET_MS = 60_000L;
+
+  private static final ScheduledExecutorService SCHEDULER =
+      Executors.newScheduledThreadPool(
+          2,
+          new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable runnable) {
+              Thread t = new Thread(runnable, "btrace-stall-watchdog");
+              t.setDaemon(true);
+              return t;
+            }
+          });
+
+  /**
+   * The single armed test. Integration tests run sequentially in one worker JVM -- no {@code
+   * forkEvery}, no parallel execution -- so one slot is correct and avoids threading state through
+   * the extension store.
+   */
+  private static final AtomicReference<Armed> CURRENT = new AtomicReference<>();
+
+  private static final AtomicBoolean STALE_DUMPS_CLEARED = new AtomicBoolean();
+
+  private static volatile Path dumpDirOverride;
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    arm(context, context.getDisplayName() + " (class setup)");
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    arm(context, context.getUniqueId());
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    // Re-arm rather than simply disarming, so a stall in an @AfterEach method or between tests is
+    // covered too. Deliberately resolved against the class context: a per-method @StallTimeout
+    // belongs to the method, and carrying it into teardown would fire a dump for a test that has
+    // already finished.
+    ExtensionContext classContext = context.getParent().orElse(context);
+    arm(classContext, classContext.getDisplayName() + " (teardown)");
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) {
+    disarm();
+  }
+
+  /** Points dumps at a caller-controlled directory. For the watchdog's own tests. */
+  static void setDumpDirForTesting(Path dir) {
+    dumpDirOverride = dir;
+  }
+
+  private void arm(ExtensionContext context, String label) {
+    disarm();
+    clearStaleDumpsOnce();
+    long timeoutMs = resolveTimeoutMs(context);
+    long gapMs = resolveGapMs(context);
+    Armed armed = new Armed(label, gapMs);
+    CURRENT.set(armed);
+    armed.frameOne = SCHEDULER.schedule(armed::fireFirstFrame, timeoutMs, TimeUnit.MILLISECONDS);
+  }
+
+  private void disarm() {
+    Armed previous = CURRENT.getAndSet(null);
+    if (previous != null) {
+      previous.disarm();
+    }
+  }
+
+  private long resolveTimeoutMs(ExtensionContext context) {
+    StallTimeout annotation = findAnnotation(context);
+    if (annotation != null) {
+      return annotation.millis();
+    }
+    Long explicit = Long.getLong(STALL_TIMEOUT_PROPERTY);
+    if (explicit != null) {
+      return explicit;
+    }
+    return Long.getLong("btrace.test.timeoutMs", 60_000L) * DEFAULT_TIMEOUT_MULTIPLIER;
+  }
+
+  private long resolveGapMs(ExtensionContext context) {
+    StallTimeout annotation = findAnnotation(context);
+    return annotation != null ? annotation.gapMillis() : DEFAULT_GAP_MS;
+  }
+
+  private StallTimeout findAnnotation(ExtensionContext context) {
+    ExtensionContext current = context;
+    while (current != null) {
+      AnnotatedElement element = current.getElement().orElse(null);
+      if (element != null) {
+        StallTimeout annotation = element.getAnnotation(StallTimeout.class);
+        if (annotation != null) {
+          return annotation;
+        }
+      }
+      current = current.getParent().orElse(null);
+    }
+    return null;
+  }
+
+  /**
+   * Drops dumps left by an earlier run, once per JVM.
+   *
+   * <p>Done when the watchdog first arms rather than when it first writes: {@code cleanTest} does
+   * not cover this directory, so otherwise a green run would upload a previous run's dumps as if
+   * they were its own.
+   */
+  private static void clearStaleDumpsOnce() {
+    if (!STALE_DUMPS_CLEARED.compareAndSet(false, true)) {
+      return;
+    }
+    File[] stale = dumpDir().toFile().listFiles();
+    if (stale == null) {
+      return;
+    }
+    for (File file : stale) {
+      if (!file.delete()) {
+        file.deleteOnExit();
+      }
+    }
+  }
+
+  private static Path dumpDir() {
+    Path override = dumpDirOverride;
+    if (override != null) {
+      return override;
+    }
+    String configured = System.getProperty(DUMP_DIR_PROPERTY);
+    // The relative fallback exists only for a direct IDE run; the build always supplies an
+    // absolute path, because a relative one would resolve against the test task's working
+    // directory, which is the project directory rather than the repository root.
+    return configured != null
+        ? Paths.get(configured)
+        : Paths.get("build", "reports", "stall-dumps");
+  }
+
+  /** One armed test, and the two capture frames it may produce. */
+  private static final class Armed {
+    private final String label;
+    private final long gapMs;
+    private final long startNanos = System.nanoTime();
+    private final AtomicBoolean disarmed = new AtomicBoolean();
+    private volatile ScheduledFuture<?> frameOne;
+    private volatile ScheduledFuture<?> frameTwo;
+
+    /**
+     * Targets are snapshotted once, when the watchdog fires, and both frames dump those exact
+     * processes. Re-reading the registry for the second frame could pick up a target belonging to
+     * the next test, if this one unwedged during the gap.
+     */
+    private volatile List<TargetRegistry.Snapshot> targets = Collections.emptyList();
+
+    Armed(String label, long gapMs) {
+      this.label = label;
+      this.gapMs = gapMs;
+    }
+
+    void disarm() {
+      disarmed.set(true);
+      cancel(frameOne);
+      cancel(frameTwo);
+    }
+
+    private void cancel(ScheduledFuture<?> future) {
+      if (future != null) {
+        // Never interrupt: a capture already in flight should finish rather than leave a
+        // half-written file.
+        future.cancel(false);
+      }
+    }
+
+    void fireFirstFrame() {
+      if (disarmed.get()) {
+        return;
+      }
+      targets = TargetRegistry.liveTargets();
+      writeFrame(1);
+      if (disarmed.get()) {
+        return;
+      }
+      frameTwo = SCHEDULER.schedule(this::fireSecondFrame, gapMs, TimeUnit.MILLISECONDS);
+    }
+
+    void fireSecondFrame() {
+      if (disarmed.get()) {
+        return;
+      }
+      writeFrame(2);
+    }
+
+    private void writeFrame(int frame) {
+      long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+      StringBuilder echo = new StringBuilder();
+      Path file = null;
+      try {
+        Path dir = dumpDir();
+        Files.createDirectories(dir);
+        file = dir.resolve(fileName(label, frame));
+        try (Writer writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+          // The file is the sink that matters: `if: always()` artifact upload survives a job
+          // cancelled at its timeout, and the release path redirects all test output into a log it
+          // only summarises once the command has exited.
+          Appendable sink = new TeeAppendable(writer, echo);
+          StallCapture.capture(sink, label, elapsedMs, frame, targets, CAPTURE_BUDGET_MS);
+        }
+      } catch (Throwable t) {
+        StallCapture.line(echo, "stall dump could not be written to file: " + t);
+        if (file != null) {
+          StallCapture.line(echo, "intended path: " + file);
+        }
+      }
+      // Second, and best-effort: System.out is a shared synchronised stream that a stalled
+      // Gradle pipeline can itself block on.
+      System.out.print(echo);
+      System.out.flush();
+    }
+  }
+
+  /**
+   * A file name derived from the test's unique id.
+   *
+   * <p>The unique id, not the method name: the test that motivated this watchdog is a
+   * {@code @ParameterizedTest} whose four rows share one method name, and the row that stalls is
+   * not the row that would win the race for the file. Truncated and hashed because a full
+   * parameterised unique id exceeds the filename length limit.
+   */
+  static String fileName(String label, int frame) {
+    StringBuilder sanitised = new StringBuilder(label.length());
+    for (int i = 0; i < label.length(); i++) {
+      char c = label.charAt(i);
+      sanitised.append(
+          (c >= 'A' && c <= 'Z')
+                  || (c >= 'a' && c <= 'z')
+                  || (c >= '0' && c <= '9')
+                  || c == '.'
+                  || c == '-'
+              ? c
+              : '_');
+    }
+    String trimmed = sanitised.length() > 120 ? sanitised.substring(0, 120) : sanitised.toString();
+    return trimmed + "-" + Integer.toHexString(label.hashCode()) + "-frame" + frame + ".txt";
+  }
+
+  /** Writes to the file and accumulates a copy for stdout, flushing the file as sections land. */
+  private static final class TeeAppendable implements Appendable, Flushable {
+    private final Writer writer;
+    private final StringBuilder echo;
+
+    TeeAppendable(Writer writer, StringBuilder echo) {
+      this.writer = writer;
+      this.echo = echo;
+    }
+
+    @Override
+    public Appendable append(CharSequence csq) throws IOException {
+      writer.append(csq);
+      echo.append(csq);
+      return this;
+    }
+
+    @Override
+    public Appendable append(CharSequence csq, int start, int end) throws IOException {
+      writer.append(csq, start, end);
+      echo.append(csq, start, end);
+      return this;
+    }
+
+    @Override
+    public Appendable append(char c) throws IOException {
+      writer.append(c);
+      echo.append(c);
+      return this;
+    }
+
+    @Override
+    public void flush() throws IOException {
+      writer.flush();
+    }
+  }
+}

--- a/integration-tests/src/test/java/tests/harness/StallWatchdog.java
+++ b/integration-tests/src/test/java/tests/harness/StallWatchdog.java
@@ -27,12 +27,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -72,13 +72,22 @@ public class StallWatchdog
    */
   private static final long DEFAULT_TIMEOUT_MULTIPLIER = 6L;
 
+  /**
+   * A ceiling on the derived deadline. {@code btrace.test.timeoutMs} is an operator knob, and
+   * raising it must not push the watchdog past the per-test timeout in {@code
+   * junit-platform.properties} -- a dump taken after the test has been abandoned is no dump at all.
+   */
+  private static final long MAX_DERIVED_TIMEOUT_MS = 6L * 60L * 1000L;
+
   private static final long DEFAULT_GAP_MS = 30_000L;
 
   /** All targets together, so accumulated targets cannot stretch a capture without bound. */
   private static final long CAPTURE_BUDGET_MS = 60_000L;
 
-  private static final ScheduledExecutorService SCHEDULER =
-      Executors.newScheduledThreadPool(
+  private static final long ECHO_TIMEOUT_MS = 10_000L;
+
+  private static final ScheduledThreadPoolExecutor SCHEDULER =
+      new ScheduledThreadPoolExecutor(
           2,
           new ThreadFactory() {
             @Override
@@ -89,6 +98,12 @@ public class StallWatchdog
             }
           });
 
+  static {
+    // arm() runs three times per test and cancels the previous task each time; without this every
+    // cancelled task would sit in the delayed queue until its deadline, which outlasts the suite.
+    SCHEDULER.setRemoveOnCancelPolicy(true);
+  }
+
   /**
    * The single armed test. Integration tests run sequentially in one worker JVM -- no {@code
    * forkEvery}, no parallel execution -- so one slot is correct and avoids threading state through
@@ -97,6 +112,9 @@ public class StallWatchdog
   private static final AtomicReference<Armed> CURRENT = new AtomicReference<>();
 
   private static final AtomicBoolean STALE_DUMPS_CLEARED = new AtomicBoolean();
+
+  /** Makes every dump path unique; two teardown stalls in one class share a label otherwise. */
+  private static final AtomicInteger SEQUENCE = new AtomicInteger();
 
   private static volatile Path dumpDirOverride;
 
@@ -145,6 +163,10 @@ public class StallWatchdog
     if (previous != null) {
       previous.disarm();
     }
+    // Drops targets that have exited. Without this the registry only ever grows, and a stall late
+    // in the run would spend its capture budget on jcmd calls against processes from earlier
+    // classes instead of the target that actually matters.
+    TargetRegistry.liveTargets();
   }
 
   private long resolveTimeoutMs(ExtensionContext context) {
@@ -156,7 +178,8 @@ public class StallWatchdog
     if (explicit != null) {
       return explicit;
     }
-    return Long.getLong("btrace.test.timeoutMs", 60_000L) * DEFAULT_TIMEOUT_MULTIPLIER;
+    long derived = Long.getLong("btrace.test.timeoutMs", 60_000L) * DEFAULT_TIMEOUT_MULTIPLIER;
+    return Math.min(derived, MAX_DERIVED_TIMEOUT_MS);
   }
 
   private long resolveGapMs(ExtensionContext context) {
@@ -177,6 +200,27 @@ public class StallWatchdog
       current = current.getParent().orElse(null);
     }
     return null;
+  }
+
+  /** Prints the captured report without letting a blocked stdout consume a scheduler thread. */
+  private static void echoToStdout(final CharSequence report) {
+    Thread printer =
+        new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                System.out.print(report);
+                System.out.flush();
+              }
+            },
+            "btrace-stall-echo");
+    printer.setDaemon(true);
+    printer.start();
+    try {
+      printer.join(ECHO_TIMEOUT_MS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   /**
@@ -267,6 +311,35 @@ public class StallWatchdog
         return;
       }
       writeFrame(2);
+      releaseTargets();
+    }
+
+    /**
+     * Kills the targets this test was talking to, once both frames have been captured.
+     *
+     * <p>The watchdog would rather only observe, but observing alone does not end the stall. The
+     * per-test timeout runs the test body on a thread JUnit does not mark as a daemon and abandons
+     * it on timeout with nothing but an interrupt -- which a thread blocked in socket I/O ignores.
+     * That surviving thread keeps the worker JVM alive, so the job burns its whole budget even
+     * though the test has been marked failed. Closing the target's sockets is what actually
+     * releases the blocked thread, and it also clears the orphaned JVMs that a stalled run used to
+     * leave behind.
+     *
+     * <p>This happens only after two frames thirty seconds apart, so the evidence is already on
+     * disk, and only to targets registered by the stalled test.
+     */
+    private void releaseTargets() {
+      for (TargetRegistry.Snapshot target : targets) {
+        try {
+          if (target.getProcess().isAlive()) {
+            target.getProcess().destroyForcibly();
+            System.out.println(
+                StallCapture.PREFIX + "released stalled target " + target.getLabel());
+          }
+        } catch (Throwable ignored) {
+          // Nothing useful is left to do about a target we cannot kill.
+        }
+      }
     }
 
     private void writeFrame(int frame) {
@@ -290,10 +363,11 @@ public class StallWatchdog
           StallCapture.line(echo, "intended path: " + file);
         }
       }
-      // Second, and best-effort: System.out is a shared synchronised stream that a stalled
-      // Gradle pipeline can itself block on.
-      System.out.print(echo);
-      System.out.flush();
+      // Second, and best-effort. This is written on a throwaway thread with a bounded join for the
+      // reason the file is written first: System.out is a shared synchronised stream, and a torn-
+      // down Gradle pipeline can block on it -- which would consume a scheduler thread and cost us
+      // the second frame.
+      echoToStdout(echo);
     }
   }
 
@@ -306,6 +380,10 @@ public class StallWatchdog
    * parameterised unique id exceeds the filename length limit.
    */
   static String fileName(String label, int frame) {
+    return fileName(label, frame, SEQUENCE.incrementAndGet());
+  }
+
+  static String fileName(String label, int frame, int sequence) {
     StringBuilder sanitised = new StringBuilder(label.length());
     for (int i = 0; i < label.length(); i++) {
       char c = label.charAt(i);
@@ -318,8 +396,20 @@ public class StallWatchdog
               ? c
               : '_');
     }
-    String trimmed = sanitised.length() > 120 ? sanitised.substring(0, 120) : sanitised.toString();
-    return trimmed + "-" + Integer.toHexString(label.hashCode()) + "-frame" + frame + ".txt";
+    // The tail, not the head: a parameterised unique id is identical up to its invocation index,
+    // so truncating from the front would give all four rows of a @ParameterizedTest one name.
+    String trimmed =
+        sanitised.length() > 120
+            ? sanitised.substring(sanitised.length() - 120)
+            : sanitised.toString();
+    return sequence
+        + "-"
+        + trimmed
+        + "-"
+        + Integer.toHexString(label.hashCode())
+        + "-frame"
+        + frame
+        + ".txt";
   }
 
   /** Writes to the file and accumulates a copy for stdout, flushing the file as sections land. */

--- a/integration-tests/src/test/java/tests/harness/StallWatchdogTest.java
+++ b/integration-tests/src/test/java/tests/harness/StallWatchdogTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.harness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Covers the watchdog's scheduling: that it fires when a test stops progressing, stays silent when
+ * one does not, and produces the second frame that makes a stall distinguishable from slowness.
+ *
+ * <p>Deadlines come from {@link StallTimeout} rather than a system property, because all
+ * integration test classes share one worker JVM and a property set here would leak into every class
+ * that runs after it.
+ */
+@ExtendWith(StallWatchdog.class)
+public class StallWatchdogTest {
+  @TempDir Path dumpDir;
+
+  @BeforeEach
+  public void redirectDumps() {
+    StallWatchdog.setDumpDirForTesting(dumpDir);
+    TargetRegistry.clear();
+  }
+
+  @AfterEach
+  public void restoreDumpDir() {
+    StallWatchdog.setDumpDirForTesting(null);
+    TargetRegistry.clear();
+  }
+
+  @Test
+  @DisplayName("A test that finishes promptly produces no dump")
+  public void staysSilentWhenGreen() throws Exception {
+    Thread.sleep(200L);
+    assertEquals(Collections.emptyList(), dumpFiles(), "a green test must not leave a dump behind");
+  }
+
+  @Test
+  @StallTimeout(millis = 1_000L, gapMillis = 60_000L)
+  @DisplayName("A stalled test is dumped, naming the stalled thread")
+  public void firesOnAStall() throws Exception {
+    Thread.currentThread().setName("stall-watchdog-test-stalled-thread");
+    Thread.sleep(3_000L);
+
+    String report = awaitFrame(1);
+    assertEquals(1, dumpFiles().size(), "expected exactly one frame, got " + dumpFiles());
+    assertTrue(report.contains("STALL DUMP frame 1"), "banner missing:\n" + report);
+    assertTrue(
+        report.contains("stall-watchdog-test-stalled-thread"),
+        "the stalled thread must be named:\n" + report);
+    assertTrue(
+        dumpFiles().get(0).getFileName().toString().endsWith("-frame1.txt"), "bad file name");
+  }
+
+  @Test
+  @StallTimeout(millis = 1_000L, gapMillis = 1_000L)
+  @DisplayName("A continuing stall produces a second frame, so it can be told from slowness")
+  public void producesASecondFrame() throws Exception {
+    Thread.sleep(4_000L);
+
+    String first = awaitFrame(1);
+    String second = awaitFrame(2);
+    assertEquals(2, dumpFiles().size(), "expected two frames, got " + dumpFiles());
+    assertTrue(first.contains("STALL DUMP frame 1"), "frame 1 missing:\n" + first);
+    assertTrue(second.contains("STALL DUMP frame 2"), "frame 2 missing:\n" + second);
+    assertNotEquals(
+        elapsedLine(first),
+        elapsedLine(second),
+        "the frames must be distinguishable; their difference is the evidence");
+  }
+
+  @Test
+  @StallTimeout(millis = 1_000L, gapMillis = 60_000L)
+  @DisplayName("A stall dump includes the threads of a registered target")
+  public void dumpsRegisteredTargets() throws Exception {
+    Process target = new ProcessBuilder("sleep", "120").start();
+    try {
+      TargetRegistry.register(target, "watchdog-test-target", "jcmd").setPid("123456789");
+      Thread.sleep(3_000L);
+
+      String report = awaitFrame(1);
+      assertEquals(1, dumpFiles().size(), "expected exactly one frame, got " + dumpFiles());
+      assertTrue(
+          report.contains("watchdog-test-target"),
+          "a registered target must appear in the dump:\n" + report);
+    } finally {
+      target.destroyForcibly();
+    }
+  }
+
+  /**
+   * Waits for a frame to be written in full.
+   *
+   * <p>The watchdog flushes each section as it is produced, so that a capture which hangs part way
+   * still leaves what it had on disk. A test therefore has to wait for the closing marker rather
+   * than for the file to appear.
+   */
+  private String awaitFrame(int frame) throws Exception {
+    String marker = "==== end of stall dump frame " + frame + " ====";
+    long deadline = System.currentTimeMillis() + 30_000L;
+    String last = "";
+    while (System.currentTimeMillis() < deadline) {
+      for (Path dump : dumpFiles()) {
+        if (dump.getFileName().toString().endsWith("-frame" + frame + ".txt")) {
+          last = read(dump);
+          if (last.contains(marker)) {
+            return last;
+          }
+        }
+      }
+      Thread.sleep(100L);
+    }
+    throw new AssertionError("frame " + frame + " was never completed; last saw:\n" + last);
+  }
+
+  private List<Path> dumpFiles() throws IOException {
+    File[] files = dumpDir.toFile().listFiles();
+    if (files == null) {
+      return Collections.emptyList();
+    }
+    Arrays.sort(files);
+    List<Path> paths = new ArrayList<>();
+    for (File file : files) {
+      paths.add(file.toPath());
+    }
+    return paths;
+  }
+
+  private static String read(Path path) throws IOException {
+    return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+  }
+
+  private static String elapsedLine(String report) {
+    for (String line : report.split("\n")) {
+      if (line.contains("elapsed:")) {
+        return line;
+      }
+    }
+    return "";
+  }
+}

--- a/integration-tests/src/test/java/tests/harness/StallWatchdogTest.java
+++ b/integration-tests/src/test/java/tests/harness/StallWatchdogTest.java
@@ -17,6 +17,7 @@
 package tests.harness;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -68,13 +69,18 @@ public class StallWatchdogTest {
   }
 
   @Test
-  @StallTimeout(millis = 1_000L, gapMillis = 60_000L)
+  @StallTimeout(millis = 300L, gapMillis = 60_000L)
   @DisplayName("A stalled test is dumped, naming the stalled thread")
   public void firesOnAStall() throws Exception {
+    String originalName = Thread.currentThread().getName();
     Thread.currentThread().setName("stall-watchdog-test-stalled-thread");
-    Thread.sleep(3_000L);
-
-    String report = awaitFrame(1);
+    String report;
+    try {
+      report = awaitFrame(1);
+    } finally {
+      // Restored, or every later dump in this worker JVM names a test that finished minutes ago.
+      Thread.currentThread().setName(originalName);
+    }
     assertEquals(1, dumpFiles().size(), "expected exactly one frame, got " + dumpFiles());
     assertTrue(report.contains("STALL DUMP frame 1"), "banner missing:\n" + report);
     assertTrue(
@@ -85,36 +91,52 @@ public class StallWatchdogTest {
   }
 
   @Test
-  @StallTimeout(millis = 1_000L, gapMillis = 1_000L)
+  @StallTimeout(millis = 300L, gapMillis = 300L)
   @DisplayName("A continuing stall produces a second frame, so it can be told from slowness")
   public void producesASecondFrame() throws Exception {
-    Thread.sleep(4_000L);
-
     String first = awaitFrame(1);
     String second = awaitFrame(2);
     assertEquals(2, dumpFiles().size(), "expected two frames, got " + dumpFiles());
     assertTrue(first.contains("STALL DUMP frame 1"), "frame 1 missing:\n" + first);
     assertTrue(second.contains("STALL DUMP frame 2"), "frame 2 missing:\n" + second);
     assertNotEquals(
-        elapsedLine(first),
-        elapsedLine(second),
-        "the frames must be distinguishable; their difference is the evidence");
+        first, second, "the frames must differ; their difference is the evidence of a stall");
   }
 
   @Test
-  @StallTimeout(millis = 1_000L, gapMillis = 60_000L)
+  @StallTimeout(millis = 300L, gapMillis = 60_000L)
   @DisplayName("A stall dump includes the threads of a registered target")
   public void dumpsRegisteredTargets() throws Exception {
     Process target = new ProcessBuilder("sleep", "120").start();
     try {
       TargetRegistry.register(target, "watchdog-test-target", "jcmd").setPid("123456789");
-      Thread.sleep(3_000L);
 
       String report = awaitFrame(1);
       assertEquals(1, dumpFiles().size(), "expected exactly one frame, got " + dumpFiles());
       assertTrue(
           report.contains("watchdog-test-target"),
           "a registered target must appear in the dump:\n" + report);
+    } finally {
+      target.destroyForcibly();
+    }
+  }
+
+  @Test
+  @StallTimeout(millis = 300L, gapMillis = 300L)
+  @DisplayName("Once both frames are captured, the stalled test's targets are released")
+  public void releasesTargetsAfterTheSecondFrame() throws Exception {
+    Process target = new ProcessBuilder("sleep", "120").start();
+    try {
+      TargetRegistry.register(target, "released-target", "jcmd").setPid("123456789");
+
+      awaitFrame(2);
+      long deadline = System.currentTimeMillis() + 15_000L;
+      while (target.isAlive() && System.currentTimeMillis() < deadline) {
+        Thread.sleep(50L);
+      }
+      // Evidence alone does not end a stall: the per-test timeout abandons the test on a thread
+      // JUnit does not mark as a daemon, and only closing the target's sockets lets it die.
+      assertFalse(target.isAlive(), "a stalled test's target must be released once dumped");
     } finally {
       target.destroyForcibly();
     }

--- a/integration-tests/src/test/java/tests/harness/TargetRegistry.java
+++ b/integration-tests/src/test/java/tests/harness/TargetRegistry.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.harness;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Tracks the JVMs an integration test has spawned, so that {@link StallWatchdog} can dump their
+ * threads when a test stops making progress.
+ *
+ * <p>Targets are registered at launch rather than once they report a pid. A target that wedges
+ * during startup never prints its {@code ready:} line, and that is precisely a case where its stack
+ * is worth having; registering late would lose it. Liveness is decided at capture time via {@link
+ * Process#isAlive()}, which means callers need no deregistration hook and a test that forgets to
+ * stop its target costs nothing.
+ *
+ * <p>Source level here is Java 8, so {@code Process.pid()} is reached reflectively.
+ */
+public final class TargetRegistry {
+  private static final List<Entry> ENTRIES = new CopyOnWriteArrayList<>();
+
+  private TargetRegistry() {}
+
+  /**
+   * Registers a freshly launched target JVM.
+   *
+   * @param process the target
+   * @param label how the target should be named in a dump
+   * @param jcmdPath the {@code jcmd} binary able to attach to this target. Passed in rather than
+   *     resolved centrally: targets are not all launched from the same JDK, and a mismatched-major
+   *     {@code jcmd} cannot attach.
+   */
+  public static Handle register(Process process, String label, String jcmdPath) {
+    Entry entry = new Entry(process, label, jcmdPath);
+    ENTRIES.add(entry);
+    return entry;
+  }
+
+  /** Live targets, in registration order. Dead ones are dropped as they are noticed. */
+  public static List<Snapshot> liveTargets() {
+    List<Snapshot> live = new ArrayList<>();
+    List<Entry> dead = new ArrayList<>();
+    for (Entry entry : ENTRIES) {
+      if (entry.process.isAlive()) {
+        live.add(new Snapshot(entry.label, entry.resolvePid(), entry.process, entry.jcmdPath));
+      } else {
+        dead.add(entry);
+      }
+    }
+    ENTRIES.removeAll(dead);
+    return Collections.unmodifiableList(live);
+  }
+
+  /** Drops every entry. For tests, which must not see targets left by their neighbours. */
+  public static void clear() {
+    ENTRIES.clear();
+  }
+
+  /** Lets a launch site publish the pid its target reported. */
+  public interface Handle {
+    void setPid(String pid);
+  }
+
+  /** An immutable view of one live target. */
+  public static final class Snapshot {
+    private final String label;
+    private final String pid;
+    private final Process process;
+    private final String jcmdPath;
+
+    Snapshot(String label, String pid, Process process, String jcmdPath) {
+      this.label = label;
+      this.pid = pid;
+      this.process = process;
+      this.jcmdPath = jcmdPath;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    /**
+     * The target's pid, or {@code null} if it never reported one and reflection could not find it.
+     */
+    public String getPid() {
+      return pid;
+    }
+
+    public Process getProcess() {
+      return process;
+    }
+
+    public String getJcmdPath() {
+      return jcmdPath;
+    }
+  }
+
+  private static final class Entry implements Handle {
+    private final Process process;
+    private final String label;
+    private final String jcmdPath;
+    private volatile String pid;
+    private volatile boolean pidLookupAttempted;
+
+    Entry(Process process, String label, String jcmdPath) {
+      this.process = process;
+      this.label = label;
+      this.jcmdPath = jcmdPath;
+    }
+
+    @Override
+    public void setPid(String pid) {
+      this.pid = pid;
+    }
+
+    /**
+     * The reported pid, falling back to {@code Process.pid()} for a target that never got far
+     * enough to report one.
+     */
+    String resolvePid() {
+      String reported = pid;
+      if (reported != null) {
+        return reported;
+      }
+      if (pidLookupAttempted) {
+        return null;
+      }
+      pidLookupAttempted = true;
+      try {
+        Method pidMethod = Process.class.getMethod("pid");
+        Object value = pidMethod.invoke(process);
+        if (value != null) {
+          pid = String.valueOf(value);
+        }
+      } catch (Throwable ignored) {
+        // Java 8 target JVM, or a Process implementation without pid(). A dump without this
+        // target is still worth producing.
+      }
+      return pid;
+    }
+  }
+}

--- a/integration-tests/src/test/resources/junit-platform.properties
+++ b/integration-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,15 @@
+# A stalled integration test used to burn the whole job budget and report nothing: no assertion
+# failure, no stack trace, and a cancelled job. This bounds an individual test method so a stall
+# becomes an attributable failure instead.
+#
+# Eight minutes, not five: a passing test() invocation runs both the dynamic-attach and the startup
+# phase, and RuntimeTest already allows a target startupTimeoutMs = timeout * 4 = 240s on its own.
+# Eight sits above the slowest legitimate run and below the 15-minute release-path job.
+# StallWatchdog fires first, at six minutes, so a thread dump is always taken while the stall is
+# still live.
+#
+# SEPARATE_THREAD is deliberate. The default mode interrupts the test thread, and a thread blocked
+# in socket I/O ignores an interrupt, so a timeout raised that way would fire and still report
+# nothing.
+junit.jupiter.execution.timeout.testable.method.default = 8m
+junit.jupiter.execution.timeout.thread.mode.default = SEPARATE_THREAD


### PR DESCRIPTION
Makes a stalled integration test produce a thread dump of both JVMs instead of nothing, and bounds the test so a stall stops burning the whole job. Refs #932.

## What this is not

It is not a root-cause fix. Issue 932's original hypothesis — and a second one I proposed in this branch's design doc — are both refuted here, and the underlying defect that wedges the target JVM is still unidentified. Both died the same way: reasoning backwards from a log shape that several mechanisms explain equally well, with no dump to arbitrate. This delivers the arbitrator.

## The refutation, since it closes off a plausible-looking dead end

The design initially argued the stall was `Client.close()` deadlocking against its own parked reader, fixable with `sock.shutdownInput()`. Measured on JDK 11/17/24/26, descriptor in both blocking and non-blocking mode, with a reader parked in an unbounded `read()`:

| action | duration | reader observes |
|---|---|---|
| `socket.close()` | 0–1 ms | `SocketException: Socket closed` |
| `socket.getOutputStream().close()` | 0 ms | `SocketException: Socket closed` |
| `socket.shutdownInput()` | 0 ms | `read()` returns `-1` |

`NioSocketImpl.close()` pre-closes the descriptor and *signals* the blocked reader; it does not wait on it. `Client.close()` is bounded and cannot be a 25-minute stall.

The supporting evidence was misread too. `log.info("Successfully started BTrace probe")` fires at `Client.java:1284`, inside `submit`'s wrapping listener, *before* `listener.onCommand(cmd)` at `:1292` reaches the test's `handleStatus`. It proves the worker reached line 1284 — not that `started.get(20, SECONDS)` returned.

What survives: `started.get` may well have timed out, and the `TimeoutException` was then lost, because the enclosing `finally` runs `TestApp.stop()` → unbounded `process.waitFor()`. A pending exception whose `finally` never returns is never delivered to JUnit. Same observable shape — no assertion failure, no `PASSED` line, orphaned JVMs — different cause.

## What it does

`StallWatchdog` arms per test via `@ExtendWith` on `RuntimeTest`. At six minutes it writes two frames thirty seconds apart: full stacks of the test JVM, plus `jcmd Thread.print -l` of every live target and client JVM. Two frames because one cannot tell a wedged thread from a slow one — both look identical parked in a socket read — so the difference between frames is the evidence.

Dumps go to a file first and stdout second, under `build/reports/stall-dumps/`, which both workflows' `if: always()` steps already upload — no workflow change. The file is the sink that survives: upload still runs after a `timeout-minutes` cancellation, whereas the cancellation tears down the worker-to-console pipeline, and the release path redirects all test output into a log it only summarises once the command exits.

It runs only when something is already wrong, so every wait it performs is bounded and every internal failure becomes text rather than an exception. Sections flush as they are produced, so a capture that hangs part way still leaves what it had.

## Two things review caught that would have shipped silently

**`.gitignore`'s bare `junit*` swallowed `junit-platform.properties`.** The file existed locally, passed every local run, and was absent from the commit — while the commit message asserted the per-test bound now existed. `.gitignore` carries a negation now, placed after the pattern it overrides.

**`ThreadInfo.toString()` caps at eight frames.** A 44-frame stack rendered as 8, truncating the test-JVM dump exactly where the answer lives. Rendered frame by frame now, with locked monitors and synchronizers, and a test asserts the depth exceeds eight.

## Why it kills targets, having said it only observes

Evidence alone does not end a stall. `javap` on `junit-jupiter-api-5.14.4` confirms `AssertTimeoutPreemptively$TimeoutThreadFactory` builds its thread with `new Thread(Runnable, String)` and never calls `setDaemon(true)`. On timeout JUnit marks the test failed, interrupts a thread blocked in socket I/O that ignores interrupts, and abandons it. That non-daemon thread keeps the Gradle worker alive, so the job burns its full budget anyway. Closing the registered targets' sockets is what actually releases it — and it clears the orphaned JVMs the issue reports. This happens only after both frames are on disk, and only to targets registered by the stalled test.

## Deliberately not done

No SIGQUIT fallback. HotSpot writes that dump to the target's stdout, and for `testStartup` targets that stream is accumulated by `OutputPump` into the buffer the validators assert on — it would fail the test it was diagnosing.

No product-code change. Nothing in `btrace-client`, `btrace-core` or `btrace-agent` is touched.

## Relationship to #934 (now merged)

#934 has landed, and it landed **without** the per-test timeout its description claimed:

```
$ git ls-tree -r --name-only origin/develop | grep junit-platform
$          # nothing
```

The cause was `.gitignore:27`'s bare `junit*` pattern, which matches `junit-platform.properties` at any depth — so the file was written and verified locally, `git status` stayed clean, and `git add -A` skipped it silently ([detail](https://github.com/btraceio/btrace/pull/934#issuecomment-5129138741)). `develop` therefore has a bounded `TestApp.stop()` but still no bound on a test method: a stall today still runs to `timeout-minutes: 30`.

This branch carries both halves — the `.gitignore` fix that caused the loss, and the timeout itself at eight minutes rather than five: a passing `test()` runs both phases and `startupTimeoutMs` alone is 240 s, so five would risk failing green tests on slow lanes. Eight sits above the slowest legitimate run (17 s measured) and below the 15-minute release job. The watchdog fires first, at six, so a dump is always taken while the stall is live.

Rebased onto `develop` after #934 merged. The only conflict was additive — both branches inserted a static helper into `RuntimeTest` at the same point — and both are kept.

## Verification

- Nine new harness tests pass.
- Full integration suite: the same two failures appear on unmodified code — `ClassFileApiTests` smoke coverage and `Issue888 targetShutdownDeliversSuccessfulExitToCli` — confirmed by re-running both with this change reverted. Pre-existing, environment-specific, unrelated.
- A green run produces no dump and prints nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/935)
<!-- Reviewable:end -->

