### PR TITLE
feat(extensions): add explicit static adapter loaders

### DIFF
--- a/btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java
@@ -161,7 +161,12 @@ final class AdapterEmitter {
     w.println("  public static " + m.returnType + " " + m.name + "(" + paramList + ") {");
     w.println("    try {");
     if (m.isStatic) {
-      w.println("      ResolvedCall call = $" + ordinal + "$resolveStatic();");
+      w.println(
+          "      ResolvedCall call = $"
+              + ordinal
+              + "$resolveStatic($"
+              + ordinal
+              + "$legacyStaticLoader());");
     } else {
       w.println("      ResolvedCall call = " + cache + ".get(self.getClass());");
     }
@@ -170,6 +175,21 @@ final class AdapterEmitter {
     w.println("call.handle.invoke(" + argList + ");");
     w.println("    } catch (Throwable t) { throw sneak(t); }");
     w.println("  }");
+    if (m.isStatic) {
+      String explicitParamList = "ClassLoader applicationLoader";
+      if (!paramList.isEmpty()) explicitParamList += ", " + paramList;
+      w.println();
+      w.println("  public static " + m.returnType + " " + m.name + "(" + explicitParamList + ") {");
+      w.println(
+          "    if (applicationLoader == null) throw new NullPointerException(\"applicationLoader\");");
+      w.println("    try {");
+      w.println("      ResolvedCall call = $" + ordinal + "$resolveStatic(applicationLoader);");
+      w.print("      ");
+      if (!"void".equals(m.returnType)) w.print("return (" + m.returnType + ") ");
+      w.println("call.handle.invoke(" + argList + ");");
+      w.println("    } catch (Throwable t) { throw sneak(t); }");
+      w.println("  }");
+    }
   }
 
   private void renderStaticSupport(PrintWriter w, MethodSpec m, int ordinal, String cache) {
@@ -193,9 +213,12 @@ final class AdapterEmitter {
             + prefix
             + "systemKey = new LoaderKey(LoaderKey.SYSTEM);");
     w.println();
-    w.println("  private static ResolvedCall $" + ordinal + "$resolveStatic() {");
+    w.println("  private static ClassLoader $" + ordinal + "$legacyStaticLoader() {");
     w.println("    ClassLoader loader = Thread.currentThread().getContextClassLoader();");
-    w.println("    if (loader == null) loader = ClassLoader.getSystemClassLoader();");
+    w.println("    return loader != null ? loader : ClassLoader.getSystemClassLoader();");
+    w.println("  }");
+    w.println();
+    w.println("  private static ResolvedCall $" + ordinal + "$resolveStatic(ClassLoader loader) {");
     w.println("    synchronized (" + prefix + "monitor) {");
     w.println("      $" + ordinal + "$expungeStatic();");
     w.println("      LoaderKey lookupKey = $" + ordinal + "$loaderKey(loader, false);");

--- a/btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java
+++ b/btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java
@@ -116,6 +116,12 @@ class ExternalTypeProcessorTest {
     String adapter = r.generatedSources.get("com.example.SparkUtils$Ext");
     assertTrue(adapter.contains("findStatic"), adapter);
     assertTrue(adapter.contains("Thread.currentThread().getContextClassLoader()"), adapter);
+    assertTrue(adapter.contains("public static java.lang.String version()"), adapter);
+    assertTrue(
+        adapter.contains("public static java.lang.String version(ClassLoader applicationLoader)"),
+        adapter);
+    assertTrue(adapter.contains("MethodType.methodType(java.lang.String.class)"), adapter);
+    assertTrue(adapter.contains("call.handle.invoke()"), adapter);
     assertFalse(
         adapter.contains("java.lang.Object self"),
         "static dispatcher must not take a receiver parameter: " + adapter);
@@ -223,6 +229,104 @@ class ExternalTypeProcessorTest {
     } finally {
       Thread.currentThread().setContextClassLoader(saved);
     }
+  }
+
+  @Test
+  void explicitStaticDispatcherSelectsLoaderWithoutChangingTccl() throws Exception {
+    Map<String, String> sources =
+        externalTypeSources("@ExternalType.Static int value();", "return 7;");
+    CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(r.success, r.errors());
+
+    MutableTargetLoader targetLoader = new MutableTargetLoader(r, true);
+    MutableTargetLoader wrongLoader = new MutableTargetLoader(r, false);
+    Class<?> adapter = r.loader.loadClass("com.example.adapter.CounterApi$Ext");
+    java.lang.reflect.Method legacy = adapter.getMethod("value");
+    java.lang.reflect.Method explicit = adapter.getMethod("value", ClassLoader.class);
+    ClassLoader saved = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(wrongLoader);
+      ExternalTypeResolutionException failure =
+          assertResolutionFailure(legacy, null, "com.example.target.Counter", "value");
+      assertInstanceOf(ClassNotFoundException.class, failure.getCause());
+      assertEquals(7, explicit.invoke(null, targetLoader));
+      assertSame(wrongLoader, Thread.currentThread().getContextClassLoader());
+    } finally {
+      Thread.currentThread().setContextClassLoader(saved);
+    }
+  }
+
+  @Test
+  void explicitStaticDispatcherRejectsNullBeforeResolution() throws Exception {
+    Map<String, String> sources =
+        externalTypeSources("@ExternalType.Static int value();", "return 7;");
+    CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(r.success, r.errors());
+    Class<?> adapter = r.loader.loadClass("com.example.adapter.CounterApi$Ext");
+    java.lang.reflect.Method explicit = adapter.getMethod("value", ClassLoader.class);
+
+    InvocationTargetException failure =
+        assertThrows(
+            InvocationTargetException.class, () -> explicit.invoke(null, new Object[] {null}));
+    assertInstanceOf(NullPointerException.class, failure.getCause());
+    assertEquals("applicationLoader", failure.getCause().getMessage());
+    assertEquals(0, resolutionAttempts(adapter, 0));
+    assertEquals(0, staticLoaderIndexEntries(adapter, 0));
+  }
+
+  @Test
+  void explicitStaticDispatcherSharesLegacyCacheAndRetriesFailures() throws Exception {
+    Map<String, String> sources =
+        externalTypeSources("@ExternalType.Static int value();", "return 7;");
+    CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(r.success, r.errors());
+    MutableTargetLoader loader = new MutableTargetLoader(r, false);
+    Class<?> adapter = r.loader.loadClass("com.example.adapter.CounterApi$Ext");
+    java.lang.reflect.Method legacy = adapter.getMethod("value");
+    java.lang.reflect.Method explicit = adapter.getMethod("value", ClassLoader.class);
+
+    ExternalTypeResolutionException failure =
+        assertResolutionFailure(explicit, loader, "com.example.target.Counter", "value");
+    assertInstanceOf(ClassNotFoundException.class, failure.getCause());
+    loader.makeVisible();
+    assertEquals(7, explicit.invoke(null, loader));
+    ClassLoader saved = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(loader);
+      assertEquals(7, legacy.invoke(null));
+    } finally {
+      Thread.currentThread().setContextClassLoader(saved);
+    }
+    assertEquals(2, loader.targetLoads, "failure retries and legacy shares the successful entry");
+    assertEquals(1, resolutionAttempts(adapter, 0));
+  }
+
+  @Test
+  void explicitStaticDispatcherForwardsRealClassLoaderArgument() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.target.Installer",
+        "package com.example.target; public class Installer { "
+            + "public static boolean install(ClassLoader loader) { return loader != null; } }");
+    sources.put(
+        "com.example.adapter.InstallerApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Installer\") public interface InstallerApi { "
+            + "@ExternalType.Static boolean install(ClassLoader targetArgument); }");
+    CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(r.success, r.errors());
+    Class<?> adapter = r.loader.loadClass("com.example.adapter.InstallerApi$Ext");
+    java.lang.reflect.Method legacy = adapter.getMethod("install", ClassLoader.class);
+    java.lang.reflect.Method explicit =
+        adapter.getMethod("install", ClassLoader.class, ClassLoader.class);
+    ClassLoader saved = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(r.loader);
+      assertEquals(true, legacy.invoke(null, r.loader));
+    } finally {
+      Thread.currentThread().setContextClassLoader(saved);
+    }
+    assertEquals(true, explicit.invoke(null, r.loader, r.loader));
   }
 
   @Test
