### PR TITLE
fix(extensions): harden external type adapters

### DIFF
--- a/btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java
+++ b/btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java
@@ -28,9 +28,13 @@ import java.lang.annotation.Target;
  *
  * <p>When combined with the {@code @ExternalType} annotation processor, a companion adapter class
  * named {@code <InterfaceSimpleName>$Ext} is generated in the same package with static dispatchers
- * for each declared method. Dispatchers lazily resolve the target class and method via {@link
- * java.lang.invoke.MethodHandles#publicLookup()} and cache the resulting {@link
- * java.lang.invoke.MethodHandle}.
+ * for each declared method. Dispatchers lazily resolve public target methods through {@link
+ * java.lang.invoke.MethodHandles#publicLookup()} and cache successful resolutions. Declared erased
+ * parameter and return types must exactly match the target member's erased JVM signature; {@code
+ * Object} does not coerce a differently typed target signature.
+ *
+ * <p>Resolution failures are reported as {@link ExternalTypeResolutionException}. Target-method
+ * failures propagate unchanged.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/btrace-core/src/main/java/io/btrace/core/extensions/ExternalTypeResolutionException.java
+++ b/btrace-core/src/main/java/io/btrace/core/extensions/ExternalTypeResolutionException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008, 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.btrace.core.extensions;
+
+/**
+ * Signals that an {@link ExternalType} adapter could not resolve its configured public target
+ * member.
+ *
+ * <p>The cause is the original {@link ClassNotFoundException}, {@link NoSuchMethodException}, or
+ * {@link IllegalAccessException}. Target-method failures are not translated to this exception.
+ */
+public final class ExternalTypeResolutionException extends IllegalStateException {
+  public ExternalTypeResolutionException(String owner, String member, Throwable cause) {
+    super("Unable to resolve @ExternalType " + owner + "#" + member, cause);
+  }
+}

--- a/btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java
@@ -31,63 +31,223 @@ final class AdapterEmitter {
     w.println("import java.lang.invoke.MethodHandle;");
     w.println("import java.lang.invoke.MethodHandles;");
     w.println("import java.lang.invoke.MethodType;");
+    w.println("import java.lang.ref.ReferenceQueue;");
+    w.println("import java.lang.ref.WeakReference;");
+    w.println("import java.util.HashMap;");
+    w.println("import java.util.Iterator;");
+    w.println("import java.util.Map;");
+    w.println("import io.btrace.core.extensions.ExternalTypeResolutionException;");
     w.println();
     w.println("public final class " + spec.adapterSimpleName() + " {");
     w.println("  private static final String OWNER = \"" + spec.externalFqn + "\";");
     w.println("  private " + spec.adapterSimpleName() + "() {}");
-    for (MethodSpec m : spec.methods) renderMethod(w, m);
+    renderResolvedCall(w);
+    renderLoaderKey(w);
+    for (int i = 0; i < spec.methods.size(); i++) renderMethod(w, spec.methods.get(i), i);
     renderSneak(w);
     w.println("}");
   }
 
-  private void renderMethod(PrintWriter w, MethodSpec m) {
-    String mhCache = "$" + m.name + "$handles";
+  private void renderResolvedCall(PrintWriter w) {
+    w.println();
+    w.println("  private static final class ResolvedCall {");
+    w.println("    final Class<?> owner;");
+    w.println("    final MethodHandle handle;");
+    w.println();
+    w.println("    ResolvedCall(Class<?> owner, MethodHandle handle) {");
+    w.println("      this.owner = owner;");
+    w.println("      this.handle = handle;");
+    w.println("    }");
+    w.println("  }");
+  }
+
+  private void renderLoaderKey(PrintWriter w) {
+    w.println();
+    w.println("  private static final class LoaderKey extends WeakReference<ClassLoader> {");
+    w.println("    private static final int BOOTSTRAP = 1;");
+    w.println("    private static final int SYSTEM = 2;");
+    w.println("    private final int hash;");
+    w.println("    private final int sentinel;");
+    w.println();
+    w.println("    LoaderKey(ClassLoader loader, ReferenceQueue<ClassLoader> queue) {");
+    w.println("      super(loader, queue);");
+    w.println("      hash = System.identityHashCode(loader);");
+    w.println("      sentinel = 0;");
+    w.println("    }");
+    w.println();
+    w.println("    LoaderKey(ClassLoader loader) {");
+    w.println("      super(loader);");
+    w.println("      hash = System.identityHashCode(loader);");
+    w.println("      sentinel = 0;");
+    w.println("    }");
+    w.println();
+    w.println("    LoaderKey(int sentinel) {");
+    w.println("      super(null);");
+    w.println("      hash = sentinel;");
+    w.println("      this.sentinel = sentinel;");
+    w.println("    }");
+    w.println();
+    w.println("    boolean isWeak() {");
+    w.println("      return sentinel == 0;");
+    w.println("    }");
+    w.println();
+    w.println("    @Override");
+    w.println("    public boolean equals(Object other) {");
+    w.println("      if (this == other) return true;");
+    w.println("      if (!(other instanceof LoaderKey)) return false;");
+    w.println("      LoaderKey that = (LoaderKey) other;");
+    w.println("      if (sentinel != 0 || that.sentinel != 0) return sentinel == that.sentinel;");
+    w.println("      ClassLoader loader = get();");
+    w.println("      return loader != null && loader == that.get();");
+    w.println("    }");
+    w.println();
+    w.println("    @Override");
+    w.println("    public int hashCode() {");
+    w.println("      return hash;");
+    w.println("    }");
+    w.println("  }");
+  }
+
+  private void renderMethod(PrintWriter w, MethodSpec m, int ordinal) {
+    String cache = "$" + ordinal + "$calls";
+    String attempts = "__btraceExternalTypeResolutionAttempts$" + ordinal;
     String[] lists = paramAndArgLists(m);
     String paramList = lists[0];
     String argList = lists[1];
-    String loaderExpr =
-        m.isStatic
-            ? "(Thread.currentThread().getContextClassLoader() != null ? Thread.currentThread().getContextClassLoader() : ClassLoader.getSystemClassLoader())"
-            : "self.getClass().getClassLoader()";
 
     w.println();
-    w.println("  private static final ClassValue<MethodHandle> " + mhCache + " =");
-    w.println("      new ClassValue<MethodHandle>() {");
+    w.println("  private static int " + attempts + ";");
+    w.println("  private static final ClassValue<ResolvedCall> " + cache + " =");
+    w.println("      new ClassValue<ResolvedCall>() {");
     w.println("        @Override");
-    w.println("        protected MethodHandle computeValue(Class<?> owner) {");
+    w.println(
+        "        protected ResolvedCall computeValue(Class<?> "
+            + (m.isStatic ? "owner" : "receiver")
+            + ") {");
     w.println("          try {");
+    if (!m.isStatic) {
+      w.println(
+          "            Class<?> owner = Class.forName(OWNER, false, receiver.getClassLoader());");
+    }
+    w.println("            " + attempts + "++;");
     if (m.isStatic) {
       w.println(
-          "            return MethodHandles.publicLookup().findStatic(owner, \""
+          "            return new ResolvedCall(owner, MethodHandles.publicLookup().findStatic(owner, \""
               + m.name
               + "\", "
               + methodTypeLiteral(m)
-              + ");");
+              + ")); ");
     } else {
       w.println(
-          "            return MethodHandles.publicLookup().findVirtual(owner, \""
+          "            return new ResolvedCall(owner, MethodHandles.publicLookup().findVirtual(owner, \""
               + m.name
               + "\", "
               + methodTypeLiteral(m)
-              + ");");
+              + ")); ");
     }
-    w.println("          } catch (NoSuchMethodException | IllegalAccessException e) {");
     w.println(
-        "            throw new IllegalStateException(\"Unable to resolve \" + OWNER + \"#"
-            + m.name
-            + "\", e);");
+        "          } catch ("
+            + (m.isStatic
+                ? "NoSuchMethodException | IllegalAccessException"
+                : "ClassNotFoundException | NoSuchMethodException | IllegalAccessException")
+            + " e) {");
+    w.println(
+        "            throw new ExternalTypeResolutionException(OWNER, \"" + m.name + "\", e);");
     w.println("          }");
     w.println("        }");
     w.println("      };");
+    if (m.isStatic) renderStaticSupport(w, m, ordinal, cache);
     w.println();
     w.println("  public static " + m.returnType + " " + m.name + "(" + paramList + ") {");
     w.println("    try {");
-    w.println("      Class<?> owner = Class.forName(OWNER, false, " + loaderExpr + ");");
-    w.println("      MethodHandle h = " + mhCache + ".get(owner);");
+    if (m.isStatic) {
+      w.println("      ResolvedCall call = $" + ordinal + "$resolveStatic();");
+    } else {
+      w.println("      ResolvedCall call = " + cache + ".get(self.getClass());");
+    }
     w.print("      ");
     if (!"void".equals(m.returnType)) w.print("return (" + m.returnType + ") ");
-    w.println("h.invoke(" + argList + ");");
+    w.println("call.handle.invoke(" + argList + ");");
     w.println("    } catch (Throwable t) { throw sneak(t); }");
