### PR TITLE
chore: update JDK test versions

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8.0.492-tem, 11.0.31-tem, 17.0.19-tem, 21.0.11-tem, 25.0.3-tem, 27.ea.31-open ]
+        java: [ 8.0.502-tem, 11.0.32-tem, 17.0.20-tem, 21.0.12-tem, 25.0.4-tem, 27.ea.32-open ]
     env:
       TEST_JAVA_HOME: "/home/runner/.sdkman/candidates/java/${{ matrix.java }}"
       # Runners are ephemeral, so the Testcontainers Ryuk reaper is unnecessary. Disabling it
@@ -123,7 +123,7 @@ jobs:
           source "$HOME/.sdkman/bin/sdkman-init.sh"
           echo 'n' | sdk install java ${{ matrix.java }}
           which java
-          echo 'y' | sdk install java 11.0.31-tem
+          echo 'y' | sdk install java 11.0.32-tem
       - name: Cache Gradle
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8.0.492-tem, 11.0.31-tem, 17.0.19-tem, 21.0.11-tem, 25.0.3-tem, 27.ea.31-open]
+        java: [8.0.502-tem, 11.0.32-tem, 17.0.20-tem, 21.0.12-tem, 25.0.4-tem, 27.ea.32-open]
     env:
       TEST_JAVA_HOME: "/home/runner/.sdkman/candidates/java/${{ matrix.java }}"
       # Runners are ephemeral, so the Testcontainers Ryuk reaper is unnecessary. Disabling it

--- a/.github/workflows/v2-protocol-tests.yml
+++ b/.github/workflows/v2-protocol-tests.yml
@@ -31,11 +31,11 @@ jobs:
       matrix:
         include:
           - java: 11
-            sdk: 11.0.31-tem
+            sdk: 11.0.32-tem
           - java: 17
-            sdk: 17.0.19-tem
+            sdk: 17.0.20-tem
           - java: 21
-            sdk: 21.0.11-tem
+            sdk: 21.0.12-tem
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
Automated JDK version update detected by SDKMan API.

### Changes
- 8.0.492-tem -> 8.0.502-tem
- 11.0.31-tem -> 11.0.32-tem
- 17.0.19-tem -> 17.0.20-tem
- 21.0.11-tem -> 21.0.12-tem
- 25.0.3-tem -> 25.0.4-tem
- 27.ea.31-open -> 27.ea.32-open
- build JDK: 11.0.31-tem -> 11.0.32-tem

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/938)
<!-- Reviewable:end -->