@@ -418,13 +522,15 @@ class ExternalTypeProcessorTest {
 
     MutableTargetLoader loader = new MutableTargetLoader(r, true);
     Class<?> adapter = r.loader.loadClass("com.example.adapter.CounterApi$Ext");
-    java.lang.reflect.Method value = adapter.getMethod("value");
+    java.lang.reflect.Method legacy = adapter.getMethod("value");
+    java.lang.reflect.Method explicit = adapter.getMethod("value", ClassLoader.class);
     CountDownLatch ready = new CountDownLatch(2);
     CountDownLatch start = new CountDownLatch(1);
     ExecutorService executor = Executors.newFixedThreadPool(2);
     try {
-      Future<Integer> first = executor.submit(() -> invokeStatic(value, loader, ready, start));
-      Future<Integer> second = executor.submit(() -> invokeStatic(value, loader, ready, start));
+      Future<Integer> first = executor.submit(() -> invokeStatic(legacy, loader, ready, start));
+      Future<Integer> second =
+          executor.submit(() -> invokeExplicitStatic(explicit, loader, ready, start));
       ready.await();
       start.countDown();
       assertEquals(7, first.get());
@@ -582,11 +688,28 @@ class ExternalTypeProcessorTest {
     }
   }
 
+  private static int invokeExplicitStatic(
+      java.lang.reflect.Method method,
+      ClassLoader loader,
+      CountDownLatch ready,
+      CountDownLatch start)
+      throws Exception {
+    ready.countDown();
+    start.await();
+    return (int) method.invoke(null, loader);
+  }
+
   private static int resolutionAttempts(Class<?> adapter, int ordinal) throws Exception {
     java.lang.reflect.Field attempts =
         adapter.getDeclaredField("__btraceExternalTypeResolutionAttempts$" + ordinal);
     attempts.setAccessible(true);
     return attempts.getInt(null);
+  }
+
+  private static int staticLoaderIndexEntries(Class<?> adapter, int ordinal) throws Exception {
+    java.lang.reflect.Field loaderIndex = adapter.getDeclaredField("$" + ordinal + "$loaderIndex");
+    loaderIndex.setAccessible(true);
+    return ((Map<?, ?>) loaderIndex.get(null)).size();
   }
 
   private static final class MutableTargetLoader extends ClassLoader {

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalApi.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalApi.java
@@ -5,5 +5,5 @@ import io.btrace.core.extensions.ExternalType;
 @ExternalType("example.target.ExternalTarget")
 public interface ExternalApi {
   @ExternalType.Static
-  String version();
+  String marker();
 }

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalTarget.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalTarget.java
@@ -1,0 +1,9 @@
+package example.target;
+
+public final class ExternalTarget {
+  private ExternalTarget() {}
+
+  public static String marker() {
+    return "external-type-explicit-ok";
+  }
+}

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalTypeSmoke.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalTypeSmoke.java
@@ -1,0 +1,9 @@
+package example;
+
+public final class ExternalTypeSmoke {
+  private ExternalTypeSmoke() {}
+
+  public static void main(String[] args) {
+    System.out.println(ExternalApi$Ext.marker(ExternalTypeSmoke.class.getClassLoader()));
+  }
+}

--- a/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalDataType.java
+++ b/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalDataType.java
@@ -30,4 +30,8 @@ public interface ExternalDataType {
   /** Maps to ExternalData.tag() — static dispatch via TCCL. */
   @ExternalType.Static
   String tag();
+
+  /** Maps to ExternalData.explicitTag() — static dispatch with an explicit application loader. */
+  @ExternalType.Static
+  String explicitTag();
 }

--- a/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestService.java
+++ b/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestService.java
@@ -24,6 +24,9 @@ public interface ExternalTypeTestService {
   /** Returns the static tag from resources.ExternalData via its @ExternalType adapter. */
   String tag();
 
+  /** Returns the static tag using the supplied target object's defining loader. */
+  String explicitTag(Object externalData);
+
   /**
    * Returns the instance value from an resources.ExternalData object via its @ExternalType adapter.
    */

--- a/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestServiceImpl.java
+++ b/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestServiceImpl.java
@@ -17,12 +17,20 @@
 package io.btrace.test.ext;
 
 import io.btrace.core.extensions.Extension;
+import io.btrace.extension.util.ClassLoadingUtil;
 
 public final class ExternalTypeTestServiceImpl extends Extension
     implements ExternalTypeTestService {
   @Override
   public String tag() {
     return ExternalDataType$Ext.tag();
+  }
+
+  @Override
+  public String explicitTag(Object externalData) {
+    ClassLoader applicationLoader = ClassLoadingUtil.definingLoader(externalData);
+    if (applicationLoader == null) applicationLoader = ClassLoader.getSystemClassLoader();
+    return ExternalDataType$Ext.explicitTag(applicationLoader);
   }
 
   @Override

--- a/docs/BTraceExtensionDevelopmentGuide.md
+++ b/docs/BTraceExtensionDevelopmentGuide.md
@@ -203,7 +203,7 @@ public interface JobStartEvent {
 }
 ```
 
-The processor generates `JobStartEvent$Ext` in the same package with a typed `public static` dispatcher per method. A virtual dispatcher takes `Object self` first and resolves the configured owner through `self`'s defining loader. A static dispatcher resolves through the current thread context class loader (TCCL), falling back to the system loader only when the TCCL is `null`. Successful resolutions are cached per application class; failed class or member lookups are not cached, so a later call can retry.
+The processor generates `JobStartEvent$Ext` in the same package with a typed `public static` dispatcher per method. A virtual dispatcher takes `Object self` first and resolves the configured owner through `self`'s defining loader. A static dispatcher has both the legacy target-arguments-only form, which resolves through the current thread context class loader (TCCL) and falls back to the system loader only when the TCCL is `null`, and a leading-`ClassLoader` form that resolves through the supplied loader exactly. Successful resolutions are cached per application loader with weak-identity loader keys; failed class or member lookups are not cached, so a later call can retry. The two static forms share that cache.
 
 Use the generated class directly in the impl:
 
@@ -223,7 +223,7 @@ try {
 - **Annotation value:** non-empty fully-qualified class name. Empty string is a compile error.
 - **Method types:** declared erased parameter and return types must exactly match the target member's JVM signature. Use `Object` only when the target member itself uses `Object`; it is not a coercion escape hatch for target-only types.
 - **Access:** dispatch uses `MethodHandles.publicLookup()`. Only public members of public, accessible types are supported; do not add module-opening flags implicitly.
-- **Static methods:** add `@ExternalType.Static` on the interface method — the dispatcher calls `findStatic` with TCCL-based class loading and the documented null-TCCL system-loader fallback.
+- **Static methods:** add `@ExternalType.Static` on the interface method. `version()` preserves legacy TCCL-based class loading with the documented null-TCCL system-loader fallback. `version(ClassLoader applicationLoader)` resolves with that non-null loader exactly; it rejects null immediately with `NullPointerException("applicationLoader")`. The control argument is not a target argument. Neither form changes the target's observed TCCL.
 - **Default methods and static interface methods:** skipped (they already have bodies).
 - **Failures:** class lookup, missing member, and inaccessible-member failures throw `ExternalTypeResolutionException` with the original cause. Exceptions thrown by the target method propagate unchanged.
 
@@ -239,11 +239,15 @@ Use generated adapters only for the supported row below. The manual path is the 
 | Fields, constructors, `instanceof`, and casts | Unsupported | Use `ClassLoadingUtil` plus the appropriate direct `MethodHandles.publicLookup()` or `Class` operation. `MethodHandleCache` caches virtual and static method lookups only. |
 | Non-public or non-exported named-module members | Unsupported | Use a public supported API or explicitly configure the target JVM outside BTrace. |
 
-For a static call under an author-controlled application loader, use `ClassLoadingUtil.withTCCL(...)` to make that selection explicit and restore the old context afterward:
+For a generated static call under an author-controlled application loader, select it explicitly. Normalize a bootstrap-owned context object's null defining loader to the system loader, whose normal delegation reaches bootstrap:
 
 ```java
-String version = ClassLoadingUtil.withTCCL(appLoader, () -> VersionApi$Ext.version());
+ClassLoader appLoader = ClassLoadingUtil.definingLoader(context);
+if (appLoader == null) appLoader = ClassLoader.getSystemClassLoader();
+String version = VersionApi$Ext.version(appLoader);
 ```
+
+Keep `ClassLoadingUtil.withTCCL(...)` for manual APIs that actually require ambient TCCL policy; it is not needed to call a generated static adapter. Regenerating an adapter adds this overload. A wildcard static import can therefore become ambiguous if another wildcard import provides the same new arity; use a qualified adapter call or an explicit single-member static import.
 
 For version-variant APIs, resolve the exact public signature manually:
 

--- a/docs/architecture/provided-style-extensions.md
+++ b/docs/architecture/provided-style-extensions.md
@@ -68,13 +68,15 @@ public final class SparkApiImpl implements SparkApi {
 
 ## External Type Adapters
 
-`@ExternalType` is useful for public, uniquely named methods with exact erased signatures. The normative support table, failure contract, and virtual-defining-loader/static-TCCL distinction are in the [Extension Development Guide](../BTraceExtensionDevelopmentGuide.md#app-type-adapters-with-externaltype). Keep the manual pattern in this guide for target-only types, overloads, fields, constructors, and type predicates.
+`@ExternalType` is useful for public, uniquely named methods with exact erased signatures. The normative support table, failure contract, and virtual-defining-loader/static-loader-selection distinction are in the [Extension Development Guide](../BTraceExtensionDevelopmentGuide.md#app-type-adapters-with-externaltype). Keep the manual pattern in this guide for target-only types, overloads, fields, constructors, and type predicates.
 
-For a static target call where the application loader is known, scope the TCCL explicitly:
+For a generated static target call where the application loader is known, pass it directly:
 
 ```java
-String version = ClassLoadingUtil.withTCCL(appLoader, () -> VersionApi$Ext.version());
+String version = VersionApi$Ext.version(appLoader);
 ```
+
+Reserve `ClassLoadingUtil.withTCCL` for manual APIs that require a TCCL policy.
 
 For fields and constructors there is no `MethodHandleCache` convenience method. Use a direct public lookup after resolving the target class:
 

--- a/integration-tests/src/test/btrace/ExternalTypeAdapterExplicitTest.java
+++ b/integration-tests/src/test/btrace/ExternalTypeAdapterExplicitTest.java
@@ -1,0 +1,22 @@
+package btrace;
+
+import static io.btrace.core.BTraceUtils.exit;
+import static io.btrace.core.BTraceUtils.println;
+
+import io.btrace.core.annotations.BTrace;
+import io.btrace.core.annotations.Injected;
+import io.btrace.core.annotations.OnMethod;
+import io.btrace.test.ext.ExternalTypeTestService;
+
+/** Integration probe for explicit @ExternalType static loader selection. */
+@BTrace
+public class ExternalTypeAdapterExplicitTest {
+  @Injected private static ExternalTypeTestService extSvc;
+
+  @OnMethod(clazz = "resources.Main", method = "probeExternalExplicit")
+  public static void onProbeExternalExplicit(Object data) {
+    if (data == null) return;
+    println("explicit-tag=" + extSvc.explicitTag(data));
+    exit(0);
+  }
+}

--- a/integration-tests/src/test/java/resources/ExternalData.java
+++ b/integration-tests/src/test/java/resources/ExternalData.java
@@ -36,4 +36,10 @@ public final class ExternalData {
   public static String tag() {
     return "ext-data-ok";
   }
+
+  public static String explicitTag() {
+    return Thread.currentThread().getContextClassLoader() == ExternalData.class.getClassLoader()
+        ? "ext-data-explicit-wrong-tccl"
+        : "ext-data-explicit-ok";
+  }
 }

--- a/integration-tests/src/test/java/resources/Main.java
+++ b/integration-tests/src/test/java/resources/Main.java
@@ -20,6 +20,7 @@ package resources;
  * @author Jaroslav Bachorik
  */
 public class Main extends TestApp {
+  private static final ClassLoader EXTERNAL_TYPE_DECOY_LOADER = new ClassLoader(null) {};
   private String id = "xxx";
   private String field;
   private static String sField;
@@ -46,11 +47,24 @@ public class Main extends TestApp {
     sField = "BBB";
     print("i=" + callB(1, "Hello World"));
     probeExternal(new ExternalData(42));
+    Thread thread = Thread.currentThread();
+    ClassLoader previous = thread.getContextClassLoader();
+    try {
+      thread.setContextClassLoader(EXTERNAL_TYPE_DECOY_LOADER);
+      probeExternalExplicit(new ExternalData(42));
+    } finally {
+      thread.setContextClassLoader(previous);
+    }
   }
 
   // Entry point for @ExternalType integration tests: provides an ExternalData
   // instance to the probe via @Self without the extension needing to compile against ExternalData.
   ExternalData probeExternal(ExternalData data) {
+    return data;
+  }
+
+  // Separate entry point: its decoy TCCL makes accidental legacy static dispatch fail.
+  ExternalData probeExternalExplicit(ExternalData data) {
     return data;
   }
 

--- a/integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java
+++ b/integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java
@@ -57,6 +57,47 @@ public class ExternalTypeAdapterIntegrationTest extends RuntimeTest {
 
   @Test
   public void testExternalTypeAdapterTagAndValue() throws Exception {
+    configureExternalTypeExtension();
+    testDynamic(
+        "resources.Main",
+        "btrace/ExternalTypeAdapterTest.java",
+        Completion.untilContains("tag=ext-data-ok", "value=42"),
+        new ResultValidator() {
+          @Override
+          public void validate(String stdout, String stderr, int retcode, String jfrFile) {
+            assertFalse(
+                stdout.contains("FAILED"), "Probe should not have failed. stderr: " + stderr);
+            assertTrue(
+                stdout.contains("tag=ext-data-ok"),
+                "@ExternalType static dispatch failed. stdout: " + stdout);
+            assertTrue(
+                stdout.contains("value=42"),
+                "@ExternalType virtual dispatch failed. stdout: " + stdout);
+          }
+        });
+  }
+
+  @Test
+  public void testExternalTypeAdapterExplicitLoader() throws Exception {
+    configureExternalTypeExtension();
+    testDynamic(
+        "resources.Main",
+        "btrace/ExternalTypeAdapterExplicitTest.java",
+        Completion.untilContains("explicit-tag=ext-data-explicit-ok"),
+        new ResultValidator() {
+          @Override
+          public void validate(String stdout, String stderr, int retcode, String jfrFile) {
+            assertFalse(
+                stdout.contains("FAILED"), "Probe should not have failed. stderr: " + stderr);
+            assertTrue(
+                stdout.contains("explicit-tag=ext-data-explicit-ok"),
+                "@ExternalType explicit static dispatch changed TCCL or selected the wrong loader. stdout: "
+                    + stdout);
+          }
+        });
+  }
+
+  private void configureExternalTypeExtension() {
     Path integrationBuild =
         Paths.get(System.getProperty("project.dir"), "build").toAbsolutePath().normalize();
     Path stagedClientLibs =
@@ -80,29 +121,5 @@ public class ExternalTypeAdapterIntegrationTest extends RuntimeTest {
     targetExtensionPath = stagedExtensions.toString();
     clientBtraceLibs = stagedClientLibs.toString();
     attachDelayMs = 500;
-    testDynamic(
-        "resources.Main",
-        "btrace/ExternalTypeAdapterTest.java",
-        // Wait for the probe's actual output — the same signals the validator asserts on — so the
-        // harness never tears the target down before the async retransform of the already-loaded
-        // resources.Main class has fired the probe.
-        Completion.untilContains("tag=ext-data-ok", "value=42"),
-        new ResultValidator() {
-          @Override
-          public void validate(String stdout, String stderr, int retcode, String jfrFile) {
-            assertFalse(
-                stdout.contains("FAILED"), "Probe should not have failed. stderr: " + stderr);
-
-            // Static dispatch via TCCL: ExternalDataType$Ext.tag() -> ExternalData.tag()
-            assertTrue(
-                stdout.contains("tag=ext-data-ok"),
-                "@ExternalType static dispatch failed. stdout: " + stdout);
-
-            // Virtual dispatch: ExternalDataType$Ext.value(data) -> ExternalData.value()
-            assertTrue(
-                stdout.contains("value=42"),
-                "@ExternalType virtual dispatch failed. stdout: " + stdout);
-          }
-        });
   }
 }

--- a/internal/plans/2026-08-07-issue-931-phase-2-static-loader-selection-plan.md
+++ b/internal/plans/2026-08-07-issue-931-phase-2-static-loader-selection-plan.md
@@ -1,0 +1,153 @@
+# Issue #931 — Phase 2 implementation plan: explicit static `@ExternalType` loader selection
+
+**Design input:** `internal/specs/2026-08-07-issue-931-phase-2-static-loader-selection.md` (CLEAN)
+**Prerequisite:** #941 / Phase 1 is merged on `develop`.
+**Scope:** Phase 2 only. Add an explicit leading-`ClassLoader` overload to generated dispatchers for `@ExternalType.Static` methods without changing the legacy dispatcher’s descriptor or behaviour.
+
+## Fixed decisions and boundaries
+
+- The generated class, not the annotated interface, is the control boundary. Each non-overloaded static adapted member has both `name(targetParameters...)` and `name(ClassLoader applicationLoader, targetParameters...)`. The leading value selects only the class-loading namespace; it is never included in `MethodType` or passed to `MethodHandle.invoke`.
+- `null` is rejected immediately with `NullPointerException("applicationLoader")`. It does not mean bootstrap, system, or TCCL, and it must not reach the static cache or `Class.forName`.
+- The old no-loader dispatcher still reads TCCL and substitutes `ClassLoader.getSystemClassLoader()` only for null TCCL. Neither form calls `Thread.setContextClassLoader`.
+- The existing Phase 1 per-member weak-identity loader index, `ClassValue<ResolvedCall>`, monitor, queue, sentinels, successful-only insertion, and resolution exception remain the sole static-resolution machinery. Do not introduce another cache, helper runtime type, annotation, processor option, Gradle DSL, or bootstrap-visible API.
+- Keep `ExternalTypeProcessor`’s method-name overload rejection unchanged. It prevents collisions such as an interface declaring both `call()` and `call(ClassLoader)`, which would otherwise collide with the generated explicit overload. Do not use this phase to add overload selection; document the generated-overload wildcard-static-import caveat instead.
+- Preserve public-lookup-only access, exact erased signatures, error wrapping, retry behaviour, virtual dispatch, and target-thrown exception transparency. No JPMS/private-access work, type chaining, fields, constructors, casts, predicates, fallback searching, or loader guessing belongs here.
+
+## Ordered, gated work
+
+- [ ] **1. Establish the Phase 2 baseline.**
+
+  In `/private/tmp/btrace-issue-931-phase2`, preserve the untracked clean specification and all unrelated state. Read the spec, `docs/architecture/MaskedJarArchitecture.md`, the Phase 1 emitter (`btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java`), `ExternalTypeProcessorTest`, the `btrace-ext-test` fixture, and the isolated `stageExternalTypeClientHome` path before editing.
+
+  **Stop:** If #941 is not actually the `develop` baseline in this worktree, or preserving the old generated no-loader method descriptor proves impossible, stop and return to design review rather than adapting Phase 2 to a different base.
+
+- [ ] **2. Refactor the generated static resolver once, while retaining the legacy entry point.**
+
+  Change only `btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java` for generated runtime behaviour. Keep the generated imports Java-8 compatible.
+
+  For each static `MethodSpec`, retain the existing per-member cache declarations and make the following emitter-only refactor:
+
+  1. Emit one shared resolver taking a non-null `ClassLoader`, conceptually `$<ordinal>$resolveStatic(ClassLoader loader)`. Move the existing synchronized expunge, weak-identity lookup-key creation, loader-index lookup, `Class.forName(OWNER, false, loader)`, `ClassValue.get(owner)`, and post-success weak-index insertion into it unchanged in order. It catches only `ClassNotFoundException` from owner resolution and wraps it in `ExternalTypeResolutionException`; `ClassValue` continues to wrap lookup `NoSuchMethodException`/`IllegalAccessException`.
+  2. Emit a small legacy-loader selector, conceptually `$<ordinal>$legacyStaticLoader()`, which reads TCCL and substitutes the system loader only when TCCL is null. The old public dispatcher calls the shared resolver with that selected loader. Its generated method signature and target `MethodType`/invoke argument list stay byte-for-byte equivalent in meaning to Phase 1.
+  3. Emit a second public static method of the same name with `ClassLoader applicationLoader` prepended to the original target parameter list. Its first statement is `if (applicationLoader == null) throw new NullPointerException("applicationLoader");`; place this before the `try`, resolver invocation, and any generated cache access. It calls the shared resolver with exactly that supplied loader, then invokes the resolved handle with only the original parameter variables.
+  4. Extend the emitter’s parameter/argument-list generation (or add a dedicated static-list helper) so the control parameter appears only in the explicit Java declaration. It must never enter `methodTypeLiteral(m)` or the handle invocation argument list. Preserve virtual method emission exactly.
+  5. Keep each static member’s monitor as the single serialization boundary. Both generated overloads must share it and the same `loaderIndex`/`ClassValue`; a legacy call and explicit call choosing the same loader must retrieve the same resolved handle. Insert into the index only after both class and member resolution succeed. Do not make a null key reachable through the explicit form; existing sentinel support remains valid for generated machinery but legacy normalizes null TCCL to system.
+
+  Keep `btrace-core/src/main/java/io/btrace/extension/processor/ExternalTypeProcessor.java`’s existing name-only duplicate detection. Add no special case for a real target `ClassLoader` argument: an interface declaration `install(ClassLoader targetArgument)` generates legacy `install(ClassLoader)` and explicit `install(ClassLoader applicationLoader, ClassLoader targetArgument)`.
+
+  **Gate:** The generated static adapter has exactly two public dispatch descriptors per supported static source method, the legacy descriptor remains present, and the only new generated public surface is the leading-loader overload. A source declaration whose name/arity would conflict stays a processor error under the established overloaded-method rule.
+
+- [ ] **3. Add compile-shape and unit-level runtime coverage in `btrace-core`.**
+
+  Extend `btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java`; extend `CompileTestHarness.java` only if its in-memory class-byte support cannot express the fixture. Keep the Phase 1 counter private and read it reflectively as the current tests do. Reuse/extend the hostile `MutableTargetLoader` so `equals` and `hashCode` throw, and add explicit invocation helpers rather than weakening the old TCCL helpers.
+
+  Add focused tests for all of the following:
+
+  1. **Generated source shape and collision controls.** For a static method with ordinary parameters, assert both public static declarations exist; assert `MethodType.methodType` contains only the target return/parameter types and `call.handle.invoke(...)` contains only target arguments. Retain static methods’ no-`self` assertion. Compile the existing duplicate-name/overload fixture (including a `ClassLoader`-arity variant) and assert the existing processor diagnostic still rejects it, proving no generated descriptor collision is silently accepted.
+  2. **Wrong ambient loader versus explicit selected loader.** Define the target only in a hostile isolated loader and set TCCL to a different loader that cannot load it. The legacy dispatcher must throw the established `ExternalTypeResolutionException` with `ClassNotFoundException`; the explicit dispatcher called with the target loader must return that loader’s marker. Assert the caller’s TCCL remains the wrong loader after the explicit call.
+  3. **Identity, isolation, and sharing.** Two hostile isolated loaders defining the same owner FQN return different loader-specific results through explicit calls. Repeated explicit calls resolve once per loader. Then make a legacy call with TCCL equal to one of those loaders and prove it reuses that member’s existing successful resolution (no additional target load/member-resolution count). This both proves `==` cache keys and a shared cache, rather than two overload-specific caches.
+  4. **Mixed-form concurrency.** Start concurrent first calls for one static member—one uses the legacy form under a selected TCCL and one uses the explicit form with that exact loader—behind a latch. Assert one target class load and one successful member-resolution counter increment. Repeat with distinct isolated loaders and assert independent values/handles, never a cross-loader result.
+  5. **Null and bootstrap cases.** Invoke the explicit overload with null and assert a `NullPointerException` with `applicationLoader` before the mutable loader’s class-load count or the private resolution-attempt count changes. Preserve the Phase 1 legacy null-TCCL/system-loader fallback test. Add an explicit `java.lang.System.currentTimeMillis` call using `ClassLoader.getSystemClassLoader()` and assert success; its test/documentation companion must show authors normalize a null `ClassLoadingUtil.definingLoader(bootstrapObject)` result to that system loader rather than pass null.
+  6. **A real target `ClassLoader` parameter.** Compile and run an adapted static target such as `install(ClassLoader targetArgument)`. Reflectively find both generated forms, call the one-argument legacy form and two-argument explicit form, and assert the target receives the target argument—not the loader-selection argument. This is the positive descriptor/forwarding proof.
+  7. **Failure and retry preservation for the explicit form.** A mutable selected loader initially missing the owner must yield the established resolution exception without an index/counter publication; after it exposes the bytes, the same explicit call succeeds and caches. Assert missing-member and inaccessible-public-lookup failures retain their original causes, and an exception thrown by the target (including `ExternalTypeResolutionException`) propagates unchanged. Do not add negative caching.
+
+  Do not modify `MethodHandleCache` or use it as an oracle; it is outside this generated-adapter phase.
+
+  **Stop:** If any test can pass only by changing TCCL, using an extension implementation loader, adding a fallback search, accepting null, or exposing a target-only type in a generated signature, stop and return to the design boundary.
+
+- [ ] **4. Split the end-to-end test into separate legacy and explicit scenarios.**
+
+  Keep `integration-tests/build.gradle`’s `stageExternalTypeClientHome` isolation and the check that `btrace-ext-test` is not a release extension. Update only the Phase 2 fixture surface:
+
+  - `integration-tests/src/test/java/resources/Main.java`
+  - `integration-tests/src/test/java/resources/ExternalData.java`
+  - `btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalDataType.java`
+  - `btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestService.java`
+  - `btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestServiceImpl.java`
+  - `integration-tests/src/test/btrace/ExternalTypeAdapterTest.java`
+  - `integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java`
+
+  Preserve `resources.Main.probeExternal(ExternalData)` as the legacy scenario. Its normal application TCCL calls only the legacy static adapter and the existing virtual adapter, emitting the current `tag=ext-data-ok` and `value=42` markers.
+
+  Add a separate `Main.probeExternalExplicit(ExternalData)` invocation path. Before calling this entry point, the target work loop selects a deterministic decoy, non-target TCCL and restores the old context afterward; that makes any accidental legacy fallback fail. Its separate BTrace handler must invoke only an explicit-loader service method. In the service implementation, derive the loader from the supplied `ExternalData` object with `ClassLoadingUtil.definingLoader(data)`, normalize a bootstrap-null result to `ClassLoader.getSystemClassLoader()`, then call `ExternalDataType$Ext.tag(applicationLoader)`. Do not use `ClassLoadingUtil.withTCCL`.
+
+  Make `ExternalData.tag()` (or a dedicated explicit marker method with the matching `@ExternalType.Static` declaration) return a deterministic marker only when it observes the decoy TCCL still installed. The explicit test waits for and asserts that marker. This proves all four real pieces: the static owner was selected from the target object’s defining loader, the target method ran, the generated adapter did not mutate TCCL, and the real client-agent-target protocol path carried the result. It must not combine the legacy/virtual and explicit/decoy assumptions in one probe invocation or one completion condition.
+
+  **Gate:** Two independently runnable `ExternalTypeAdapterIntegrationTest` test methods/scenarios each stage the test extension below the integration build home, prove their own markers, and leave release extensions untouched.
+
+- [ ] **5. Extend the masked-artifact external compilation and run proof.**
+
+  Use the published masked JAR only: `btrace-dist/build/resources/main/v<version>/libs/btrace.jar`, never a `btrace-core` class directory or sibling JAR. Update/add inputs beneath `btrace-dist/src/test/resources/external-type-processor-smoke/src/example/` so the external API has a static `@ExternalType` method and a small `main` driver that calls the generated explicit overload with its own non-null class loader. Include a minimal target class in the smoke sources which returns a stable marker.
+
+  From a fresh temporary output directory, compile all those external sources using both `-cp` and `-processorpath` set only to the built `btrace.jar`; then run the driver with classpath `<smoke-classes>:<btrace.jar>` and assert the marker. Inspect the JAR first for root-visible `ExternalType.class`, `ExternalTypeResolutionException.class`, the exact `io/btrace/extension/processor/ExternalTypeProcessor.class` entry and its support package, and `META-INF/services/javax.annotation.processing.Processor`, including service content naming `ExternalTypeProcessor`.
+
+  Do not alter `btrace-dist/build.gradle`, the plugin, or masked-JAR section rules unless this proof demonstrates a concrete package/service omission. If it does, make the minimal packaging change, rebuild clean, and repeat the whole inspection/compile/run proof. Do not add the smoke extension to release extensions.
+
+  **Stop:** If external compilation or running needs an unmasked `btrace-core` artifact, an extension implementation JAR, or broad new masked-JAR exposure, stop for distribution compatibility review.
+
+- [ ] **6. Update the canonical documentation without expanding later phases.**
+
+  Update `docs/BTraceExtensionDevelopmentGuide.md` as the authoritative contract:
+
+  - explain both generated static forms, the unchanged no-loader TCCL/system-fallback policy, and the explicit exact-loader policy;
+  - document immediate null rejection, unchanged target TCCL, public-lookup/module limitations, successful-only retry, and shared weak-identity cache behaviour;
+  - replace the `ClassLoadingUtil.withTCCL(... VersionApi$Ext.version())` workaround for generated static calls with a leading-loader example, including `ClassLoadingUtil.definingLoader(context)` and the bootstrap-null-to-system normalization;
+  - retain `withTCCL` only for manual APIs;
+  - state the regeneration/source compatibility caveat: newly generated overloads can make a wildcard static import ambiguous if another wildcard import contributes the same new arity; use a qualified adapter call or explicit single-member import.
+
+  Update `docs/architecture/provided-style-extensions.md` to point to this canonical explanation and replace its generated-adapter TCCL-scoping workaround with the explicit-overload form. Do not duplicate a second support table. Leave `docs/BTraceTutorial.md` and `docs/GettingStarted.md` untouched unless a targeted search proves either independently tells users to use the old generated-adapter `withTCCL` workaround.
+
+  **Gate:** A repository search finds no advice to scope TCCL merely to call a generated static adapter, while manual API examples still legitimately use `withTCCL`.
+
+- [ ] **7. Run progressive verification, inspect release shape, and conclude Phase 2.**
+
+  From `/private/tmp/btrace-issue-931-phase2`, redirect every Gradle invocation to a log before reading it and use the worktree-local cache. A nonzero exit, `BUILD FAILED`, test failure, format failure, unexpected masked-JAR entry, or wrong integration marker stops at the owning step. Build `btrace-dist` before integration. If a restricted environment hits address-selection failures, repeat the affected Gradle command with `JAVA_TOOL_OPTIONS="-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false"`.
+
+  ```bash
+  GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-core:test > /tmp/btrace-issue-931-phase2-core-test.log 2>&1
+  rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|ExternalType" /tmp/btrace-issue-931-phase2-core-test.log
+
+  GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-core:spotlessCheck > /tmp/btrace-issue-931-phase2-core-spotless.log 2>&1
+  rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase2-core-spotless.log
+
+  GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew clean :btrace-dist:btraceJar > /tmp/btrace-issue-931-phase2-masked-jar.log 2>&1
+  rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|btraceJar" /tmp/btrace-issue-931-phase2-masked-jar.log
+
+  rg --files btrace-dist/build/resources/main | rg '^btrace-dist/build/resources/main/v[^/]+/libs/btrace\.jar$' > /tmp/btrace-issue-931-phase2-jar-path.log
+  test "$(rg -c '^' /tmp/btrace-issue-931-phase2-jar-path.log)" = 1
+  BTRACE_931_PHASE2_JAR="$(rg -x 'btrace-dist/build/resources/main/v[^/]+/libs/btrace\.jar' /tmp/btrace-issue-931-phase2-jar-path.log)"
+  jar tf "$BTRACE_931_PHASE2_JAR" > /tmp/btrace-issue-931-phase2-jar-entries.log
+  rg -n "io/btrace/core/extensions/ExternalType(ResolutionException)?\\.class|io/btrace/extension/processor/ExternalTypeProcessor\\.class|io/btrace/extension/processor/|META-INF/services/javax.annotation.processing.Processor" /tmp/btrace-issue-931-phase2-jar-entries.log
+  unzip -p "$BTRACE_931_PHASE2_JAR" META-INF/services/javax.annotation.processing.Processor > /tmp/btrace-issue-931-phase2-processor-service.log
+  rg -n '^io\.btrace\.extension\.processor\.ExternalTypeProcessor$' /tmp/btrace-issue-931-phase2-processor-service.log
+
+  BTRACE_931_PHASE2_SMOKE=$(mktemp -d /tmp/btrace-issue-931-phase2-smoke.XXXXXX)
+  mkdir -p "$BTRACE_931_PHASE2_SMOKE/classes" "$BTRACE_931_PHASE2_SMOKE/generated"
+  javac -cp "$BTRACE_931_PHASE2_JAR" -processorpath "$BTRACE_931_PHASE2_JAR" -d "$BTRACE_931_PHASE2_SMOKE/classes" -s "$BTRACE_931_PHASE2_SMOKE/generated" btrace-dist/src/test/resources/external-type-processor-smoke/src/example/*.java > /tmp/btrace-issue-931-phase2-external-javac.log 2>&1
+  rg -n "error:|warning:|ExternalType|ExternalApi" /tmp/btrace-issue-931-phase2-external-javac.log || true
+  test -f "$BTRACE_931_PHASE2_SMOKE/generated/example/ExternalApi\$Ext.java"
+  test -f "$BTRACE_931_PHASE2_SMOKE/classes/example/ExternalApi\$Ext.class"
+  java -cp "$BTRACE_931_PHASE2_SMOKE/classes:$BTRACE_931_PHASE2_JAR" example.ExternalTypeSmoke > /tmp/btrace-issue-931-phase2-external-run.log 2>&1
+  rg -n '^external-type-explicit-ok$' /tmp/btrace-issue-931-phase2-external-run.log
+
+  GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-dist:build > /tmp/btrace-issue-931-phase2-dist-build.log 2>&1
+  rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Test" /tmp/btrace-issue-931-phase2-dist-build.log
+
+  GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-extensions:btrace-ext-test:spotlessCheck > /tmp/btrace-issue-931-phase2-ext-spotless.log 2>&1
+  rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase2-ext-spotless.log
+
+  GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:spotlessCheck > /tmp/btrace-issue-931-phase2-integration-spotless.log 2>&1
+  rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase2-integration-spotless.log
+
+  GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:test -Pintegration --tests tests.ExternalTypeAdapterIntegrationTest > /tmp/btrace-issue-931-phase2-integration.log 2>&1
+  rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|ExternalTypeAdapterIntegrationTest|timed out" /tmp/btrace-issue-931-phase2-integration.log
+
+  git diff --check
+  git status --short
+  ```
+
+  Review the final diff against the clean specification: it must contain only the generated leading-loader static form, shared resolver/cache refactor, focused tests, external artifact proof resources, the split real integration scenarios, and canonical documentation. Do not commit until all gates pass and the user authorizes it.
+
+## Completion criteria
+
+Phase 2 is complete only when every newly generated static adapter has the explicit leading-`ClassLoader` dispatcher while every legacy dispatcher keeps its exact TCCL/system-fallback behaviour and descriptor; null is rejected before cache mutation; explicit and legacy forms share one weak-identity cache; loader isolation, retry, error causes, target-error transparency, real `ClassLoader` target arguments, bootstrap/system access, and mixed concurrency all pass focused tests; the masked published JAR alone compiles and runs an external explicit-overload extension; two distinct client-agent-target integration scenarios prove legacy and explicit behaviour without TCCL mutation; and the canonical docs replace the generated-adapter TCCL workaround. This phase does not authorize Phase 3+ capabilities.

--- a/internal/specs/2026-08-07-issue-931-phase-2-static-loader-selection.md
+++ b/internal/specs/2026-08-07-issue-931-phase-2-static-loader-selection.md
@@ -1,0 +1,209 @@
+# Issue #931, Phase 2: explicit static ExternalType loader selection
+
+Date: 2026-08-07
+Status: design proposal; implementation must not start until design review is clean
+Prerequisite: Phase 1 of #931 merged as #941
+
+## Problem and goal
+
+Phase 1 deliberately retained the historical static-adapter policy: a generated dispatcher for an
+ExternalType.Static method loads its target through the calling thread context class loader (TCCL),
+falling back to the system loader only when TCCL is null. This is source and binary compatible, but
+TCCL is ambient state and is frequently wrong in application servers, OSGi, and plugin containers.
+A static call has no receiver from which to derive an application defining loader.
+
+This phase adds an explicit, per-invocation application-loader selection for generated static
+adapters. It does not mutate ambient thread state, and it retains the old generated dispatcher
+unchanged for existing callers.
+
+## Decision: a generated leading-ClassLoader overload
+
+For each non-overloaded ExternalType.Static interface method, the processor generates:
+
+- the existing static dispatcher, with only the annotated target method parameters; and
+- an additional public static dispatcher with a leading ClassLoader applicationLoader parameter,
+  followed by those same target parameters.
+
+For example, an annotated static method current(int format) generates current(int format), which
+keeps the legacy TCCL policy, and current(ClassLoader applicationLoader, int format), which uses the
+supplied loader exactly. The leading loader is adapter control data: it is absent from MethodType
+and is not sent to MethodHandle.invoke.
+
+The interface deliberately remains a faithful target-member signature. A target method that itself
+takes ClassLoader remains unambiguous: install(ClassLoader targetArgument) has the legacy generated
+form install(ClassLoader targetArgument), and the explicit form
+install(ClassLoader applicationLoader, ClassLoader targetArgument).
+
+### Options assessed
+
+| Option | Decision | Evidence |
+| --- | --- | --- |
+| Generated leading-ClassLoader overload | Chosen | The generated class is already the static dispatch boundary. This adds no annotation syntax, helper object, or runtime public type; it is explicit at each call site and shares Phase 1's loader-keyed cache. |
+| Parameter annotation such as ExternalType.Loader | Rejected | It inserts adapter control data into an interface intended to mirror the exact target signature, needs validation/diagnostics, and obscures a real target ClassLoader parameter. |
+| Explicit context object or builder | Rejected | There is only one required value. A context type adds release surface, allocation, and loader-lifetime questions without a needed policy dimension. |
+| Change Static to a defining-loader policy | Rejected | A static call has no defining object. Changing the established TCCL behavior would break generated-extension compatibility. |
+| Annotation enum for TCCL/system/bootstrap | Rejected | It cannot select a container-specific application loader and makes a runtime choice a fixed declaration. |
+
+Author guidance: derive the explicit argument from a known application object with
+ClassLoadingUtil.definingLoader(applicationObject). That helper returns null for a bootstrap-owned
+object, while the explicit overload deliberately rejects null. In that case normalize the selected
+loader to ClassLoader.getSystemClassLoader(), whose normal delegation reaches bootstrap, before
+calling the adapter. Use the legacy method only when TCCL is intentionally the policy. Do not
+substitute the extension implementation's own loader.
+
+## Exact behavior
+
+### Existing no-loader static dispatcher
+
+The existing generated method obtains Thread.currentThread().getContextClassLoader(). If it is
+null, it substitutes ClassLoader.getSystemClassLoader(). It then loads the owner, performs the
+existing publicLookup().findStatic exact-erased-signature lookup, and invokes it. This remains the
+behavior of both newly regenerated and already-built adapters. There is no bootstrap reinterpretation,
+alternate fallback search, or change to its descriptor.
+
+### New explicit-loader static dispatcher
+
+The new overload must:
+
+1. Reject a null applicationLoader with NullPointerException before any cache mutation, class load,
+   or member lookup. The generated check uses the stable parameter name applicationLoader.
+2. Resolve the owner only with Class.forName(OWNER, false, applicationLoader).
+3. Use the same MethodHandles.publicLookup().findStatic exact MethodType as Phase 1.
+4. Invoke the handle using only the original annotated parameters.
+
+Null deliberately means no policy; it does not select bootstrap, system, or TCCL. It is too easy to
+pass accidentally and each fallback has a different observable result. Bootstrap members remain
+reachable through a non-null system loader, whose normal delegation reaches bootstrap. Legacy
+null-TCCL behavior still falls back to system.
+
+Neither overload calls Thread.setContextClassLoader at any point. Target code must therefore
+observe the caller's unchanged TCCL, there is no restoration responsibility, and shared executor
+threads cannot leak context across invocations.
+
+### Failure, security, and module boundaries
+
+Phase 1 remains the complete lookup failure contract. Class-not-found, no-such-method, and
+IllegalAccessException while resolving the owner/member become ExternalTypeResolutionException,
+with the established message and original cause. Failures are not cached. Target-thrown exceptions,
+including target-thrown ExternalTypeResolutionException, propagate unchanged.
+
+Supplying a loader selects only the owner-resolution namespace. Lookup stays publicLookup: it does
+not add module read/export edges, use privateLookupIn, access non-public members, change classpaths,
+or bypass a SecurityManager. Existing JVM permission checks remain observable and must not be
+caught/wrapped as resolution failures.
+
+## Cache, lifecycle, and concurrency
+
+The Phase 1 static cache is retained per generated adapter member:
+
+- Its weak-identity loader-to-owner-class index has weak values and bootstrap/system sentinel keys.
+- The owner ClassValue holding ResolvedCall is the sole strong owner of the resolved owner/handle
+  pair. The index must not retain ResolvedCall.
+- Expunge, lookup, Class.forName, ClassValue.get, and insertion remain serialized on the existing
+  per-member monitor. Insert only after class and member resolution both succeed.
+- The explicit overload passes its supplied loader to this same resolver. It must not create a
+  second cache, a thread-local cache, or a strong ClassLoader map.
+
+Thus an explicit and legacy invocation that select the same loader share a cache entry; isolated
+loaders defining the same owner FQN use different handles. Concurrent first calls through either
+overload are single-flight per member. Failed explicit resolution creates no index/ClassValue entry
+and retries on a later invocation.
+
+## Compatibility and release surface
+
+- Source: existing annotations, direct qualified calls to generated no-loader methods, virtual
+  dispatch, target matching, and the extension Gradle DSL remain unchanged. Adding a same-name
+  overload can make a separately compiled consumer that uses wildcard static imports ambiguous if
+  another wildcard-imported type already contributes the new-arity signature. This is a Java source
+  compatibility caveat for regeneration, not a behavior change in a direct legacy call. Document
+  it and advise qualified generated-adapter calls (or an explicit single-member static import).
+- Binary: old generated adapters continue unchanged. New generated adapters preserve every old
+  descriptor and add only a leading-ClassLoader overload. Rebuilding an extension is required only
+  to call the new overload.
+- Processor/runtime: this is a processor-output change only. Do not add an annotation, helper,
+  service descriptor, bootstrap-visible class, or Java-11 API. Generated source stays Java 8.
+- Published artifact: validate against the masked io.btrace:btrace JAR, which already carries the
+  processor service from Phase 1, not directly against btrace-core. No distribution or plugin
+  wiring change is expected unless this validation proves one is necessary.
+- Documentation: the canonical ExternalType section in docs/BTraceExtensionDevelopmentGuide.md
+  documents both overloads, the null contract, and loader selection. Replace its
+  ClassLoadingUtil.withTCCL workaround for generated static calls with the new overload, while
+  retaining withTCCL for manual APIs. Update docs/architecture/provided-style-extensions.md to
+  point to that canonical explanation. Change tutorial/getting-started only if they independently
+  state the old workaround.
+
+## Scope
+
+In scope:
+
+- Generate the loader-selecting overload for each generated static dispatcher.
+- Preserve the exact Phase 1 legacy dispatch path and route both overloads through the existing
+  loader-safe cache.
+- Test null/failure/cache/concurrency semantics, external artifact packaging, documentation, and
+  the full extension-client-agent-target integration path.
+
+Out of scope:
+
+- New interface annotations, context objects, processor options, Gradle DSL/configuration,
+  fallback search, automatic loader selection, or target-loader guessing.
+- Virtual dispatch changes; target-library signature types/chaining; overload selectors; fields,
+  constructors, casts, and predicates.
+- Non-public/JPMS access; module or classpath mutation; security bypass; extension/agent loading
+  changes; redesigning MethodHandleCache.
+
+## Affected components
+
+- btrace-core: AdapterEmitter and focused ExternalTypeProcessor tests. ExternalType,
+  ExternalTypeResolutionException, and ClassLoadingUtil need no API change.
+- docs/BTraceExtensionDevelopmentGuide.md and
+  docs/architecture/provided-style-extensions.md.
+- btrace-dist, btrace-gradle-plugin, and integration-tests for validation/staging only unless a
+  real artifact-level wiring defect is demonstrated.
+
+## Acceptance criteria
+
+### Processor and runtime tests
+
+1. Generated-source assertions prove both descriptors: legacy target-arguments-only and explicit
+   leading-ClassLoader. They prove the control argument is not present in MethodType or invoke.
+2. A hostile isolated loader defines the target where a deliberately wrong TCCL cannot find it.
+   The explicit call succeeds with a loader-specific result; the legacy call retains TCCL behavior
+   and fails with the established resolution exception.
+3. Two isolated loaders defining the same FQN return their own values via the explicit overload.
+   Repeated calls resolve once per loader; an explicit and legacy call selecting the same loader
+   share one entry. Fixtures whose equals/hashCode throw preserve the identity-cache guarantee.
+4. Concurrent first use through legacy and explicit forms with one loader resolves once under the
+   member monitor. Repeat across distinct loaders to prove no handle crosses loader boundaries.
+5. Explicit null throws NullPointerException before fixture class-load/member-lookup counters move.
+   Separately retain Phase 1's legacy null-TCCL system-loader fallback test.
+6. A bootstrap-owned target is called through the explicit overload with
+   ClassLoader.getSystemClassLoader(), including the documented normalization of a null result from
+   ClassLoadingUtil.definingLoader; it must resolve successfully without treating null as a loader
+   selector.
+7. A target signature with a real ClassLoader parameter compiles and invokes correctly through
+   both generated forms, proving that the leading control argument is distinct and target arguments
+   are forwarded.
+8. Missing class/member/access, retry-after-class-appears, and target-thrown failures remain valid
+   for the explicit form as appropriate. Failed explicit lookup must never be negatively cached.
+
+### Integration and release tests
+
+9. Split ExternalTypeAdapterIntegrationTest into two independently triggered target/probe
+   scenarios. The existing resources.Main.probeExternal scenario keeps its normal application TCCL
+   and proves legacy static TCCL dispatch plus virtual dispatch both succeed. A distinct target
+   entry point (for example, probeExternalExplicit) sets a deterministic non-target TCCL and drives
+   only the explicit-loader static adapter; it proves the explicit call emits the target-owned
+   marker and that target code observes its TCCL unchanged. Do not combine the incompatible TCCL
+   assumptions in one probe invocation.
+10. From clean state build btrace-dist:btraceJar, inspect the masked JAR for the processor service
+   and processor implementation, then compile and run a minimal external extension against that
+   JAR that calls the new overload.
+11. Run btrace-core:test, btrace-core:spotlessCheck, clean btrace-dist:btraceJar,
+    btrace-dist:build, and the focused integration test with -Pintegration. Use a workspace-local
+    GRADLE_USER_HOME, redirect each Gradle run to /tmp, and filter relevant output before reading.
+
+## Completion boundary
+
+Phase 2 is complete only when the generated leading-ClassLoader overload, unchanged legacy
+overload, weak-identity cache behavior, null/error semantics, documentation, masked-artifact proof,
+and end-to-end integration path satisfy these criteria. It does not authorize later #931 phases.


### PR DESCRIPTION
Closes #931.

## Summary

- Add an explicit `ClassLoader` overload to generated static `@ExternalType` adapters.
- Preserve the legacy TCCL/system-loader dispatcher and share the loader-safe cache between both forms.
- Cover wrong-TCCL dispatch, null rejection, mixed first-use concurrency, masked-JAR smoke compilation, and distinct legacy/explicit integration paths.
- Update the canonical extension guidance.

## Compatibility

Existing generated static adapter descriptors and behavior are unchanged. Rebuilding adds an overload; wildcard static imports may need qualification if another wildcard imports a same-arity method.

## Verification

- `:btrace-core:test`
- `:btrace-core:spotlessCheck`

The broader distribution and integration test run is not included in this PR's local verification yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/942)
<!-- Reviewable:end -->