+    w.println("  }");
+  }
+
+  private void renderStaticSupport(PrintWriter w, MethodSpec m, int ordinal, String cache) {
+    String prefix = "$" + ordinal + "$";
+    w.println();
+    w.println("  private static final Object " + prefix + "monitor = new Object();");
+    w.println(
+        "  private static final ReferenceQueue<ClassLoader> "
+            + prefix
+            + "loaderQueue = new ReferenceQueue<ClassLoader>();");
+    w.println(
+        "  private static final Map<LoaderKey, WeakReference<Class<?>>> "
+            + prefix
+            + "loaderIndex = new HashMap<LoaderKey, WeakReference<Class<?>>>();");
+    w.println(
+        "  private static final LoaderKey "
+            + prefix
+            + "bootstrapKey = new LoaderKey(LoaderKey.BOOTSTRAP);");
+    w.println(
+        "  private static final LoaderKey "
+            + prefix
+            + "systemKey = new LoaderKey(LoaderKey.SYSTEM);");
+    w.println();
+    w.println("  private static ResolvedCall $" + ordinal + "$resolveStatic() {");
+    w.println("    ClassLoader loader = Thread.currentThread().getContextClassLoader();");
+    w.println("    if (loader == null) loader = ClassLoader.getSystemClassLoader();");
+    w.println("    synchronized (" + prefix + "monitor) {");
+    w.println("      $" + ordinal + "$expungeStatic();");
+    w.println("      LoaderKey lookupKey = $" + ordinal + "$loaderKey(loader, false);");
+    w.println(
+        "      WeakReference<Class<?>> ownerReference = " + prefix + "loaderIndex.get(lookupKey);");
+    w.println("      Class<?> owner = ownerReference != null ? ownerReference.get() : null;");
+    w.println("      if (owner != null) return " + cache + ".get(owner);");
+    w.println("      try {");
+    w.println("        owner = Class.forName(OWNER, false, loader);");
+    w.println("      } catch (ClassNotFoundException e) {");
+    w.println("        throw new ExternalTypeResolutionException(OWNER, \"" + m.name + "\", e);");
+    w.println("      }");
+    w.println("      ResolvedCall call = " + cache + ".get(owner);");
+    w.println(
+        "      "
+            + prefix
+            + "loaderIndex.put($"
+            + ordinal
+            + "$loaderKey(loader, true), new WeakReference<Class<?>>(owner));");
+    w.println("      return call;");
+    w.println("    }");
+    w.println("  }");
+    w.println();
+    w.println(
+        "  private static LoaderKey $"
+            + ordinal
+            + "$loaderKey(ClassLoader loader, boolean stored) {");
+    w.println("    if (loader == null) return " + prefix + "bootstrapKey;");
+    w.println(
+        "    if (loader == ClassLoader.getSystemClassLoader()) return " + prefix + "systemKey;");
+    w.println(
+        "    return stored ? new LoaderKey(loader, "
+            + prefix
+            + "loaderQueue) : new LoaderKey(loader);");
+    w.println("  }");
+    w.println();
+    w.println("  private static void $" + ordinal + "$expungeStatic() {");
+    w.println("    LoaderKey stale;");
+    w.println(
+        "    while ((stale = (LoaderKey) "
+            + prefix
+            + "loaderQueue.poll()) != null) "
+            + prefix
+            + "loaderIndex.remove(stale);");
+    w.println(
+        "    for (Iterator<Map.Entry<LoaderKey, WeakReference<Class<?>>>> it = "
+            + prefix
+            + "loaderIndex.entrySet().iterator(); it.hasNext();) {");
+    w.println("      Map.Entry<LoaderKey, WeakReference<Class<?>>> entry = it.next();");
+    w.println(
+        "      if ((entry.getKey().isWeak() && entry.getKey().get() == null) || entry.getValue().get() == null) it.remove();");
+    w.println("    }");
     w.println("  }");
   }
 

--- a/btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java
+++ b/btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java
@@ -18,8 +18,14 @@ package io.btrace.extension.processor;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.btrace.core.extensions.ExternalTypeResolutionException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
 
 class ExternalTypeProcessorTest {
@@ -85,9 +91,9 @@ class ExternalTypeProcessorTest {
     CompileTestHarness.Result r = CompileTestHarness.compile(sources);
     assertTrue(r.success, r.errors());
     String adapter = r.generatedSources.get("com.example.JobStart$Ext");
-    assertTrue(adapter.contains("ClassValue<MethodHandle>"), adapter);
+    assertTrue(adapter.contains("ClassValue<ResolvedCall>"), adapter);
     assertTrue(adapter.contains("findVirtual"), adapter);
-    assertTrue(adapter.contains("self.getClass().getClassLoader()"), adapter);
+    assertTrue(adapter.contains("receiver.getClassLoader()"), adapter);
     assertTrue(adapter.contains("(int)"), adapter);
   }
 
@@ -347,5 +353,284 @@ class ExternalTypeProcessorTest {
     // Raw type must appear in the MethodType literal (no angle brackets).
     assertTrue(adapter.contains("MethodType.methodType(java.util.List.class"), adapter);
     assertFalse(adapter.contains("java.util.List<java.lang.String>.class"), adapter);
+  }
+
+  @Test
+  void virtualResolutionRetriesAfterSameLoaderMakesTargetVisibleAndCachesSuccess()
+      throws Exception {
+    Map<String, String> sources = externalTypeSources("int value();", "return 42;");
+    CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(r.success, r.errors());
+
+    MutableTargetLoader loader = new MutableTargetLoader(r, false);
+    Class<?> adapter = r.loader.loadClass("com.example.adapter.CounterApi$Ext");
+    java.lang.reflect.Method value = adapter.getMethod("value", Object.class);
+    Object context = loader.loadClass("com.example.target.Context").getConstructor().newInstance();
+    assertSame(loader, context.getClass().getClassLoader());
+    ExternalTypeResolutionException failure =
+        assertResolutionFailure(value, context, "com.example.target.Counter", "value");
+    assertInstanceOf(ClassNotFoundException.class, failure.getCause());
+    assertEquals(1, loader.targetLoads, "same loader must attempt the missing target class");
+
+    loader.makeVisible();
+    Object counter = loader.loadClass("com.example.target.Counter").getConstructor().newInstance();
+    assertEquals(42, value.invoke(null, counter));
+    assertEquals(42, value.invoke(null, counter));
+    assertEquals(2, loader.targetLoads, "same loader must retry after making the target visible");
+    assertEquals(1, resolutionAttempts(adapter, 0), "successful member resolution must be cached");
+  }
+
+  @Test
+  void staticResolutionUsesLoaderIdentityAndCachesEachTccl() throws Exception {
+    Map<String, String> sources =
+        externalTypeSources("@ExternalType.Static int value();", "return 7;");
+    CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(r.success, r.errors());
+
+    MutableTargetLoader first = new MutableTargetLoader(r, false);
+    MutableTargetLoader second = new MutableTargetLoader(r, true);
+    Class<?> adapter = r.loader.loadClass("com.example.adapter.CounterApi$Ext");
+    java.lang.reflect.Method value = adapter.getMethod("value");
+    ClassLoader saved = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(first);
+      assertResolutionFailure(value, null, "com.example.target.Counter", "value");
+      first.makeVisible();
+      assertEquals(7, value.invoke(null));
+      assertEquals(7, value.invoke(null));
+      Thread.currentThread().setContextClassLoader(second);
+      assertEquals(7, value.invoke(null));
+      assertEquals(7, value.invoke(null));
+    } finally {
+      Thread.currentThread().setContextClassLoader(saved);
+    }
+    assertEquals(2, first.targetLoads, "failed static resolution must not be cached");
+    assertEquals(1, second.targetLoads);
+    assertEquals(2, resolutionAttempts(adapter, 0));
+  }
+
+  @Test
+  void staticFirstUseResolvesOnceUnderTheMemberMonitor() throws Exception {
+    Map<String, String> sources =
+        externalTypeSources("@ExternalType.Static int value();", "return 7;");
+    CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(r.success, r.errors());
+
+    MutableTargetLoader loader = new MutableTargetLoader(r, true);
+    Class<?> adapter = r.loader.loadClass("com.example.adapter.CounterApi$Ext");
+    java.lang.reflect.Method value = adapter.getMethod("value");
+    CountDownLatch ready = new CountDownLatch(2);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<Integer> first = executor.submit(() -> invokeStatic(value, loader, ready, start));
+      Future<Integer> second = executor.submit(() -> invokeStatic(value, loader, ready, start));
+      ready.await();
+      start.countDown();
+      assertEquals(7, first.get());
+      assertEquals(7, second.get());
+    } finally {
+      executor.shutdownNow();
+    }
+    assertEquals(1, loader.targetLoads, "static first use must load once");
+    assertEquals(1, resolutionAttempts(adapter, 0), "static first use must resolve once");
+  }
+
+  @Test
+  void missingMembersRetryAndTargetFailuresStayTransparent() throws Exception {
+    Map<String, String> missing = externalTypeSources("int value();", "return 1;", "different");
+    CompileTestHarness.RunnableResult missingResult = CompileTestHarness.compileAndLoad(missing);
+    assertTrue(missingResult.success, missingResult.errors());
+    Class<?> missingAdapter = missingResult.loader.loadClass("com.example.adapter.CounterApi$Ext");
+    java.lang.reflect.Method missingValue = missingAdapter.getMethod("value", Object.class);
+    MutableTargetLoader missingLoader = new MutableTargetLoader(missingResult, true);
+    Object missingTarget =
+        missingLoader.loadClass("com.example.target.Counter").getConstructor().newInstance();
+    ExternalTypeResolutionException first =
+        assertResolutionFailure(missingValue, missingTarget, "com.example.target.Counter", "value");
+    ExternalTypeResolutionException second =
+        assertResolutionFailure(missingValue, missingTarget, "com.example.target.Counter", "value");
+    assertInstanceOf(NoSuchMethodException.class, first.getCause());
+    assertInstanceOf(NoSuchMethodException.class, second.getCause());
+    assertEquals(2, resolutionAttempts(missingAdapter, 0));
+
+    Map<String, String> throwing =
+        externalTypeSources(
+            "int value();",
+            "throw new io.btrace.core.extensions.ExternalTypeResolutionException(\"target\", \"value\", new IllegalAccessException());");
+    CompileTestHarness.RunnableResult throwingResult = CompileTestHarness.compileAndLoad(throwing);
+    assertTrue(throwingResult.success, throwingResult.errors());
+    MutableTargetLoader throwingLoader = new MutableTargetLoader(throwingResult, true);
+    Object throwingTarget =
+        throwingLoader.loadClass("com.example.target.Counter").getConstructor().newInstance();
+    java.lang.reflect.Method throwingValue =
+        throwingResult
+            .loader
+            .loadClass("com.example.adapter.CounterApi$Ext")
+            .getMethod("value", Object.class);
+    InvocationTargetException thrown =
+        assertThrows(
+            InvocationTargetException.class, () -> throwingValue.invoke(null, throwingTarget));
+    assertInstanceOf(ExternalTypeResolutionException.class, thrown.getCause());
+    assertEquals("Unable to resolve @ExternalType target#value", thrown.getCause().getMessage());
+  }
+
+  @Test
+  void exactSignatureAndPublicLookupFailuresPreserveTheirCauses() throws Exception {
+    Map<String, String> mismatched = externalTypeSources("int value();", "return 42L;");
+    CompileTestHarness.RunnableResult mismatchResult =
+        CompileTestHarness.compileAndLoad(mismatched);
+    assertTrue(mismatchResult.success, mismatchResult.errors());
+    MutableTargetLoader mismatchLoader = new MutableTargetLoader(mismatchResult, true);
+    Object mismatchTarget =
+        mismatchLoader.loadClass("com.example.target.Counter").getConstructor().newInstance();
+    java.lang.reflect.Method mismatchValue =
+        mismatchResult
+            .loader
+            .loadClass("com.example.adapter.CounterApi$Ext")
+            .getMethod("value", Object.class);
+    ExternalTypeResolutionException mismatch =
+        assertResolutionFailure(
+            mismatchValue, mismatchTarget, "com.example.target.Counter", "value");
+    assertInstanceOf(NoSuchMethodException.class, mismatch.getCause());
+
+    Map<String, String> inaccessible = new LinkedHashMap<>();
+    inaccessible.put(
+        "com.example.target.Hidden",
+        "package com.example.target; class Hidden { public int value() { return 1; } }");
+    inaccessible.put(
+        "com.example.target.Factory",
+        "package com.example.target; public class Factory { "
+            + "public static Object create() { return new Hidden(); } }");
+    inaccessible.put(
+        "com.example.adapter.HiddenApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Hidden\") public interface HiddenApi { int value(); }");
+    CompileTestHarness.RunnableResult inaccessibleResult =
+        CompileTestHarness.compileAndLoad(inaccessible);
+    assertTrue(inaccessibleResult.success, inaccessibleResult.errors());
+    Class<?> factory = inaccessibleResult.loader.loadClass("com.example.target.Factory");
+    Object hidden = factory.getMethod("create").invoke(null);
+    java.lang.reflect.Method hiddenValue =
+        inaccessibleResult
+            .loader
+            .loadClass("com.example.adapter.HiddenApi$Ext")
+            .getMethod("value", Object.class);
+    ExternalTypeResolutionException access =
+        assertResolutionFailure(hiddenValue, hidden, "com.example.target.Hidden", "value");
+    assertInstanceOf(IllegalAccessException.class, access.getCause());
+  }
+
+  private static Map<String, String> externalTypeSources(String apiMethod, String implementation) {
+    return externalTypeSources(apiMethod, implementation, "value");
+  }
+
+  private static Map<String, String> externalTypeSources(
+      String apiMethod, String implementation, String targetMethod) {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.target.Counter",
+        "package com.example.target; public class Counter { public Counter() {} public "
+            + (apiMethod.contains("@ExternalType.Static") ? "static " : "")
+            + (implementation.contains("L;") ? "long " : "int ")
+            + targetMethod
+            + "() { "
+            + implementation
+            + " } }");
+    sources.put(
+        "com.example.target.Context",
+        "package com.example.target; public class Context { public Context() {} }");
+    sources.put(
+        "com.example.adapter.CounterApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Counter\") public interface CounterApi { "
+            + apiMethod
+            + " }");
+    return sources;
+  }
+
+  private static ExternalTypeResolutionException assertResolutionFailure(
+      java.lang.reflect.Method method, Object target, String owner, String member) {
+    InvocationTargetException failure =
+        assertThrows(
+            InvocationTargetException.class,
+            () ->
+                method.invoke(
+                    null, method.getParameterCount() == 0 ? new Object[0] : new Object[] {target}));
+    assertInstanceOf(ExternalTypeResolutionException.class, failure.getCause());
+    ExternalTypeResolutionException resolution =
+        (ExternalTypeResolutionException) failure.getCause();
+    assertEquals(
+        "Unable to resolve @ExternalType " + owner + "#" + member, resolution.getMessage());
+    return resolution;
+  }
+
+  private static int invokeStatic(
+      java.lang.reflect.Method method,
+      ClassLoader loader,
+      CountDownLatch ready,
+      CountDownLatch start)
+      throws Exception {
+    ClassLoader saved = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(loader);
+      ready.countDown();
+      start.await();
+      return (int) method.invoke(null);
+    } finally {
+      Thread.currentThread().setContextClassLoader(saved);
+    }
+  }
+
+  private static int resolutionAttempts(Class<?> adapter, int ordinal) throws Exception {
+    java.lang.reflect.Field attempts =
+        adapter.getDeclaredField("__btraceExternalTypeResolutionAttempts$" + ordinal);
+    attempts.setAccessible(true);
+    return attempts.getInt(null);
+  }
+
+  private static final class MutableTargetLoader extends ClassLoader {
+    private final Map<String, byte[]> classBytes;
+    private boolean visible;
+    int targetLoads;
+
+    MutableTargetLoader(CompileTestHarness.RunnableResult result, boolean visible) {
+      super(result.loader);
+      classBytes = result.classBytes;
+      this.visible = visible;
+    }
+
+    void makeVisible() {
+      visible = true;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      throw new AssertionError("adapter cache must not call ClassLoader.equals");
+    }
+
+    @Override
+    public int hashCode() {
+      throw new AssertionError("adapter cache must not call ClassLoader.hashCode");
+    }
+
+    @Override
+    protected synchronized Class<?> loadClass(String name, boolean resolve)
+        throws ClassNotFoundException {
+      boolean counter = "com.example.target.Counter".equals(name);
+      boolean context = "com.example.target.Context".equals(name);
+      if (!counter && !context) return super.loadClass(name, resolve);
+      if (counter) {
+        targetLoads++;
+        if (!visible) throw new ClassNotFoundException(name);
+      }
+      Class<?> loaded = findLoadedClass(name);
+      if (loaded == null) {
+        byte[] bytes = classBytes.get(name);
+        loaded = defineClass(name, bytes, 0, bytes.length);
+      }
+      if (resolve) resolveClass(loaded);
+      return loaded;
+    }
   }
 }

--- a/btrace-core/src/test/java/io/btrace/extension/util/MethodHandleCacheTest.java
+++ b/btrace-core/src/test/java/io/btrace/extension/util/MethodHandleCacheTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008, 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.btrace.extension.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MethodHandleCacheTest {
+  @Test
+  void cachesSuccessfulPublicLookupsAndRetriesFailuresWithoutLoaderSafetyClaim() throws Exception {
+    MethodHandleCache cache = new MethodHandleCache();
+
+    MethodHandle virtual = cache.findVirtual(Fixture.class, "value", int.class);
+    assertSame(virtual, cache.findVirtual(Fixture.class, "value", int.class));
+    MethodHandle statik = cache.findStatic(Fixture.class, "twice", int.class, int.class);
+    assertSame(statik, cache.findStatic(Fixture.class, "twice", int.class, int.class));
+    assertEquals(2, entries(cache));
+
+    assertThrows(
+        MethodHandleCache.LookupRuntimeException.class,
+        () -> cache.findVirtual(Fixture.class, "missing", int.class));
+    assertEquals(2, entries(cache), "failed lookup must not be stored");
+    assertThrows(
+        MethodHandleCache.LookupRuntimeException.class,
+        () -> cache.findVirtual(Fixture.class, "missing", int.class));
+    assertEquals(2, entries(cache), "a repeated failed lookup must remain retryable");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static int entries(MethodHandleCache cache) throws Exception {
+    Field field = MethodHandleCache.class.getDeclaredField("cache");
+    field.setAccessible(true);
+    return ((Map<Object, MethodHandle>) field.get(cache)).size();
+  }
+
+  public static final class Fixture {
+    public int value() {
+      return 1;
+    }
+
+    public static int twice(int value) {
+      return value * 2;
+    }
+  }
+}

--- a/btrace-dist/build.gradle
+++ b/btrace-dist/build.gradle
@@ -398,6 +398,14 @@ task btraceJar(type: Jar) {
         exclude 'META-INF/MANIFEST.MF'
     }
 
+    // External provided-style extensions use btrace.jar directly as both their compilation and
+    // processor path. The processor service and its self-contained implementation therefore need
+    // regular root entries; the rest of the extension implementation remains masked.
+    from(zipTree(allClassesShadow.archiveFile)) {
+        include 'io/btrace/extension/processor/**/*.class'
+        include 'META-INF/services/javax.annotation.processing.Processor'
+    }
+
     // 3. Include masked agent classes (as .classdata)
     into('META-INF/btrace/agent') {
         from("${maskedJarTmpDir}/agent") {

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalApi.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalApi.java
@@ -1,0 +1,9 @@
+package example;
+
+import io.btrace.core.extensions.ExternalType;
+
+@ExternalType("example.target.ExternalTarget")
+public interface ExternalApi {
+  @ExternalType.Static
+  String version();
+}

--- a/docs/BTraceExtensionDevelopmentGuide.md
+++ b/docs/BTraceExtensionDevelopmentGuide.md
@@ -185,7 +185,7 @@ public class MyProbe {
 
 ## App-Type Adapters with `@ExternalType`
 
-When an extension's impl needs to interact with application-specific classes (Spark event objects, Hadoop types, custom framework classes), use the `@ExternalType` annotation to generate reflective adapters at build time. The extension Gradle plugin auto-registers the annotation processor.
+When an extension's impl needs to interact with application-specific classes (Spark event objects, Hadoop types, custom framework classes), use the `@ExternalType` annotation to generate reflective adapters at build time. The extension Gradle plugin auto-registers the annotation processor. This is the normative reference for the supported adapter boundary.
 
 ### How It Works
 
@@ -203,37 +203,57 @@ public interface JobStartEvent {
 }
 ```
 
-The processor generates `JobStartEvent$Ext` in the same package with a typed `public static` dispatcher per method. Each dispatcher lazily resolves the target class via `self.getClass().getClassLoader()` (virtual methods) or TCCL (static methods), then stores the `MethodHandle` in a classloader-safe `ClassValue` cache. This keeps extension calls isolated when multiple application classloaders define the same target class. If the external class is not yet loaded, resolution throws and the next call retries — no `ExceptionInInitializerError` at extension load time.
+The processor generates `JobStartEvent$Ext` in the same package with a typed `public static` dispatcher per method. A virtual dispatcher takes `Object self` first and resolves the configured owner through `self`'s defining loader. A static dispatcher resolves through the current thread context class loader (TCCL), falling back to the system loader only when the TCCL is `null`. Successful resolutions are cached per application class; failed class or member lookups are not cached, so a later call can retry.
 
 Use the generated class directly in the impl:
 
 ```java
-// No manual MethodHandle or try/catch needed
-int  id = JobStartEvent$Ext.jobId(event);
-long ts = JobStartEvent$Ext.time(event);
+try {
+    int id = JobStartEvent$Ext.jobId(event);
+    long ts = JobStartEvent$Ext.time(event);
+    // emit metrics / logs...
+} catch (ExternalTypeResolutionException unavailable) {
+    // choose the extension's logging/degradation policy for an unavailable optional API
+}
 ```
 
 ### Rules
 
 - **Target:** interfaces only (`ElementType.TYPE`). The processor emits a compile error for classes.
 - **Annotation value:** non-empty fully-qualified class name. Empty string is a compile error.
-- **Method types:** use `Object` for types that only exist at runtime and can't be on the compile classpath.
-- **Static methods:** add `@ExternalType.Static` on the interface method — the dispatcher calls `findStatic` with TCCL-based class loading.
+- **Method types:** declared erased parameter and return types must exactly match the target member's JVM signature. Use `Object` only when the target member itself uses `Object`; it is not a coercion escape hatch for target-only types.
+- **Access:** dispatch uses `MethodHandles.publicLookup()`. Only public members of public, accessible types are supported; do not add module-opening flags implicitly.
+- **Static methods:** add `@ExternalType.Static` on the interface method — the dispatcher calls `findStatic` with TCCL-based class loading and the documented null-TCCL system-loader fallback.
 - **Default methods and static interface methods:** skipped (they already have bodies).
+- **Failures:** class lookup, missing member, and inaccessible-member failures throw `ExternalTypeResolutionException` with the original cause. Exceptions thrown by the target method propagate unchanged.
 
-### Current Scope Limits (Planned for Future Versions)
+### Supported boundary and manual path
 
-The following are not yet handled by the processor. Use `ClassLoadingUtil` / `MethodHandleCache` directly as a workaround; these are all planned for a future `@ExternalType` version:
+Use generated adapters only for the supported row below. The manual path is the normal solution for version-variant or target-only APIs; it is not an error condition.
 
-| Feature | Status | Manual workaround |
+| Capability | Phase 1 support | Author action |
 |---------|--------|-------------------|
-| Field read/write | Planned | `MethodHandleCache.findGetter` / `findSetter` |
-| Constructors | Planned | `MethodHandleCache.findConstructor` |
-| `instanceof` / `checkcast` on external types | Planned | `ClassLoadingUtil.load(...)` + `Class.isInstance` |
-| Chained `@ExternalType` return types | Planned | Manual adapter per level |
-| Non-`public` methods | Planned | `MethodHandles.privateLookupIn` (Java 9+) |
+| Public, uniquely named static or virtual methods with exact erased signatures | Supported | Use `@ExternalType`; use `Object` only where the target member itself uses `Object`. |
+| A target method with target-library parameter or return types | Unsupported | Use `ClassLoadingUtil` and `MethodHandleCache` directly. |
+| Overloads | Unsupported; processor error | Use `MethodHandleCache` with the exact return and parameter `Class` values. |
+| Fields, constructors, `instanceof`, and casts | Unsupported | Use `ClassLoadingUtil` plus the appropriate direct `MethodHandles.publicLookup()` or `Class` operation. `MethodHandleCache` caches virtual and static method lookups only. |
+| Non-public or non-exported named-module members | Unsupported | Use a public supported API or explicitly configure the target JVM outside BTrace. |
 
-The hand-written pattern in [`docs/architecture/provided-style-extensions.md`](architecture/provided-style-extensions.md) works alongside `@ExternalType`-generated adapters in the same impl class until these gaps are closed.
+For a static call under an author-controlled application loader, use `ClassLoadingUtil.withTCCL(...)` to make that selection explicit and restore the old context afterward:
+
+```java
+String version = ClassLoadingUtil.withTCCL(appLoader, () -> VersionApi$Ext.version());
+```
+
+For version-variant APIs, resolve the exact public signature manually:
+
+```java
+Class<?> owner = ClassLoadingUtil.load("com.example.OptionalApi", appLoader);
+MethodHandle call = handles.findStatic(owner, "version", String.class, int.class);
+String version = (String) call.invoke(3);
+```
+
+`MethodHandleCache` caches successful public static/virtual method lookups only; a caught lookup failure remains retryable. Its current keys retain owner classes and can therefore retain application loaders strongly. It has no getter, setter, or constructor helper. See the [provided-style manual linking guide](architecture/provided-style-extensions.md) for the complete pattern.
 
 ## Metadata and Permissions (Auto-Generated)
 

--- a/docs/BTraceTutorial.md
+++ b/docs/BTraceTutorial.md
@@ -973,7 +973,7 @@ Configuration (optional):
 
 ##### Building App Integration Extensions with @ExternalType
 
-When an extension needs to interact with application-specific types (Spark events, Hadoop objects, custom framework classes), use the `@ExternalType` annotation to eliminate manual reflective boilerplate. The BTrace extension plugin auto-registers the annotation processor.
+When an extension needs to interact with application-specific types (Spark events, Hadoop objects, custom framework classes), use the `@ExternalType` annotation for supported methods without manual lookup boilerplate. The BTrace extension plugin auto-registers the annotation processor.
 
 Declare an interface in `src/main/java` annotated with `@ExternalType("fully.qualified.AppType")`:
 
@@ -986,25 +986,25 @@ public interface JobStartEvent {
 }
 ```
 
-The processor generates `JobStartEvent$Ext` with lazy, cached `MethodHandle` dispatchers. Use them directly in the impl — no `try/catch` or cache setup required:
+The processor generates `JobStartEvent$Ext` with lazy, cached `MethodHandle` dispatchers. Call them from an extension-level error boundary appropriate for an optional target API:
 
 ```java
 // src/main/java/org/example/spark/impl/SparkApiImpl.java
 public final class SparkApiImpl extends Extension implements SparkApi {
     @Override
     public void onJobStart(Object event) {
-        int  id = JobStartEvent$Ext.jobId(event);
-        long ts = JobStartEvent$Ext.time(event);
-        // emit metrics / logs...
+        try {
+            int id = JobStartEvent$Ext.jobId(event);
+            long ts = JobStartEvent$Ext.time(event);
+            // emit metrics / logs...
+        } catch (ExternalTypeResolutionException unavailable) {
+            // log or degrade this optional integration
+        }
     }
 }
 ```
 
-Resolution happens lazily on the first call via the event object's own class loader; the handle is cached for subsequent calls. If the external class isn't loaded yet, the resolver retries next call — no `ExceptionInInitializerError` at extension startup.
-
-Field access, constructors, non-public methods, and chained external types are **not yet handled** by the processor — they are planned for a future `@ExternalType` version. Use `ClassLoadingUtil` / `MethodHandleCache` directly in the meantime (see [Provided-Style Extensions](architecture/provided-style-extensions.md) for the full scope-limits table and workarounds).
-
-For the full `@ExternalType` reference, see [BTrace Extension Development Guide](BTraceExtensionDevelopmentGuide.md).
+Resolution happens lazily; successful calls cache and failed resolution retries on a later call. For exact support limits, the static TCCL rule, and the manual path for target-only types, overloads, fields, constructors, and casts, see the normative [BTrace Extension Development Guide](BTraceExtensionDevelopmentGuide.md#app-type-adapters-with-externaltype).
 
 ##### Zero-Config Probe Auto-Selection (ExtensionConfigurator)
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -821,7 +821,7 @@ btraceFatAgent {
 
 #### Writing Extensions That Integrate With App Types (@ExternalType)
 
-When your extension needs to interact with application-specific classes (Spark events, Hadoop objects, etc.), use `@ExternalType` to generate lazy reflective dispatchers at build time — no manual `MethodHandle` boilerplate:
+When your extension needs to interact with application-specific classes (Spark events, Hadoop objects, etc.), use `@ExternalType` to generate lazy reflective dispatchers at build time:
 
 ```java
 // src/main/java/org/example/ext/api/JobEvent.java
@@ -832,7 +832,7 @@ public interface JobEvent {
 }
 ```
 
-The plugin auto-registers the annotation processor, which generates `JobEvent$Ext` with cached, lazy-resolving static methods. See [Extension Development Guide](BTraceExtensionDevelopmentGuide.md) for details.
+The plugin auto-registers the annotation processor, which generates `JobEvent$Ext` with cached, lazy-resolving static methods. See the normative [Extension Development Guide](BTraceExtensionDevelopmentGuide.md#app-type-adapters-with-externaltype) for the exact supported boundary and required error policy.
 
 #### Zero-Config Probe Auto-Selection
 

--- a/docs/architecture/provided-style-extensions.md
+++ b/docs/architecture/provided-style-extensions.md
@@ -20,7 +20,7 @@ This guide shows how to migrate profile-based integrations (e.g., Spark/Hadoop) 
   - Optional child loader: `newChildURLClassLoader(List<Path>, ClassLoader)`, `safeClose(ClassLoader)`
 
 - `io.btrace.extension.util.MethodHandleCache`
-  - Caches public `MethodHandle`s for reflective adapters.
+  - Caches successful public static and virtual method lookups only. Its strong owner-class keys can retain application loaders; it has no getter, setter, or constructor helper.
 
 ## API Sketch (Spark example)
 
@@ -66,62 +66,22 @@ public final class SparkApiImpl implements SparkApi {
 }
 ```
 
-## External Type Adapters (Recommended)
+## External Type Adapters
 
-Writing reflective adapters by hand with `ClassLoadingUtil` + `MethodHandleCache` works but has three ergonomic costs: string method names aren't refactor-safe, eager `static final MethodHandle` fields fail extension init if the target class isn't yet visible, and every reflective call expands into 5+ lines of try/catch and cache plumbing.
+`@ExternalType` is useful for public, uniquely named methods with exact erased signatures. The normative support table, failure contract, and virtual-defining-loader/static-TCCL distinction are in the [Extension Development Guide](../BTraceExtensionDevelopmentGuide.md#app-type-adapters-with-externaltype). Keep the manual pattern in this guide for target-only types, overloads, fields, constructors, and type predicates.
 
-The `@ExternalType` annotation + build-time annotation processor removes all three.
-
-### How it works
-
-Declare an interface in your extension's exported API set marked with `@ExternalType("fully.qualified.AppType")`. In practice this means an API-facing interface under `src/main/java`. The BTrace extension Gradle plugin auto-registers the annotation processor, which generates a companion `<InterfaceSimpleName>$Ext` class in the same package with typed `public static` dispatchers for each method.
+For a static target call where the application loader is known, scope the TCCL explicitly:
 
 ```java
-package com.example.spark.api;
-
-import io.btrace.core.extensions.ExternalType;
-
-@ExternalType("org.apache.spark.scheduler.SparkListenerJobStart")
-public interface JobStart {
-  int jobId();
-  long time();
-}
+String version = ClassLoadingUtil.withTCCL(appLoader, () -> VersionApi$Ext.version());
 ```
 
-The generated `JobStart$Ext` can then be called directly from the impl:
+For fields and constructors there is no `MethodHandleCache` convenience method. Use a direct public lookup after resolving the target class:
 
 ```java
-int id = JobStart$Ext.jobId(event);
-long ts = JobStart$Ext.time(event);
+Class<?> type = ClassLoadingUtil.load("com.example.AppType", appLoader);
+MethodHandle constructor = MethodHandles.publicLookup().findConstructor(type, MethodType.methodType(void.class));
 ```
-
-### What the generated code does
-
-Each dispatcher resolves the target class lazily via `self.getClass().getClassLoader()` (virtual methods) or `Thread.currentThread().getContextClassLoader()` (static methods, see below), then calls `MethodHandles.publicLookup().findVirtual` / `findStatic`. Handles are cached in a per-method `ClassValue`, keyed by the resolved application class, so one extension can safely serve applications with isolated classloaders. Subsequent calls reuse the handle without retaining unloaded application classloaders.
-
-If the external class isn't yet loaded when the dispatcher is first called, resolution throws; since the `ClassValue` does not record a value, the next call retries. No eager init, no `ExceptionInInitializerError` at extension load.
-
-### Rules
-
-- **Target:** `ElementType.TYPE`, interface only. The processor rejects classes with a compile error.
-- **Annotation value:** non-empty fully-qualified class name. Empty string is a compile error.
-- **Method return and parameter types:** anything resolvable at build time is fine. Types you can't put on the extension's compile classpath (app-private types, classes that only exist at runtime) must be typed as `Object`.
-- **Static methods:** annotate with `@ExternalType.Static` on the interface method — the generated dispatcher calls `findStatic` and uses TCCL for class loading.
-- **Default methods and static interface methods:** skipped (they already have bodies).
-
-### Scope limits (v1) — Planned for Future Versions
-
-The following are not yet handled by the processor. Use `ClassLoadingUtil` / `MethodHandleCache` directly as a workaround; all items in the table below are planned for a future `@ExternalType` version:
-
-| Feature | Status | Manual workaround |
-|---------|--------|-------------------|
-| Field access (read/write) | Planned | `MethodHandleCache.findGetter` / `findSetter` |
-| Constructors (`new ExternalType(...)`) | Planned | `MethodHandleCache.findConstructor` |
-| `instanceof` / `checkcast` on external types | Planned | `ClassLoadingUtil.load(...)` + `Class.isInstance` |
-| Chained `@ExternalType` references | Planned | Manual adapter per level |
-| Non-`public` methods | Planned | `MethodHandles.privateLookupIn` (Java 9+) |
-
-The hand-written pattern in the "Impl Sketch" section above works alongside `@ExternalType`-based adapters in the same impl class until these gaps are closed.
 
 ## Role Detection & Config
 

--- a/internal/plans/2026-08-06-issue-931-phase-1-implementation-plan.md
+++ b/internal/plans/2026-08-06-issue-931-phase-1-implementation-plan.md
@@ -1,0 +1,136 @@
+# Issue #931 — Phase 1 implementation plan: dependable `@ExternalType` baseline
+
+**Design input:** `internal/specs/2026-08-06-issue-931-external-type-roadmap.md`
+**Scope:** Phase 1 only. Preserve the annotation source shape and generated adapter method shapes. Do not start target-type signatures, overload selection, fields, constructors, casts, or JPMS/private access.
+
+## Fixed implementation decisions
+
+- Keep resolution and cache code self-contained in generated adapters; do not add a shared adapter runtime helper. The only new public runtime API is `io.btrace.core.extensions.ExternalTypeResolutionException`.
+- Keep `MethodHandleCache` structurally unchanged. Its existing strong `Class<?>`/handle cache is a manual-utility lifecycle limitation, not a generated-adapter cache.
+- Preserve virtual defining-loader lookup, static TCCL lookup, and null-TCCL system-loader fallback. Preserve target-thrown failures. Translate only class/member resolution failures.
+- Do not change extension Gradle DSL/plugin IDs. Touch `btrace-gradle-plugin` only if the external artifact proof shows its existing `io.btrace:btrace` processor coordinate is insufficient.
+
+## Ordered, gated work
+
+- [ ] **1. Establish the baseline and keep Phase 1 bounded.**
+
+  Preserve the untracked roadmap and unrelated changes. Read the roadmap, `docs/architecture/MaskedJarArchitecture.md`, the current processor/emitter, staging, and distribution rules before edits. Explicitly exclude target-type annotations, overload selectors, field/constructor/cast operations, `privateLookupIn`, module flags, extension loading/classpath injection, and Gradle DSL work.
+
+  **Stop:** If source compatibility of the current annotated interface or generated public static method shape cannot be retained, return to design review.
+
+- [ ] **2. Add the exact public resolution-failure contract in `btrace-core`.**
+
+  Add `btrace-core/src/main/java/io/btrace/core/extensions/ExternalTypeResolutionException.java` as a final public `IllegalStateException`. Its narrow constructor accepts owner FQN, member, and original cause; its message is exactly `Unable to resolve @ExternalType <owner>#<member>`, retaining the original `ClassNotFoundException`, `NoSuchMethodException`, or `IllegalAccessException`.
+
+  Update `btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java` Javadoc for the exact-erased/public-lookup boundary and link this exception. Do not expose a generic reflection API or a checked adapter signature.
+
+  **Gate:** Java-8 source compatibility; the exception is the only new public adapter runtime type.
+
+- [ ] **3. Replace generated resolution/caching in `btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java`.**
+
+  Keep `ExternalTypeProcessor.java`, `AdapterSpec.java`, and `MethodSpec.java` validation, generated class names, overloaded-method rejection, and default/static-interface-method skipping. Change only emission/imports and small emitter-only support. For each adapted member, emit:
+
+  - **Virtual:** a `ClassValue<ResolvedCall>` keyed by `self.getClass()`, whose computation loads the configured owner through that receiver class’s defining loader, resolves the exact erased `MethodType` through `MethodHandles.publicLookup().findVirtual`, and stores the resolved owner/handle pair. Sequential calls for one receiver class reuse the call; isolated receiver classes have independent values; the VM can release values with the key class. Do not promise virtual single-flight.
+  - **Static:** a per-member monitor, `ReferenceQueue<ClassLoader>`, a `Map<LoaderKey, WeakReference<Class<?>>>`, fixed bootstrap/system sentinel keys, and a `ClassValue<ResolvedCall>` keyed by the resolved target class. A normal `LoaderKey` holds a weak loader reference, compares only `==`, and hashes with `System.identityHashCode`; it must never invoke a loader’s `equals` or `hashCode`. Under the monitor, expunge stale weak keys/values; select TCCL or system loader if null; check the weak loader index; on miss load the owner, get the `ClassValue` call, then—and only then—insert the weak loader-to-class index. The index never holds `ResolvedCall` or a strong loader. This serializes expunge, lookup, resolution, `ClassValue.get`, and insertion for static first use.
+  - **Failure/invocation boundary:** only computations loading the class/finding the handle catch `ClassNotFoundException`, `NoSuchMethodException`, and `IllegalAccessException` and wrap the Step-2 exception. Keep `MethodHandle.invoke` outside that catch and retain the existing sneaky-throw bridge only for transparent invocation propagation. A target-thrown `ExternalTypeResolutionException` must pass through unchanged.
+  - **Test seam:** emit a package-private static integer field per member, incremented immediately before its member lookup, solely to prove missing-member retry. Give it a deterministic reserved prefix plus the emitted member ordinal (for example, `__btraceExternalTypeResolutionAttempts$0`), so fields are unique even when an interface method name contains the prefix; fields and generated dispatch methods may share no conflicting declaration namespace. The processor test reads that known field with `getDeclaredField(...)`/`setAccessible(true)`, never as public adapter API. It is neither a cache mechanism nor part of the supported binary surface.
+
+  **Gate:** successful resolution, not a failed lookup, is the only publication point. `Object` remains an exact signature type, not a coercion escape hatch.
+
+- [ ] **4. Add focused `btrace-core` tests.**
+
+  Extend `btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java`; extend `CompileTestHarness.java` only if needed for mutable/counting child loaders. Retain current compile-shape tests and add runnable fixtures for:
+
+  1. Sequential virtual calls through two loaders defining the same owner FQN: distinct values and exactly one successful class/member resolution per loader.
+  2. Sequential static calls through two TCCLs defining the same owner FQN: distinct values/one success each plus retained null-TCCL system fallback. Make both loaders hostile—`equals`/`hashCode` must throw or record and fail the test if invoked—so the test proves the static index uses loader identity only.
+  3. Mutable virtual and static/TCCL loaders: initial missing class throws the new exception; making bytes visible through the same loader makes the next call succeed, proving no failed class/index/`ClassValue` cache.
+  4. Missing member called twice on loader A: exact exception/message/cause and two attempts via the collision-safe package-private counter field, read reflectively; loader B defining the same owner with the member succeeds.
+  5. A public-lookup-inaccessible fixture, exact-signature mismatch, and a target deliberately throwing the new exception: respectively `IllegalAccessException`, `NoSuchMethodException`, and transparent target propagation.
+  6. Concurrent static first use with a blocking/counting hostile loader has exactly one class-load and one member-lookup counter increment, proving the monitor covers resolution through index insertion. Do not add a virtual concurrency promise.
+
+  Add `btrace-core/src/test/java/io/btrace/extension/util/MethodHandleCacheTest.java`. Prove repeated public static/virtual lookups return the cached handle and repeated missing lookups retry; name/comment the test so it makes no loader-safety claim.
+
+  **Stop:** A test requiring a hidden lookup, a different target signature behind `Object`, or negative caching is Phase 3/6 work, not a Phase-1 workaround.
+
+- [ ] **5. Gate the external masked-JAR processor/runtime contract.**
+
+  First build `:btrace-dist:btraceJar` clean and inspect the one validated `btrace-dist/build/resources/main/v<version>/libs/btrace.jar`, never a sibling `btrace-core` output. Record its `jar tf` entries and extract the actual `META-INF/services/javax.annotation.processing.Processor` content to a log. Verify root-visible `ExternalType.class` and `ExternalTypeResolutionException.class`, the service’s declared processor class, and every `io/btrace/extension/processor/` class that processor requires at javac time.
+
+  Add the one-interface input at `btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalApi.java`, so the proof does not depend on hand-created source. Invoke `javac -cp` and `-processorpath` pointing *only* at this `btrace.jar`, with `-d <temporary-smoke>/classes` and `-s <temporary-smoke>/generated`. Redirect both javac stdout/stderr to `/tmp/btrace-issue-931-external-javac.log`; then assert the expected generated `example/ExternalApi$Ext.java` below `generated/` and `example/ExternalApi$Ext.class` below `classes/`. Do not put a sibling `btrace-core` artifact on either path or stage this smoke extension in release extensions.
+
+  If inspection shows the service entry is absent, update only `btrace-dist/build.gradle` to package that exact `META-INF/services/javax.annotation.processing.Processor` entry explicitly. If inspection separately shows that the declared processor/support classes are absent, expose only the required root `io/btrace/extension/processor/**/*.class`; do not add it merely because the service is missing. Rebuild clean and repeat the inspection and javac proof. Do not expose unrelated core/client/agent packages or change the Gradle plugin unless its own external wiring demonstrably fails.
+
+  **Gate:** External compilation succeeds with the published-style masked JAR alone. If that needs an unmasked internal module or broad exposure, stop for compatibility review.
+
+- [ ] **6. Maintain the real client/agent/target integration path.**
+
+  Retain `integration-tests/build.gradle`’s `stageExternalTypeClientHome` isolated staging path; do not add the test extension to `btrace-dist` release assembly. Update only as necessary:
+
+  - `btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalDataType.java`
+  - `btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestService.java`
+  - `btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestServiceImpl.java`
+  - `integration-tests/src/test/btrace/ExternalTypeAdapterTest.java` (only if a new marker is needed)
+  - `integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java`
+
+  Keep one static and one virtual call through the staged test extension, real client, agent, target JVM, and protocol. Keep the assertion that `btrace-ext-test` appears only below the integration build home and not the release distribution. Add a controlled failure case here only if it can show an extension catches/contains a resolution failure at its boundary; detailed classification stays unit-level.
+
+  **Gate:** Both real-path markers pass; release extensions do not contain `btrace-ext-test`.
+
+- [ ] **7. Consolidate documentation, with the extension guide authoritative.**
+
+  Make `docs/BTraceExtensionDevelopmentGuide.md` normative. Replace its “planned” table and “no try/catch” implication with the design’s exact support table: public uniquely named methods with exact erased signatures; manual `ClassLoadingUtil`/`MethodHandleCache` for target-only types, overloads, fields, constructors, casts/predicates; and public/exported-only module access. Document `Object`’s non-coercion rule, virtual defining loader/static TCCL distinction, null-TCCL fallback, successful-only retry semantics, the new exception, transparent target errors, and extension-level logging/degradation.
+
+  Include a `ClassLoadingUtil.withTCCL(...)` static-call example and a version-variant manual method example using exact `Class` values/`MethodHandleCache`. State that the utility caches only successful static/virtual method lookup and can retain application loaders strongly. Replace nonexistent `MethodHandleCache.findGetter`, `findSetter`, and `findConstructor` examples with direct `MethodHandles.publicLookup()` examples or an explicit “no helper exists.”
+
+  Reduce `docs/architecture/provided-style-extensions.md` to concrete manual linking and point adapter scope at the normative table. Make `docs/BTraceTutorial.md` and `docs/GettingStarted.md` short accurate introductions/links only; remove duplicate scope tables, future promises, and assertions that generated interaction needs no error policy.
+
+  **Gate:** Repository search finds no nonexistent cache helper claim, no user-doc “planned” statement for unsupported operations, and no promise that generated calls need no error boundary.
+
+- [ ] **8. Execute progressive verification and final review.**
+
+  From the repository root, run each Gradle call with a workspace-local cache, redirect before reading, then filter the log. A nonzero exit, `BUILD FAILED`, test failure, or format failure stops at its owning step. Build distribution before integration. When any Step-6 extension fixture is touched, run both its extension-module and integration-module Spotless gates below. For an address-selection failure, rerun the same command with `JAVA_TOOL_OPTIONS="-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false"`.
+
+      GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-core:test > /tmp/btrace-issue-931-core-test.log 2>&1
+      rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|ExternalType|MethodHandleCache" /tmp/btrace-issue-931-core-test.log
+
+      GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-core:spotlessCheck > /tmp/btrace-issue-931-core-spotless.log 2>&1
+      rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-core-spotless.log
+
+      GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew clean :btrace-dist:btraceJar > /tmp/btrace-issue-931-masked-jar.log 2>&1
+      rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|btraceJar" /tmp/btrace-issue-931-masked-jar.log
+
+      rg --files btrace-dist/build/resources/main | rg '^btrace-dist/build/resources/main/v[^/]+/libs/btrace\.jar$' > /tmp/btrace-issue-931-masked-jar-path.log
+      test "$(rg -c '^' /tmp/btrace-issue-931-masked-jar-path.log)" = 1
+      BTRACE_931_JAR="$(rg -x 'btrace-dist/build/resources/main/v[^/]+/libs/btrace\.jar' /tmp/btrace-issue-931-masked-jar-path.log)"
+      jar tf "$BTRACE_931_JAR" > /tmp/btrace-issue-931-masked-jar-entries.log
+      rg -n "io/btrace/core/extensions/ExternalType(ResolutionException)?\.class|io/btrace/extension/processor/|META-INF/services/javax.annotation.processing.Processor" /tmp/btrace-issue-931-masked-jar-entries.log
+      unzip -p "$BTRACE_931_JAR" META-INF/services/javax.annotation.processing.Processor > /tmp/btrace-issue-931-processor-service.log
+      rg -n '^io\.btrace\.extension\.processor\.ExternalTypeProcessor$' /tmp/btrace-issue-931-processor-service.log
+
+      BTRACE_931_SMOKE=$(mktemp -d /tmp/btrace-issue-931-external-type-smoke.XXXXXX)
+      mkdir -p "$BTRACE_931_SMOKE/classes" "$BTRACE_931_SMOKE/generated"
+      javac -cp "$BTRACE_931_JAR" -processorpath "$BTRACE_931_JAR" -d "$BTRACE_931_SMOKE/classes" -s "$BTRACE_931_SMOKE/generated" btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalApi.java > /tmp/btrace-issue-931-external-javac.log 2>&1
+      rg -n "error:|warning:|ExternalType|ExternalApi" /tmp/btrace-issue-931-external-javac.log || true
+      test -f "$BTRACE_931_SMOKE/generated/example/ExternalApi\$Ext.java"
+      test -f "$BTRACE_931_SMOKE/classes/example/ExternalApi\$Ext.class"
+
+      GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-dist:build > /tmp/btrace-issue-931-dist-build.log 2>&1
+      rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Test" /tmp/btrace-issue-931-dist-build.log
+
+      GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-dist:test > /tmp/btrace-issue-931-dist-test.log 2>&1
+      rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Test" /tmp/btrace-issue-931-dist-test.log
+
+      GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-extensions:btrace-ext-test:spotlessCheck > /tmp/btrace-issue-931-ext-test-spotless.log 2>&1
+      rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-ext-test-spotless.log
+
+      GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:spotlessCheck > /tmp/btrace-issue-931-integration-spotless.log 2>&1
+      rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-integration-spotless.log
+
+      GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:test -Pintegration --tests tests.ExternalTypeAdapterIntegrationTest > /tmp/btrace-issue-931-external-type-it.log 2>&1
+      rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|ExternalTypeAdapterIntegrationTest|timed out" /tmp/btrace-issue-931-external-type-it.log
+
+  Preserve/filter the Step-5 external-javac result in `/tmp/btrace-issue-931-external-javac.log`. Finish with `git diff --check`, `git status --short`, and a release-surface review.
+
+## Completion criteria
+
+Phase 1 is complete only when existing interfaces stay source-compatible; virtual/static sequential calls cache successfully and remain loader-isolated; failed class/member resolution retries; static first use is serialized without a loader leak; exact contextual/cause-preserving resolution errors replace checked class-load leakage; target failures remain transparent; manual-cache semantics/limitation are covered; staged real client-agent-target integration passes; the external masked-JAR compilation proof passes; and the four user docs carry one accurate canonical contract. No later-phase API, module bypass, target-library dependency, release-extension staging, or plugin DSL change is part of completion.

--- a/internal/specs/2026-08-06-issue-931-external-type-roadmap.md
+++ b/internal/specs/2026-08-06-issue-931-external-type-roadmap.md
@@ -1,0 +1,260 @@
+# Issue #931: `@ExternalType` dependable baseline and phased roadmap
+
+Date: 2026-08-06
+Status: design contract for [#931](https://github.com/btraceio/btrace/issues/931)
+
+## Decision
+
+Deliver this issue as small, independently releasable phases. Phase 1 hardens and documents the
+existing adapter model; it does **not** expand that model. It is the first implementation because
+it gives extension authors a dependable supported boundary now, while preserving a deliberate
+manual escape hatch for the APIs the processor cannot model.
+
+The existing implementation is already sound for public methods whose erased signatures are
+expressible by the extension: it produces lazy `MethodHandle` dispatch and isolates virtual
+handles by resolved target class. Its unsupported surface and runtime failure semantics, however,
+are ambiguous in user documentation, and successful class resolution is repeated on every call.
+Phase 1 closes those reliability/documentation gaps before adding new annotation syntax or target
+type modelling.
+
+## Phase 1: dependable v1 adapter contract
+
+### Scope
+
+Keep the current `@ExternalType` source shape and generate adapters only for an annotated
+interface's non-default, non-static interface methods:
+
+- A virtual adapter accepts `Object self` followed by the declared parameters. It resolves the
+  target class using `self`'s defining class loader.
+- A method annotated `@ExternalType.Static` has no receiver and resolves the target class through
+  the current thread context class loader (TCCL), falling back to the system loader only when the
+  TCCL is `null`.
+- Lookup uses `MethodHandles.publicLookup()` and therefore supports only public members of a type
+  accessible to that lookup. The declared erased parameter and return types must exactly match the
+  target member's erased JVM signature. In particular, use `Object` at the adapter boundary for a
+  target-only type; `Object` does not make a differently typed target method match.
+- Class/handle resolution is cached only after both the target class and requested member resolve
+  successfully. It must not perform `Class.forName` on every successful call. Failed class or
+  member resolution is never cached, so a later call can succeed when an application class becomes
+  available or a deployment changes.
+- Resolution failures use the public
+  `io.btrace.core.extensions.ExternalTypeResolutionException`, a final
+  `IllegalStateException` whose message is exactly
+  `Unable to resolve @ExternalType <owner>#<member>` and whose cause is the original
+  `ClassNotFoundException`, `NoSuchMethodException`, or `IllegalAccessException`. A missing target
+  class must no longer escape as an undeclared checked `ClassNotFoundException`. Invocation
+  failures from a target method retain the current transparent propagation behavior.
+
+The implementation may use generated self-contained code or a minimal shared runtime helper, but
+must retain generated-adapter binary/source compatibility for the existing annotation and method
+forms. If a helper is introduced, it is part of the supported `io.btrace:btrace` masked-JAR
+surface required by externally built extensions, with only the narrow root-visible exposure needed
+at runtime and no dependency on an unmasked internal module.
+
+### Cache ownership and failure invariants
+
+Generated code owns the cache; `MethodHandleCache` is not a substitute for its lifecycle rules.
+The generated adapter must follow these invariants:
+
+- **Virtual dispatch:** use a `ClassValue<ResolvedCall>` anchored to `self.getClass()`, where a
+  `ResolvedCall` contains the resolved owner and its method handle. Its computation loads the
+  configured owner with that receiver class's defining loader and resolves the exact member. A
+  `ClassValue` computation that fails installs no value. Anchoring the value to the receiver class
+  gives independent entries for isolated application classes and lets the VM discard the entry
+  when that class unloads. Phase 1 guarantees reuse for sequential calls after successful
+  resolution; it does not promise virtual-dispatch single-flight behavior for concurrent first use.
+- **Static dispatch:** use a per-adapter/per-member weak-*identity* loader index whose values are
+  weak references to the resolved target `Class<?>`. A key compares class loaders only with `==`
+  and hashes with `System.identityHashCode`; it must never use a loader's `equals` or `hashCode`.
+  Fixed bootstrap and system-loader sentinel keys cover those non-weak identity cases. Expunge
+  stale weak keys and values before lookup or insertion. The member's
+  `ClassValue<ResolvedCall>` is keyed by that target class and is the sole strong owner of the
+  resolved owner/handle pair; the loader index must not contain a `ResolvedCall`. On an index miss,
+  load the target class, obtain its `ClassValue` entry, and add the weak loader-to-class index only
+  after that lookup resolves successfully. This topology keeps a live loader's call cached through
+  its live class without allowing the index to keep the loader alive.
+- **Static-cache concurrency:** serialize expunge, index lookup, class resolution,
+  `ClassValue.get`, and index insertion on a per-member monitor. This defines single-flight
+  resolution for that member (including one loader at a time); a failed resolution leaves no index
+  entry and releases the monitor before it is reported. Do not use an unsynchronized check-then-act
+  sequence that can publish a partial or failed entry.
+- **Failure boundary:** catch only the three resolution exception types above while loading the
+  owner or finding the member and wrap them in `ExternalTypeResolutionException`. Do not surround
+  `MethodHandle.invoke` with that catch; a target-thrown `Throwable`, including a target-thrown
+  `ExternalTypeResolutionException`, passes through exactly as it does today.
+
+`MethodHandleCache` currently uses a `ConcurrentHashMap` keyed by a strong `Class<?>` and stores a
+strong `MethodHandle`; a long-lived extension instance can therefore retain an application loader.
+Phase 1 does not redesign that pre-existing manual utility. Its loader-safe redesign, if wanted,
+needs its own compatibility/lifecycle review. Phase 1 instead documents this limitation and adds
+focused unit coverage that successful manual lookups are cached while failed manual lookups remain
+uncached.
+
+### Documentation contract
+
+Make `docs/BTraceExtensionDevelopmentGuide.md` the normative `@ExternalType` reference. Make
+`docs/architecture/provided-style-extensions.md` the complementary concrete manual-linking guide
+and point its adapter-scope discussion back to that normative table. Make the tutorial and
+getting-started copies link to the normative guide rather than independently promise features. The
+reference must state, without calling deferred items "planned":
+
+| Capability | Phase 1 support | Author action |
+| --- | --- | --- |
+| Public, uniquely named static or virtual methods with exact erased signatures | Supported | Use `@ExternalType`; use `Object` only where the target member itself uses `Object`. |
+| A target method with target-library parameter or return types | Unsupported | Use `ClassLoadingUtil` and `MethodHandleCache` directly. |
+| Overloads | Unsupported; processor error | Use the manual helper with exact return and parameter `Class` values; it constructs the exact `MethodType` internally. |
+| Fields, constructors, `instanceof`, and casts | Unsupported | Use `ClassLoadingUtil` plus the appropriate manual `MethodHandles`/`Class` operation. `MethodHandleCache` currently caches virtual and static method lookup only. |
+| Non-public or non-exported named-module members | Unsupported | Do not add module-opening flags implicitly; use a public supported API or explicitly configure the target JVM outside BTrace. |
+
+The guide must document the virtual-defining-loader/static-TCCL distinction and show
+`ClassLoadingUtil.withTCCL(...)` for an author-controlled static-call context. It must also show
+the manual helper pattern as the sanctioned normal path for version-variant APIs, including that
+`MethodHandleCache` caches only successful lookups so a caught lookup failure remains a retryable
+capability check, and disclose its current strong-loader retention. Remove the implication that
+generated calls need no error boundary: callers must choose an appropriate extension-level
+logging/degradation policy around target interaction. Correct the existing nonexistent
+`MethodHandleCache.findGetter`, `findSetter`, and `findConstructor` examples: use direct
+`MethodHandles.publicLookup()` examples (or state clearly that no cache helper exists) instead of
+documenting APIs that BTrace does not provide.
+
+### Affected components
+
+- `btrace-core`: `ExternalType`, new public `ExternalTypeResolutionException`,
+  `ExternalTypeProcessor`, generated adapter emission, `MethodHandleCache` documentation-level
+  contract tests, and focused processor/runtime tests. Keep Java 8 source compatibility.
+- `btrace-dist` and masked-JAR packaging only if Phase 1 introduces a runtime helper. Validate the
+  published `btrace.jar`, not a sibling `btrace-core` classpath, as the external build/runtime
+  contract.
+- `btrace-gradle-plugin`: only if its processor/runtime artifact wiring needs adjustment; no DSL or
+  plugin-ID change is intended.
+- `btrace-extensions:btrace-ext-test` and `integration-tests`: extend the real extension/client /
+  agent/target path to exercise regenerated static and virtual adapters.
+- `docs/BTraceExtensionDevelopmentGuide.md`, `docs/architecture/provided-style-extensions.md`,
+  `docs/BTraceTutorial.md`, and `docs/GettingStarted.md`: one canonical reference and concise
+  pointers. No new user-documentation hierarchy is needed.
+
+### Phase 1 acceptance criteria
+
+1. Existing interfaces using distinct method names, primitive/JDK/value signatures, virtual
+   dispatch, and `@ExternalType.Static` compile and run without source changes.
+2. Repeated **sequential** virtual calls resolve a same-named target class independently for each
+   of two isolated application loaders; neither loader's target handle is used for the other, and
+   each loader's successful `Class.forName`/member resolution occurs once rather than once per
+   call. Concurrent first use is intentionally outside this criterion.
+3. Repeated static calls do the same through each of two isolated TCCLs. Static dispatch retains
+   the documented `null`-TCCL system-loader fallback and does not silently switch to a
+   receiver/defining-loader policy.
+4. A mutable test loader proves missing-class retry separately for virtual and static paths: an
+   initial lookup fails, the same loader exposes the class, and the next invocation succeeds. The
+   failed class lookup creates no index or `ClassValue` entry.
+5. A missing-member test invokes the adapter twice against loader A and uses a package-private
+   resolution test seam to prove two member-lookup attempts (no negative cache). An isolated
+   loader B defining the same target name with the member then succeeds, proving A's failure does
+   not poison B.
+6. Missing-class, missing-member, and inaccessible-public-lookup failures are contextual,
+   cause-preserving `ExternalTypeResolutionException`s with the specified message, while a
+   target-thrown exception remains transparent.
+7. A focused `MethodHandleCache` unit test proves repeated successful static/virtual lookup returns
+   the cached handle and repeated failed lookup remains retryable; the test and docs make no
+   loader-safety claim for that utility.
+8. The end-to-end integration test passes through the staged test extension and the real client,
+   agent, and target JVM for one static and one virtual call. If failure behavior is observable on
+   this path, add a controlled regression that proves it is contained at the extension boundary;
+   detailed lookup classification may remain a `btrace-core` runtime test.
+9. Documentation accurately describes the supported boundary, the static-loader caveat, modules,
+   retry semantics, and the manual path. It does not claim that unsupported features are imminent.
+
+### Verification
+
+Run from the repository root with `GRADLE_USER_HOME=$(pwd)/.gradle-user`. Redirect each Gradle
+invocation to `/tmp/btrace-issue-931-*.log`; use `rg` to extract task/test failures and `BUILD
+SUCCESSFUL` before reading the filtered output.
+
+```text
+:btrace-core:test
+:btrace-core:spotlessCheck
+:btrace-dist:build
+:btrace-dist:test
+:integration-tests:test -Pintegration --tests tests.ExternalTypeAdapterIntegrationTest
+```
+
+Build the distribution from clean state with `:btrace-dist:btraceJar`, inspect the resulting masked
+JAR/service metadata for `ExternalTypeResolutionException` (and any helper), and run an external
+extension compilation proof against the staged/published-style `btrace.jar`. If the restricted
+environment shows the known address-selection failure, rerun the same affected command with the
+repository's documented IPv4 `JAVA_TOOL_OPTIONS` setting.
+
+## Later, independently gated phases
+
+Later phases are candidates ordered by dependency and risk. Completion of Phase 1 does not commit
+their API shape, release, or date.
+
+### Phase 2: explicit static-loader policy
+
+Static dispatch has no receiver from which to derive an application loader. Evaluate a small,
+explicit opt-in that lets an author supply a context/loader, while preserving `@ExternalType.Static`
+and its TCCL behavior unchanged for source and binary compatibility. This phase must define
+class-loader lifecycle/caching, TCCL restoration, and application-server/OSGi coverage before an
+API is added. It must not guess a loader, mutate a thread's TCCL globally, or change existing
+static adapters' loader policy.
+
+### Phase 3: target-type signatures and chained adapters
+
+Design an explicit representation for a target-library type in parameters and returns, including
+how its target `Class` is resolved in the same application loader and substituted into the exact
+`MethodType`. Cover nested/chained calls, nulls, same-name types from isolated loaders, generics
+erasure, and generated public API leakage. This is deliberately separate from Phase 1 because
+using another annotated Java interface as a type has runtime/linkage and compatibility consequences
+that cannot be inferred from the current `Object` boundary.
+
+### Phase 4: overload disambiguation
+
+Add an opt-in source-level selector for a target member name/signature, retaining the existing
+compile-time error for ambiguous legacy declarations. The selector must map to an exact erased
+`MethodType`, have diagnostics for duplicate/invalid selectors, and coexist with Phase 3 target
+type modelling. It must never select an overload by runtime argument coercion.
+
+### Phase 5: fields, constructors, and type predicates
+
+Introduce narrowly scoped adapter operations for public getter/setter, constructor, and
+`isInstance`/cast behavior only after their generated API, null/error behavior, and access rules
+are reviewed. This phase may extend the manual `MethodHandleCache` API where needed, but must not
+turn annotations into a general reflection language or silently initialize target classes.
+
+### Phase 6: non-public members and JPMS access (only with a security design)
+
+No phase may use `privateLookupIn`, `--add-opens`, `--add-exports`, instrumentation-based module
+rewrites, or privileged lookup merely to make an adapter work. If a real supported integration
+requires it, create a separate security/release design covering explicit operator authority,
+minimum module/package scope, JDK-version behavior, revocation, diagnostics, and integration
+coverage. Until then, public exported target APIs are the boundary.
+
+## Non-goals
+
+- Do not change extension loading, classpath/bootclasspath injection, service discovery,
+  permissions, attach/protocol behavior, or the extension Gradle DSL in Phase 1.
+- Do not make target-library classes compile-time dependencies of ordinary extensions.
+- Do not automatically open/read named modules, access private members, or broaden BTrace's
+  privileges.
+- Do not cache failed lookup results, since lazy application loading and capability probing depend
+  on retry.
+- Do not bundle test-only extensions into the release distribution; retain the isolated staging
+  path used by `ExternalTypeAdapterIntegrationTest`.
+
+## Compatibility, migration, release, and security boundaries
+
+Phase 1 preserves the annotation, generated class naming, method shape, virtual defining-loader
+behavior, and static TCCL behavior. Existing already-built extensions retain their generated
+implementation until rebuilt; rebuilding against Phase 1 gains the cache/failure hardening without
+an author migration. The only intentional observable failure change is that adapter resolution
+does not leak an undeclared checked `ClassNotFoundException`; extension authors who deliberately
+inspect that implementation detail must instead handle the documented unchecked resolution
+`ExternalTypeResolutionException`/cause. Target-method exceptions retain their current propagation.
+
+The external consumer contract is the published masked `io.btrace:btrace` artifact and its narrow
+annotation-processor/runtime surface. `ExternalTypeResolutionException` is intentionally the only
+new public adapter runtime type; any helper introduced by this work must be present there without
+accidentally exposing unrelated core/client classes. No new permissions, network surface, target
+JVM flags, authentication/trust decisions, module bypasses, or classpath injection are authorized
+by this issue. The `publicLookup()` restriction is a security boundary, not a defect to be bypassed
+silently.


### PR DESCRIPTION
Closes #931.

## Summary

- Make generated `@ExternalType` adapters cache successful virtual and static lookups without retaining application class loaders.
- Normalize class/member lookup failures to `ExternalTypeResolutionException`, while preserving target-thrown failures.
- Package the annotation processor service and implementation in the published masked `btrace.jar`, and prove external compilation against that artifact alone.
- Establish one documented Phase 1 boundary and the supported manual fallback for target-only or version-variant APIs.

## Scope

This is the dependable baseline only. Target-type signatures, overload selectors, fields/constructors, and JPMS or non-public access remain deferred.

## Verification

- `:btrace-core:test`
- `:btrace-core:spotlessCheck`
- `clean :btrace-dist:btraceJar` plus external `javac -cp/-processorpath` smoke test using only `btrace.jar`
- `:btrace-dist:build`, `:btrace-dist:test`
- `:integration-tests:test -Pintegration --tests tests.ExternalTypeAdapterIntegrationTest`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/941)
<!-- Reviewable:end -->
