### PR TITLE
feat(extensions): support target type signatures

### DIFF
--- a/btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java
+++ b/btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java
@@ -50,4 +50,16 @@ public @interface ExternalType {
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
   @interface Static {}
+
+  /**
+   * Marks a direct {@code Object} method return or parameter as an external target type described
+   * by another {@link ExternalType} contract. The processor consumes this source-only metadata;
+   * the runtime value does not implement the referenced contract interface.
+   */
+  @Retention(RetentionPolicy.SOURCE)
+  @Target({ElementType.METHOD, ElementType.PARAMETER})
+  @interface Type {
+    /** The external contract that supplies the target type name. */
+    Class<?> value();
+  }
 }

--- a/btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java
+++ b/btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java
@@ -53,8 +53,8 @@ public @interface ExternalType {
 
   /**
    * Marks a direct {@code Object} method return or parameter as an external target type described
-   * by another {@link ExternalType} contract. The processor consumes this source-only metadata;
-   * the runtime value does not implement the referenced contract interface.
+   * by another {@link ExternalType} contract. The processor consumes this source-only metadata; the
+   * runtime value does not implement the referenced contract interface.
    */
   @Retention(RetentionPolicy.SOURCE)
   @Target({ElementType.METHOD, ElementType.PARAMETER})

--- a/btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java
@@ -146,10 +146,7 @@ final class AdapterEmitter {
               + methodTypeLiteral(m, ordinal)
               + ")); ");
     }
-    w.println(
-        "          } catch ("
-            + resolutionExceptions(m)
-            + " e) {");
+    w.println("          } catch (" + resolutionExceptions(m) + " e) {");
     w.println(
         "            throw new ExternalTypeResolutionException(OWNER, \"" + m.name + "\", e);");
     w.println("          }");
@@ -313,9 +310,7 @@ final class AdapterEmitter {
   private String methodTypeLiteral(MethodSpec m, int ordinal) {
     StringBuilder result = new StringBuilder("MethodType.methodType(");
     result.append(
-        m.returnTargetFqn == null
-            ? m.returnType + ".class"
-            : "$" + ordinal + "$returnType");
+        m.returnTargetFqn == null ? m.returnType + ".class" : "$" + ordinal + "$returnType");
     for (int i = 0; i < m.paramTypes.size(); i++) {
       result.append(", ");
       result.append(

--- a/btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java
@@ -129,27 +129,26 @@ final class AdapterEmitter {
       w.println(
           "            Class<?> owner = Class.forName(OWNER, false, receiver.getClassLoader());");
     }
+    renderMarkedTypes(w, m, ordinal);
     w.println("            " + attempts + "++;");
     if (m.isStatic) {
       w.println(
           "            return new ResolvedCall(owner, MethodHandles.publicLookup().findStatic(owner, \""
               + m.name
               + "\", "
-              + methodTypeLiteral(m)
+              + methodTypeLiteral(m, ordinal)
               + ")); ");
     } else {
       w.println(
           "            return new ResolvedCall(owner, MethodHandles.publicLookup().findVirtual(owner, \""
               + m.name
               + "\", "
-              + methodTypeLiteral(m)
+              + methodTypeLiteral(m, ordinal)
               + ")); ");
     }
     w.println(
         "          } catch ("
-            + (m.isStatic
-                ? "NoSuchMethodException | IllegalAccessException"
-                : "ClassNotFoundException | NoSuchMethodException | IllegalAccessException")
+            + resolutionExceptions(m)
             + " e) {");
     w.println(
         "            throw new ExternalTypeResolutionException(OWNER, \"" + m.name + "\", e);");
@@ -274,10 +273,56 @@ final class AdapterEmitter {
     w.println("  }");
   }
 
-  private String methodTypeLiteral(MethodSpec m) {
+  private void renderMarkedTypes(PrintWriter w, MethodSpec m, int ordinal) {
+    if (m.returnTargetFqn != null) {
+      w.println(
+          "            Class<?> $"
+              + ordinal
+              + "$returnType = Class.forName(\""
+              + m.returnTargetFqn
+              + "\", false, owner.getClassLoader());");
+    }
+    for (int i = 0; i < m.paramTargetFqns.size(); i++) {
+      String fqn = m.paramTargetFqns.get(i);
+      if (fqn == null) continue;
+      w.println(
+          "            Class<?> $"
+              + ordinal
+              + "$parameterType"
+              + i
+              + " = Class.forName(\""
+              + fqn
+              + "\", false, owner.getClassLoader());");
+    }
+  }
+
+  private String resolutionExceptions(MethodSpec m) {
+    if (!m.isStatic || m.returnTargetFqn != null || hasMarkedParameter(m)) {
+      return "ClassNotFoundException | NoSuchMethodException | IllegalAccessException";
+    }
+    return "NoSuchMethodException | IllegalAccessException";
+  }
+
+  private boolean hasMarkedParameter(MethodSpec m) {
+    for (String targetFqn : m.paramTargetFqns) {
+      if (targetFqn != null) return true;
+    }
+    return false;
+  }
+
+  private String methodTypeLiteral(MethodSpec m, int ordinal) {
     StringBuilder result = new StringBuilder("MethodType.methodType(");
-    result.append(m.returnType).append(".class");
-    for (String p : m.paramTypes) result.append(", ").append(p).append(".class");
+    result.append(
+        m.returnTargetFqn == null
+            ? m.returnType + ".class"
+            : "$" + ordinal + "$returnType");
+    for (int i = 0; i < m.paramTypes.size(); i++) {
+      result.append(", ");
+      result.append(
+          m.paramTargetFqns.get(i) == null
+              ? m.paramTypes.get(i) + ".class"
+              : "$" + ordinal + "$parameterType" + i);
+    }
     return result.append(")").toString();
   }
 

--- a/btrace-core/src/main/java/io/btrace/extension/processor/ExternalTypeProcessor.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/ExternalTypeProcessor.java
@@ -50,7 +50,8 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
 
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-    Set<Element> markers = new HashSet<>(roundEnv.getElementsAnnotatedWith(ExternalType.Type.class));
+    Set<Element> markers =
+        new HashSet<>(roundEnv.getElementsAnnotatedWith(ExternalType.Type.class));
     Set<Element> consumedMarkers = new HashSet<>();
     for (Element e : roundEnv.getElementsAnnotatedWith(ExternalType.class)) {
       if (e.getKind() != ElementKind.INTERFACE) {
@@ -100,10 +101,7 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
   }
 
   private AdapterSpec buildSpec(
-      TypeElement iface,
-      String externalFqn,
-      Set<Element> markers,
-      Set<Element> consumedMarkers) {
+      TypeElement iface, String externalFqn, Set<Element> markers, Set<Element> consumedMarkers) {
     String pkg = processingEnv.getElementUtils().getPackageOf(iface).getQualifiedName().toString();
     String simple = iface.getSimpleName().toString();
     List<MethodSpec> methods = new ArrayList<>();
@@ -149,7 +147,8 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
         }
         paramTargetFqns.add(targetFqn);
       }
-      methods.add(new MethodSpec(methodName, rt, returnTargetFqn, params, paramTargetFqns, isStatic));
+      methods.add(
+          new MethodSpec(methodName, rt, returnTargetFqn, params, paramTargetFqns, isStatic));
     }
     if (invalid) return null;
     return new AdapterSpec(pkg, simple, externalFqn, methods);
@@ -166,7 +165,8 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
       return null;
     }
     TypeMirror contractType = annotationTypeValue(marker);
-    if (contractType == null || !(processingEnv.getTypeUtils().asElement(contractType) instanceof TypeElement)) {
+    if (contractType == null
+        || !(processingEnv.getTypeUtils().asElement(contractType) instanceof TypeElement)) {
       return invalidContract(marker);
     }
     TypeElement contract = (TypeElement) processingEnv.getTypeUtils().asElement(contractType);

--- a/btrace-core/src/main/java/io/btrace/extension/processor/ExternalTypeProcessor.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/ExternalTypeProcessor.java
@@ -33,10 +33,14 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 
-@SupportedAnnotationTypes("io.btrace.core.extensions.ExternalType")
+@SupportedAnnotationTypes({
+  "io.btrace.core.extensions.ExternalType",
+  "io.btrace.core.extensions.ExternalType.Type"
+})
 public final class ExternalTypeProcessor extends AbstractProcessor {
 
   @Override
@@ -46,6 +50,8 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
 
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    Set<Element> markers = new HashSet<>(roundEnv.getElementsAnnotatedWith(ExternalType.Type.class));
+    Set<Element> consumedMarkers = new HashSet<>();
     for (Element e : roundEnv.getElementsAnnotatedWith(ExternalType.class)) {
       if (e.getKind() != ElementKind.INTERFACE) {
         processingEnv
@@ -69,8 +75,8 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
         continue;
       }
       try {
-        AdapterSpec spec = buildSpec(iface, externalFqn);
-        emit(spec, iface);
+        AdapterSpec spec = buildSpec(iface, externalFqn, markers, consumedMarkers);
+        if (spec != null) emit(spec, iface);
       } catch (Exception ex) {
         processingEnv
             .getMessager()
@@ -80,14 +86,29 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
                 iface);
       }
     }
+    for (Element marker : markers) {
+      if (consumedMarkers.contains(marker)) continue;
+      processingEnv
+          .getMessager()
+          .printMessage(
+              Diagnostic.Kind.ERROR,
+              "@ExternalType.Type is only valid as @ExternalType.Type(OtherContract.class) Object "
+                  + "on a non-static, non-default method of an @ExternalType interface.",
+              marker);
+    }
     return true;
   }
 
-  private AdapterSpec buildSpec(TypeElement iface, String externalFqn) {
+  private AdapterSpec buildSpec(
+      TypeElement iface,
+      String externalFqn,
+      Set<Element> markers,
+      Set<Element> consumedMarkers) {
     String pkg = processingEnv.getElementUtils().getPackageOf(iface).getQualifiedName().toString();
     String simple = iface.getSimpleName().toString();
     List<MethodSpec> methods = new ArrayList<>();
     Set<String> seen = new HashSet<>();
+    boolean invalid = false;
     for (Element m : iface.getEnclosedElements()) {
       if (m.getKind() != ElementKind.METHOD) continue;
       ExecutableElement em = (ExecutableElement) m;
@@ -104,17 +125,83 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
                     + iface.getQualifiedName()
                     + ". Rename the methods or use MethodHandleCache directly for overloaded dispatch.",
                 em);
+        invalid = true;
         continue;
       }
       boolean isStatic = em.getAnnotation(ExternalType.Static.class) != null;
       String rt = processingEnv.getTypeUtils().erasure(em.getReturnType()).toString();
-      List<String> params = new ArrayList<>();
-      for (VariableElement p : em.getParameters()) {
-        params.add(processingEnv.getTypeUtils().erasure(p.asType()).toString());
+      String returnTargetFqn = null;
+      if (markers.contains(em)) {
+        consumedMarkers.add(em);
+        returnTargetFqn = targetFqn(em, rt);
+        invalid |= returnTargetFqn == null;
       }
-      methods.add(new MethodSpec(methodName, rt, params, isStatic));
+      List<String> params = new ArrayList<>();
+      List<String> paramTargetFqns = new ArrayList<>();
+      for (VariableElement p : em.getParameters()) {
+        String paramType = processingEnv.getTypeUtils().erasure(p.asType()).toString();
+        params.add(paramType);
+        String targetFqn = null;
+        if (markers.contains(p)) {
+          consumedMarkers.add(p);
+          targetFqn = targetFqn(p, paramType);
+          invalid |= targetFqn == null;
+        }
+        paramTargetFqns.add(targetFqn);
+      }
+      methods.add(new MethodSpec(methodName, rt, returnTargetFqn, params, paramTargetFqns, isStatic));
     }
+    if (invalid) return null;
     return new AdapterSpec(pkg, simple, externalFqn, methods);
+  }
+
+  private String targetFqn(Element marker, String erasedType) {
+    if (!"java.lang.Object".equals(erasedType)) {
+      processingEnv
+          .getMessager()
+          .printMessage(
+              Diagnostic.Kind.ERROR,
+              "@ExternalType.Type is valid only as @ExternalType.Type(OtherContract.class) Object.",
+              marker);
+      return null;
+    }
+    TypeMirror contractType = annotationTypeValue(marker);
+    if (contractType == null || !(processingEnv.getTypeUtils().asElement(contractType) instanceof TypeElement)) {
+      return invalidContract(marker);
+    }
+    TypeElement contract = (TypeElement) processingEnv.getTypeUtils().asElement(contractType);
+    ExternalType externalType = contract.getAnnotation(ExternalType.class);
+    if (contract.getKind() != ElementKind.INTERFACE
+        || externalType == null
+        || externalType.value().isEmpty()) {
+      return invalidContract(marker);
+    }
+    return externalType.value();
+  }
+
+  private String invalidContract(Element marker) {
+    processingEnv
+        .getMessager()
+        .printMessage(
+            Diagnostic.Kind.ERROR,
+            "@ExternalType.Type must reference an interface with a non-empty @ExternalType value.",
+            marker);
+    return null;
+  }
+
+  private TypeMirror annotationTypeValue(Element marker) {
+    for (javax.lang.model.element.AnnotationMirror annotation : marker.getAnnotationMirrors()) {
+      if (!annotation
+          .getAnnotationType()
+          .toString()
+          .equals("io.btrace.core.extensions.ExternalType.Type")) continue;
+      for (javax.lang.model.element.AnnotationValue value :
+          processingEnv.getElementUtils().getElementValuesWithDefaults(annotation).values()) {
+        Object raw = value.getValue();
+        if (raw instanceof TypeMirror) return (TypeMirror) raw;
+      }
+    }
+    return null;
   }
 
   private void emit(AdapterSpec spec, TypeElement origin) throws IOException {

--- a/btrace-core/src/main/java/io/btrace/extension/processor/MethodSpec.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/MethodSpec.java
@@ -38,8 +38,7 @@ final class MethodSpec {
     this.returnType = returnType;
     this.returnTargetFqn = returnTargetFqn;
     this.paramTypes = Collections.unmodifiableList(new java.util.ArrayList<>(paramTypes));
-    this.paramTargetFqns =
-        Collections.unmodifiableList(new java.util.ArrayList<>(paramTargetFqns));
+    this.paramTargetFqns = Collections.unmodifiableList(new java.util.ArrayList<>(paramTargetFqns));
     this.isStatic = isStatic;
   }
 }

--- a/btrace-core/src/main/java/io/btrace/extension/processor/MethodSpec.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/MethodSpec.java
@@ -22,13 +22,24 @@ import java.util.List;
 final class MethodSpec {
   final String name;
   final String returnType;
+  final String returnTargetFqn;
   final List<String> paramTypes;
+  final List<String> paramTargetFqns;
   final boolean isStatic;
 
-  MethodSpec(String name, String returnType, List<String> paramTypes, boolean isStatic) {
+  MethodSpec(
+      String name,
+      String returnType,
+      String returnTargetFqn,
+      List<String> paramTypes,
+      List<String> paramTargetFqns,
+      boolean isStatic) {
     this.name = name;
     this.returnType = returnType;
+    this.returnTargetFqn = returnTargetFqn;
     this.paramTypes = Collections.unmodifiableList(new java.util.ArrayList<>(paramTypes));
+    this.paramTargetFqns =
+        Collections.unmodifiableList(new java.util.ArrayList<>(paramTargetFqns));
     this.isStatic = isStatic;
   }
 }

--- a/btrace-core/src/test/java/io/btrace/core/extensions/ExternalTypeAnnotationTest.java
+++ b/btrace-core/src/test/java/io/btrace/core/extensions/ExternalTypeAnnotationTest.java
@@ -51,4 +51,13 @@ class ExternalTypeAnnotationTest {
     Retention r = ExternalType.class.getAnnotation(Retention.class);
     assertEquals(RetentionPolicy.RUNTIME, r.value());
   }
+
+  @Test
+  void typeMarkerIsSourceOnlyOnDeclarations() {
+    Retention retention = ExternalType.Type.class.getAnnotation(Retention.class);
+    Target target = ExternalType.Type.class.getAnnotation(Target.class);
+    assertEquals(RetentionPolicy.SOURCE, retention.value());
+    assertArrayEquals(
+        new ElementType[] {ElementType.METHOD, ElementType.PARAMETER}, target.value());
+  }
 }

--- a/btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java
+++ b/btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java
@@ -460,6 +460,196 @@ class ExternalTypeProcessorTest {
   }
 
   @Test
+  void markedObjectSignaturesResolveTargetTypesAndChainWithoutContractDescriptors()
+      throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.target.Child",
+        "package com.example.target; public class Child { public String label() { return \"child\"; } }");
+    sources.put(
+        "com.example.target.Parent",
+        "package com.example.target; public class Parent { "
+            + "public Child child() { return new Child(); } "
+            + "public String replace(Child child) { return child.label(); } }");
+    sources.put(
+        "com.example.adapter.ChildApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Child\") public interface ChildApi { "
+            + "String label(); }");
+    sources.put(
+        "com.example.adapter.ParentApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Parent\") public interface ParentApi { "
+            + "@ExternalType.Type(ChildApi.class) Object child(); "
+            + "String replace(@ExternalType.Type(ChildApi.class) Object child); }");
+    CompileTestHarness.Result compiled = CompileTestHarness.compile(sources);
+    assertTrue(compiled.success, compiled.errors());
+    String adapterSource = compiled.generatedSources.get("com.example.adapter.ParentApi$Ext");
+    assertTrue(adapterSource.contains("Class.forName(\"com.example.target.Child\", false, owner.getClassLoader())"));
+    assertFalse(adapterSource.contains("ChildApi.class"), adapterSource);
+    assertFalse(adapterSource.contains("com.example.target.Child.class"), adapterSource);
+
+    CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(r.success, r.errors());
+    Object parent = r.loader.loadClass("com.example.target.Parent").getConstructor().newInstance();
+    Class<?> parentAdapter = r.loader.loadClass("com.example.adapter.ParentApi$Ext");
+    Object child = parentAdapter.getMethod("child", Object.class).invoke(null, parent);
+    Class<?> childAdapter = r.loader.loadClass("com.example.adapter.ChildApi$Ext");
+    assertEquals("child", childAdapter.getMethod("label", Object.class).invoke(null, child));
+    assertEquals(
+        "child", parentAdapter.getMethod("replace", Object.class, Object.class).invoke(null, parent, child));
+  }
+
+  @Test
+  void rejectsInvalidTargetTypeMarkerWithoutEmittingAdapter() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put("com.example.NotAContract", "package com.example; public interface NotAContract {}");
+    sources.put(
+        "com.example.BadApi",
+        "package com.example; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.Target\") public interface BadApi { "
+            + "@ExternalType.Type(NotAContract.class) Object child(); }");
+    CompileTestHarness.Result r = CompileTestHarness.compile(sources);
+    assertFalse(r.success);
+    assertTrue(r.errors().contains("must reference an interface with a non-empty @ExternalType value"));
+    assertFalse(r.generatedSources.containsKey("com.example.BadApi$Ext"));
+  }
+
+  @Test
+  void rejectsMarkersOutsideAdaptedMethodsAndNonObjectDeclarations() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.ChildApi",
+        "package com.example; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"target.Child\") public interface ChildApi { String label(); }");
+    sources.put(
+        "com.example.Outside",
+        "package com.example; import io.btrace.core.extensions.ExternalType; "
+            + "public interface Outside { @ExternalType.Type(ChildApi.class) Object child(); }");
+    sources.put(
+        "com.example.BadApi",
+        "package com.example; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"target.Parent\") public interface BadApi { "
+            + "@ExternalType.Type(ChildApi.class) String child(); "
+            + "default @ExternalType.Type(ChildApi.class) Object skipped() { return null; } }");
+    CompileTestHarness.Result r = CompileTestHarness.compile(sources);
+    assertFalse(r.success);
+    assertTrue(r.errors().contains("only valid as @ExternalType.Type(OtherContract.class) Object"));
+    assertTrue(r.errors().contains("non-static, non-default method"));
+    assertFalse(r.generatedSources.containsKey("com.example.BadApi$Ext"));
+  }
+
+  @Test
+  void markedStaticSignatureUsesOwnerDefiningLoaderForLegacyAndExplicitCalls() throws Exception {
+    Map<String, String> sources = chainSources(true);
+    CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(r.success, r.errors());
+    ChainLoader ownerLoader = new ChainLoader(r, "parent");
+    ClassLoader selectedChild =
+        new ClassLoader(ownerLoader) {
+          @Override
+          protected synchronized Class<?> loadClass(String name, boolean resolve)
+              throws ClassNotFoundException {
+            if (!"com.example.target.Child".equals(name)) return super.loadClass(name, resolve);
+            Class<?> loaded = findLoadedClass(name);
+            if (loaded == null) {
+              byte[] bytes = r.classBytes.get(name);
+              loaded = defineClass(name, bytes, 0, bytes.length);
+            }
+            if (resolve) resolveClass(loaded);
+            return loaded;
+          }
+        };
+    Class<?> adapter = r.loader.loadClass("com.example.adapter.ParentApi$Ext");
+    java.lang.reflect.Method legacy = adapter.getMethod("child");
+    java.lang.reflect.Method explicit = adapter.getMethod("child", ClassLoader.class);
+    ClassLoader saved = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(selectedChild);
+      Object legacyChild = legacy.invoke(null);
+      assertSame(ownerLoader, legacyChild.getClass().getClassLoader());
+    } finally {
+      Thread.currentThread().setContextClassLoader(saved);
+    }
+    Object explicitChild = explicit.invoke(null, selectedChild);
+    assertSame(ownerLoader, explicitChild.getClass().getClassLoader());
+  }
+
+  @Test
+  void markedChainsKeepLoaderIdentityAndRetryMissingSignatureType() throws Exception {
+    CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(chainSources(false));
+    assertTrue(r.success, r.errors());
+    ChainLoader first = new ChainLoader(r, "first");
+    ChainLoader second = new ChainLoader(r, "second");
+    Class<?> parentAdapter = r.loader.loadClass("com.example.adapter.ParentApi$Ext");
+    Class<?> childAdapter = r.loader.loadClass("com.example.adapter.ChildApi$Ext");
+    Object firstParent = first.loadClass("com.example.target.Parent").getConstructor().newInstance();
+    Object secondParent = second.loadClass("com.example.target.Parent").getConstructor().newInstance();
+    Object firstChild = parentAdapter.getMethod("child", Object.class).invoke(null, firstParent);
+    Object secondChild = parentAdapter.getMethod("child", Object.class).invoke(null, secondParent);
+    assertEquals("first", childAdapter.getMethod("label", Object.class).invoke(null, firstChild));
+    assertEquals("second", childAdapter.getMethod("label", Object.class).invoke(null, secondChild));
+    InvocationTargetException wrong =
+        assertThrows(
+            InvocationTargetException.class,
+            () ->
+                parentAdapter
+                    .getMethod("replace", Object.class, Object.class)
+                    .invoke(null, firstParent, secondChild));
+    assertTrue(
+        wrong.getCause() instanceof ClassCastException
+            || wrong.getCause() instanceof java.lang.invoke.WrongMethodTypeException);
+
+    ChainLoader missing = new ChainLoader(r, "missing");
+    missing.hideChild();
+    Object missingParent = missing.loadClass("com.example.target.Parent").getConstructor().newInstance();
+    ExternalTypeResolutionException failure =
+        assertResolutionFailure(
+            parentAdapter.getMethod("child", Object.class), missingParent, "com.example.target.Parent", "child");
+    assertInstanceOf(ClassNotFoundException.class, failure.getCause());
+    missing.showChild();
+    assertNotNull(parentAdapter.getMethod("child", Object.class).invoke(null, missingParent));
+  }
+
+  @Test
+  void markedNullReturnAndParameterPreserveOpaqueAndVirtualNullSemantics() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.target.Child",
+        "package com.example.target; public class Child { public String label() { return \"child\"; } }");
+    sources.put(
+        "com.example.target.Parent",
+        "package com.example.target; public class Parent { "
+            + "public Child nullChild() { return null; } "
+            + "public String accept(Child child) { return child == null ? \"null-ok\" : \"wrong\"; } }");
+    sources.put(
+        "com.example.adapter.ChildApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Child\") public interface ChildApi { String label(); }");
+    sources.put(
+        "com.example.adapter.ParentApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Parent\") public interface ParentApi { "
+            + "@ExternalType.Type(ChildApi.class) Object nullChild(); "
+            + "String accept(@ExternalType.Type(ChildApi.class) Object child); }");
+    CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(r.success, r.errors());
+
+    Object parent = r.loader.loadClass("com.example.target.Parent").getConstructor().newInstance();
+    Class<?> parentAdapter = r.loader.loadClass("com.example.adapter.ParentApi$Ext");
+    Class<?> childAdapter = r.loader.loadClass("com.example.adapter.ChildApi$Ext");
+    Object child = parentAdapter.getMethod("nullChild", Object.class).invoke(null, parent);
+    assertNull(child);
+    assertEquals(
+        "null-ok", parentAdapter.getMethod("accept", Object.class, Object.class).invoke(null, parent, null));
+    InvocationTargetException nullReceiver =
+        assertThrows(
+            InvocationTargetException.class,
+            () -> childAdapter.getMethod("label", Object.class).invoke(null, new Object[] {null}));
+    assertInstanceOf(NullPointerException.class, nullReceiver.getCause());
+  }
+
+  @Test
   void virtualResolutionRetriesAfterSameLoaderMakesTargetVisibleAndCachesSuccess()
       throws Exception {
     Map<String, String> sources = externalTypeSources("int value();", "return 42;");
@@ -631,6 +821,32 @@ class ExternalTypeProcessorTest {
     return externalTypeSources(apiMethod, implementation, "value");
   }
 
+  private static Map<String, String> chainSources(boolean staticParent) {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.target.Child",
+        "package com.example.target; public class Child { public String label() { return "
+            + "String.valueOf(Child.class.getClassLoader()).contains(\"first\") ? \"first\" : "
+            + "String.valueOf(Child.class.getClassLoader()).contains(\"second\") ? \"second\" : \"parent\"; } }");
+    sources.put(
+        "com.example.target.Parent",
+        "package com.example.target; public class Parent { public "
+            + (staticParent ? "static " : "")
+            + "Child child() { return new Child(); } public String replace(Child child) { return child.label(); } }");
+    sources.put(
+        "com.example.adapter.ChildApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Child\") public interface ChildApi { String label(); }");
+    sources.put(
+        "com.example.adapter.ParentApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Parent\") public interface ParentApi { "
+            + (staticParent ? "@ExternalType.Static " : "")
+            + "@ExternalType.Type(ChildApi.class) Object child(); "
+            + "String replace(@ExternalType.Type(ChildApi.class) Object child); }");
+    return sources;
+  }
+
   private static Map<String, String> externalTypeSources(
       String apiMethod, String implementation, String targetMethod) {
     Map<String, String> sources = new LinkedHashMap<>();
@@ -747,6 +963,57 @@ class ExternalTypeProcessorTest {
         targetLoads++;
         if (!visible) throw new ClassNotFoundException(name);
       }
+      Class<?> loaded = findLoadedClass(name);
+      if (loaded == null) {
+        byte[] bytes = classBytes.get(name);
+        loaded = defineClass(name, bytes, 0, bytes.length);
+      }
+      if (resolve) resolveClass(loaded);
+      return loaded;
+    }
+  }
+
+  private static final class ChainLoader extends ClassLoader {
+    private final Map<String, byte[]> classBytes;
+    private final String id;
+    private boolean childVisible = true;
+
+    ChainLoader(CompileTestHarness.RunnableResult result, String id) {
+      super(result.loader);
+      classBytes = result.classBytes;
+      this.id = id;
+    }
+
+    void hideChild() {
+      childVisible = false;
+    }
+
+    void showChild() {
+      childVisible = true;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      throw new AssertionError("adapter cache must not call ClassLoader.equals");
+    }
+
+    @Override
+    public int hashCode() {
+      throw new AssertionError("adapter cache must not call ClassLoader.hashCode");
+    }
+
+    @Override
+    public String toString() {
+      return id;
+    }
+
+    @Override
+    protected synchronized Class<?> loadClass(String name, boolean resolve)
+        throws ClassNotFoundException {
+      if (!"com.example.target.Parent".equals(name) && !"com.example.target.Child".equals(name)) {
+        return super.loadClass(name, resolve);
+      }
+      if ("com.example.target.Child".equals(name) && !childVisible) throw new ClassNotFoundException(name);
       Class<?> loaded = findLoadedClass(name);
       if (loaded == null) {
         byte[] bytes = classBytes.get(name);

--- a/btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java
+++ b/btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java
@@ -485,7 +485,9 @@ class ExternalTypeProcessorTest {
     CompileTestHarness.Result compiled = CompileTestHarness.compile(sources);
     assertTrue(compiled.success, compiled.errors());
     String adapterSource = compiled.generatedSources.get("com.example.adapter.ParentApi$Ext");
-    assertTrue(adapterSource.contains("Class.forName(\"com.example.target.Child\", false, owner.getClassLoader())"));
+    assertTrue(
+        adapterSource.contains(
+            "Class.forName(\"com.example.target.Child\", false, owner.getClassLoader())"));
     assertFalse(adapterSource.contains("ChildApi.class"), adapterSource);
     assertFalse(adapterSource.contains("com.example.target.Child.class"), adapterSource);
 
@@ -497,13 +499,15 @@ class ExternalTypeProcessorTest {
     Class<?> childAdapter = r.loader.loadClass("com.example.adapter.ChildApi$Ext");
     assertEquals("child", childAdapter.getMethod("label", Object.class).invoke(null, child));
     assertEquals(
-        "child", parentAdapter.getMethod("replace", Object.class, Object.class).invoke(null, parent, child));
+        "child",
+        parentAdapter.getMethod("replace", Object.class, Object.class).invoke(null, parent, child));
   }
 
   @Test
   void rejectsInvalidTargetTypeMarkerWithoutEmittingAdapter() throws Exception {
     Map<String, String> sources = new LinkedHashMap<>();
-    sources.put("com.example.NotAContract", "package com.example; public interface NotAContract {}");
+    sources.put(
+        "com.example.NotAContract", "package com.example; public interface NotAContract {}");
     sources.put(
         "com.example.BadApi",
         "package com.example; import io.btrace.core.extensions.ExternalType; "
@@ -511,7 +515,8 @@ class ExternalTypeProcessorTest {
             + "@ExternalType.Type(NotAContract.class) Object child(); }");
     CompileTestHarness.Result r = CompileTestHarness.compile(sources);
     assertFalse(r.success);
-    assertTrue(r.errors().contains("must reference an interface with a non-empty @ExternalType value"));
+    assertTrue(
+        r.errors().contains("must reference an interface with a non-empty @ExternalType value"));
     assertFalse(r.generatedSources.containsKey("com.example.BadApi$Ext"));
   }
 
@@ -583,8 +588,10 @@ class ExternalTypeProcessorTest {
     ChainLoader second = new ChainLoader(r, "second");
     Class<?> parentAdapter = r.loader.loadClass("com.example.adapter.ParentApi$Ext");
     Class<?> childAdapter = r.loader.loadClass("com.example.adapter.ChildApi$Ext");
-    Object firstParent = first.loadClass("com.example.target.Parent").getConstructor().newInstance();
-    Object secondParent = second.loadClass("com.example.target.Parent").getConstructor().newInstance();
+    Object firstParent =
+        first.loadClass("com.example.target.Parent").getConstructor().newInstance();
+    Object secondParent =
+        second.loadClass("com.example.target.Parent").getConstructor().newInstance();
     Object firstChild = parentAdapter.getMethod("child", Object.class).invoke(null, firstParent);
     Object secondChild = parentAdapter.getMethod("child", Object.class).invoke(null, secondParent);
     assertEquals("first", childAdapter.getMethod("label", Object.class).invoke(null, firstChild));
@@ -602,10 +609,14 @@ class ExternalTypeProcessorTest {
 
     ChainLoader missing = new ChainLoader(r, "missing");
     missing.hideChild();
-    Object missingParent = missing.loadClass("com.example.target.Parent").getConstructor().newInstance();
+    Object missingParent =
+        missing.loadClass("com.example.target.Parent").getConstructor().newInstance();
     ExternalTypeResolutionException failure =
         assertResolutionFailure(
-            parentAdapter.getMethod("child", Object.class), missingParent, "com.example.target.Parent", "child");
+            parentAdapter.getMethod("child", Object.class),
+            missingParent,
+            "com.example.target.Parent",
+            "child");
     assertInstanceOf(ClassNotFoundException.class, failure.getCause());
     missing.showChild();
     assertNotNull(parentAdapter.getMethod("child", Object.class).invoke(null, missingParent));
@@ -641,7 +652,8 @@ class ExternalTypeProcessorTest {
     Object child = parentAdapter.getMethod("nullChild", Object.class).invoke(null, parent);
     assertNull(child);
     assertEquals(
-        "null-ok", parentAdapter.getMethod("accept", Object.class, Object.class).invoke(null, parent, null));
+        "null-ok",
+        parentAdapter.getMethod("accept", Object.class, Object.class).invoke(null, parent, null));
     InvocationTargetException nullReceiver =
         assertThrows(
             InvocationTargetException.class,
@@ -1013,7 +1025,8 @@ class ExternalTypeProcessorTest {
       if (!"com.example.target.Parent".equals(name) && !"com.example.target.Child".equals(name)) {
         return super.loadClass(name, resolve);
       }
-      if ("com.example.target.Child".equals(name) && !childVisible) throw new ClassNotFoundException(name);
+      if ("com.example.target.Child".equals(name) && !childVisible)
+        throw new ClassNotFoundException(name);
       Class<?> loaded = findLoadedClass(name);
       if (loaded == null) {
         byte[] bytes = classBytes.get(name);

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/ChildApi.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/ChildApi.java
@@ -1,0 +1,8 @@
+package example;
+
+import io.btrace.core.extensions.ExternalType;
+
+@ExternalType("example.target.ExternalChild")
+public interface ChildApi {
+  String marker();
+}

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/ExternalTypeSmoke.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/ExternalTypeSmoke.java
@@ -1,0 +1,14 @@
+package example;
+
+import java.lang.reflect.Constructor;
+
+public final class ExternalTypeSmoke {
+  private ExternalTypeSmoke() {}
+
+  public static void main(String[] args) throws Exception {
+    Class<?> parentType = Class.forName("example.target.ExternalParent");
+    Constructor<?> constructor = parentType.getConstructor();
+    Object child = ParentApi$Ext.child(constructor.newInstance());
+    System.out.println(ChildApi$Ext.marker(child));
+  }
+}

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/ParentApi.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/ParentApi.java
@@ -1,0 +1,9 @@
+package example;
+
+import io.btrace.core.extensions.ExternalType;
+
+@ExternalType("example.target.ExternalParent")
+public interface ParentApi {
+  @ExternalType.Type(ChildApi.class)
+  Object child();
+}

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalApi.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalApi.java
@@ -1,9 +1,0 @@
-package example;
-
-import io.btrace.core.extensions.ExternalType;
-
-@ExternalType("example.target.ExternalTarget")
-public interface ExternalApi {
-  @ExternalType.Static
-  String marker();
-}

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalTarget.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalTarget.java
@@ -1,9 +1,0 @@
-package example.target;
-
-public final class ExternalTarget {
-  private ExternalTarget() {}
-
-  public static String marker() {
-    return "external-type-explicit-ok";
-  }
-}

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalTypeSmoke.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/src/example/ExternalTypeSmoke.java
@@ -1,9 +1,0 @@
-package example;
-
-public final class ExternalTypeSmoke {
-  private ExternalTypeSmoke() {}
-
-  public static void main(String[] args) {
-    System.out.println(ExternalApi$Ext.marker(ExternalTypeSmoke.class.getClassLoader()));
-  }
-}

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/target-src/example/target/ExternalChild.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/target-src/example/target/ExternalChild.java
@@ -1,0 +1,7 @@
+package example.target;
+
+public final class ExternalChild {
+  public String marker() {
+    return "external-type-chain-ok";
+  }
+}

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/target-src/example/target/ExternalParent.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/target-src/example/target/ExternalParent.java
@@ -1,0 +1,7 @@
+package example.target;
+
+public final class ExternalParent {
+  public ExternalChild child() {
+    return new ExternalChild();
+  }
+}

--- a/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalChildType.java
+++ b/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalChildType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2008, 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.btrace.test.ext;
+
+import io.btrace.core.extensions.ExternalType;
+
+/** External contract for the application-only nested child type. */
+@ExternalType("resources.ExternalChild")
+public interface ExternalChildType {
+  String marker();
+}

--- a/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalDataType.java
+++ b/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalDataType.java
@@ -27,6 +27,13 @@ public interface ExternalDataType {
   /** Maps to ExternalData.value() — virtual dispatch. */
   int value();
 
+  /** Maps to ExternalData.child() while retaining an opaque Object adapter boundary. */
+  @ExternalType.Type(ExternalChildType.class)
+  Object child();
+
+  /** Maps to ExternalData.acceptChild(ExternalChild) through an opaque Object boundary. */
+  String acceptChild(@ExternalType.Type(ExternalChildType.class) Object child);
+
   /** Maps to ExternalData.tag() — static dispatch via TCCL. */
   @ExternalType.Static
   String tag();

--- a/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestService.java
+++ b/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestService.java
@@ -27,6 +27,12 @@ public interface ExternalTypeTestService {
   /** Returns the static tag using the supplied target object's defining loader. */
   String explicitTag(Object externalData);
 
+  /** Chains the opaque ExternalData child result into the child adapter. */
+  String childMarker(Object externalData);
+
+  /** Passes an opaque child back through a target-type adapter parameter. */
+  String acceptedChildMarker(Object externalData);
+
   /**
    * Returns the instance value from an resources.ExternalData object via its @ExternalType adapter.
    */

--- a/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestServiceImpl.java
+++ b/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestServiceImpl.java
@@ -34,6 +34,18 @@ public final class ExternalTypeTestServiceImpl extends Extension
   }
 
   @Override
+  public String childMarker(Object externalData) {
+    Object child = ExternalDataType$Ext.child(externalData);
+    return ExternalChildType$Ext.marker(child);
+  }
+
+  @Override
+  public String acceptedChildMarker(Object externalData) {
+    Object child = ExternalDataType$Ext.child(externalData);
+    return ExternalDataType$Ext.acceptChild(externalData, child);
+  }
+
+  @Override
   public int value(Object externalData) {
     return ExternalDataType$Ext.value(externalData);
   }

--- a/docs/BTraceExtensionDevelopmentGuide.md
+++ b/docs/BTraceExtensionDevelopmentGuide.md
@@ -217,11 +217,35 @@ try {
 }
 ```
 
+For a public target method whose direct signature contains another application type, link it to a
+second external contract while keeping the generated API opaque:
+
+```java
+@ExternalType("vendor.Child")
+interface ChildApi {
+    String label();
+}
+
+@ExternalType("vendor.Parent")
+interface ParentApi {
+    @ExternalType.Type(ChildApi.class)
+    Object child();
+}
+
+Object child = ParentApi$Ext.child(parent);
+String label = ChildApi$Ext.label(child);
+```
+
+The contracts are processor metadata only: `child` remains an `Object` and does not implement
+`ChildApi`. The adapter resolves `vendor.Child` through the already-resolved parent's defining
+loader to form the exact method type. A same-name object from another loader fails normally rather
+than being coerced; null target values are passed through unchanged.
+
 ### Rules
 
 - **Target:** interfaces only (`ElementType.TYPE`). The processor emits a compile error for classes.
 - **Annotation value:** non-empty fully-qualified class name. Empty string is a compile error.
-- **Method types:** declared erased parameter and return types must exactly match the target member's JVM signature. Use `Object` only when the target member itself uses `Object`; it is not a coercion escape hatch for target-only types.
+- **Method types:** declared erased parameter and return types must exactly match the target member's JVM signature. For a direct target-library position, use `@ExternalType.Type(ChildApi.class) Object`; it keeps the adapter boundary opaque while resolving the child's target class from the resolved owner's defining loader. The returned value does not implement `ChildApi`, but can flow into `ChildApi$Ext` directly. Markers are valid only on direct `Object` returns/parameters, not generic elements or arrays.
 - **Access:** dispatch uses `MethodHandles.publicLookup()`. Only public members of public, accessible types are supported; do not add module-opening flags implicitly.
 - **Static methods:** add `@ExternalType.Static` on the interface method. `version()` preserves legacy TCCL-based class loading with the documented null-TCCL system-loader fallback. `version(ClassLoader applicationLoader)` resolves with that non-null loader exactly; it rejects null immediately with `NullPointerException("applicationLoader")`. The control argument is not a target argument. Neither form changes the target's observed TCCL.
 - **Default methods and static interface methods:** skipped (they already have bodies).
@@ -234,7 +258,8 @@ Use generated adapters only for the supported row below. The manual path is the 
 | Capability | Phase 1 support | Author action |
 |---------|--------|-------------------|
 | Public, uniquely named static or virtual methods with exact erased signatures | Supported | Use `@ExternalType`; use `Object` only where the target member itself uses `Object`. |
-| A target method with target-library parameter or return types | Unsupported | Use `ClassLoadingUtil` and `MethodHandleCache` directly. |
+| A direct target-library `Object` parameter or return type | Supported | Mark it with `@ExternalType.Type(OtherContract.class) Object`; chain opaque results into another generated adapter. |
+| Target types in generic elements or arrays | Unsupported | Use `ClassLoadingUtil` and `MethodHandleCache` directly. |
 | Overloads | Unsupported; processor error | Use `MethodHandleCache` with the exact return and parameter `Class` values. |
 | Fields, constructors, `instanceof`, and casts | Unsupported | Use `ClassLoadingUtil` plus the appropriate direct `MethodHandles.publicLookup()` or `Class` operation. `MethodHandleCache` caches virtual and static method lookups only. |
 | Non-public or non-exported named-module members | Unsupported | Use a public supported API or explicitly configure the target JVM outside BTrace. |

--- a/docs/BTraceExtensionDevelopmentGuide.md
+++ b/docs/BTraceExtensionDevelopmentGuide.md
@@ -241,6 +241,13 @@ The contracts are processor metadata only: `child` remains an `Object` and does 
 loader to form the exact method type. A same-name object from another loader fails normally rather
 than being coerced; null target values are passed through unchanged.
 
+This explicit `Object` boundary is intentional, even though it is a little more verbose. Declaring
+`ChildApi` as the return type would falsely promise that the target's `vendor.Child` object
+implements that extension-side interface; a Java cast would then fail. Hiding the conversion would
+require rewriting every extension call site or introducing wrappers/proxies, which would add
+class-loader, identity, and lifecycle problems. The marker supplies the exact lookup type while
+keeping the runtime value honest and directly usable by another generated adapter.
+
 ### Rules
 
 - **Target:** interfaces only (`ElementType.TYPE`). The processor emits a compile error for classes.

--- a/docs/architecture/provided-style-extensions.md
+++ b/docs/architecture/provided-style-extensions.md
@@ -68,7 +68,7 @@ public final class SparkApiImpl implements SparkApi {
 
 ## External Type Adapters
 
-`@ExternalType` is useful for public, uniquely named methods with exact erased signatures. The normative support table, failure contract, and virtual-defining-loader/static-loader-selection distinction are in the [Extension Development Guide](../BTraceExtensionDevelopmentGuide.md#app-type-adapters-with-externaltype). Keep the manual pattern in this guide for target-only types, overloads, fields, constructors, and type predicates.
+`@ExternalType` supports public, uniquely named methods with exact erased signatures, including direct opaque target-type positions declared as `@ExternalType.Type(ChildApi.class) Object`. The normative support table, owner-defining-loader chain semantics, failure contract, and virtual-defining-loader/static-loader-selection distinction are in the [Extension Development Guide](../BTraceExtensionDevelopmentGuide.md#app-type-adapters-with-externaltype). Keep the manual pattern in this guide for target types in generic elements/arrays, overloads, fields, constructors, and type predicates.
 
 For a generated static target call where the application loader is known, pass it directly:
 

--- a/integration-tests/src/test/btrace/ExternalTypeAdapterTest.java
+++ b/integration-tests/src/test/btrace/ExternalTypeAdapterTest.java
@@ -25,6 +25,8 @@ public class ExternalTypeAdapterTest {
     if (data == null) return;
     println("tag=" + extSvc.tag());
     println("value=" + extSvc.value(data));
+    println("child=" + extSvc.childMarker(data));
+    println("accepted-child=" + extSvc.acceptedChildMarker(data));
     exit(0);
   }
 }

--- a/integration-tests/src/test/java/resources/ExternalChild.java
+++ b/integration-tests/src/test/java/resources/ExternalChild.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2008, 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package resources;
+
+/** Application-only child type used by the external type adapter chain test. */
+public final class ExternalChild {
+  public String marker() {
+    return "ext-child-chain-ok";
+  }
+}

--- a/integration-tests/src/test/java/resources/ExternalData.java
+++ b/integration-tests/src/test/java/resources/ExternalData.java
@@ -33,6 +33,14 @@ public final class ExternalData {
     return value;
   }
 
+  public ExternalChild child() {
+    return new ExternalChild();
+  }
+
+  public String acceptChild(ExternalChild child) {
+    return child != null ? child.marker() : "ext-child-parameter-null";
+  }
+
   public static String tag() {
     return "ext-data-ok";
   }

--- a/integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java
+++ b/integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java
@@ -61,7 +61,11 @@ public class ExternalTypeAdapterIntegrationTest extends RuntimeTest {
     testDynamic(
         "resources.Main",
         "btrace/ExternalTypeAdapterTest.java",
-        Completion.untilContains("tag=ext-data-ok", "value=42"),
+        Completion.untilContains(
+            "tag=ext-data-ok",
+            "value=42",
+            "child=ext-child-chain-ok",
+            "accepted-child=ext-child-chain-ok"),
         new ResultValidator() {
           @Override
           public void validate(String stdout, String stderr, int retcode, String jfrFile) {
@@ -73,6 +77,12 @@ public class ExternalTypeAdapterIntegrationTest extends RuntimeTest {
             assertTrue(
                 stdout.contains("value=42"),
                 "@ExternalType virtual dispatch failed. stdout: " + stdout);
+            assertTrue(
+                stdout.contains("child=ext-child-chain-ok"),
+                "@ExternalType target-type chain failed. stdout: " + stdout);
+            assertTrue(
+                stdout.contains("accepted-child=ext-child-chain-ok"),
+                "@ExternalType target-type parameter dispatch failed. stdout: " + stdout);
           }
         });
   }

--- a/internal/plans/2026-08-07-issue-931-phase-3-target-type-signatures-plan.md
+++ b/internal/plans/2026-08-07-issue-931-phase-3-target-type-signatures-plan.md
@@ -1,0 +1,182 @@
+# Issue #931 — Phase 3 implementation plan: target-type signatures and chains
+
+**Design input:** `internal/specs/2026-08-07-issue-931-phase-3-target-type-signatures.md` (CLEAN)
+**Baseline:** `a6a7ed57` on `issue-931-target-type-signatures`
+**Scope:** Phase 3 only. Add direct target-type lookup metadata and opaque chained calls without changing Phase 1/2 loader policies or beginning overload, field, constructor, cast, predicate, private-access, or JPMS work.
+
+## Fixed implementation decisions
+
+- Add source-retained `@ExternalType.Type(OtherContract.class)` with `{METHOD, PARAMETER}` targets. It is valid only as a direct `Object` method-return or formal-parameter declaration annotation of an adapted interface method. The Java source form remains `@Type(Other.class) Object child()` / `void set(@Type(Other.class) Object child)`; the referenced contract must itself be a non-empty `@ExternalType` interface.
+- Keep generated public Java boundaries and JVM descriptors `Object`. The referenced contract is processor-only metadata: generated adapters must not use its `.class`, name it in a public signature/field, or cast target values to it.
+- Resolve marked target classes only by `Class.forName(fqn, false, owner.getClassLoader())`, after resolving the owner and before the exact `MethodType`/public lookup. Do not use TCCL, a Phase 2 explicit loader, an extension loader, or fallback search for a marked type.
+- Preserve Phase 2 static forms and shared cache exactly. A legacy or explicit static invocation first resolves its owner with its existing policy; marked types then resolve through that owner’s defining loader. No second type cache, FQN-only map, strong loader key, or Type runtime helper is permitted.
+- Claim `ExternalType.Type` in addition to outer `ExternalType` and inspect every `METHOD`/`PARAMETER` declaration marker returned by `RoundEnvironment`. Every invalid/unconsumed declaration marker produces exactly one source-positioned diagnostic; a valid direct marker produces no duplicate diagnostic. Generic/array-component/local/cast/new type-use misuse is a javac applicability error, and duplicate annotations are javac's native non-repeatable error.
+
+## Ordered, gated work
+
+- [ ] **1. Establish the bounded baseline.**
+
+  Preserve the untracked design specification and unrelated files in `/private/tmp/btrace-issue-931-phase3`. Read the clean design, `AGENTS.md`, `docs/architecture/MaskedJarArchitecture.md`, Phase 2 `AdapterEmitter`, `ExternalTypeProcessor`, `MethodSpec`, `CompileTestHarness`, staged integration fixtures, and existing external processor smoke resources before edits.
+
+  Explicitly exclude array/generic-element markers, target types in fields/constructors/casts/predicates, overload selectors, wrappers/proxies, `MethodHandleCache` changes, target classpath dependencies, TCCL mutation/fallback, private lookup, module alteration, and Gradle DSL work.
+
+  **Stop:** If an implementation would expose a target-library or contract-interface class in a generated public descriptor, needs a wrapper, or cannot preserve every Phase 2 static method descriptor, return to design review.
+
+- [ ] **2. Add the Java-8 source annotation and processor support.**
+
+  Update `btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java`:
+
+  - add public nested `ExternalType.Type` with `@Retention(RetentionPolicy.SOURCE)`, `@Target({ElementType.METHOD, ElementType.PARAMETER})`, and `Class<?> value()`;
+  - document that it marks a direct `Object` signature position with another `@ExternalType` contract, does not make the runtime value implement that interface, and is consumed only by the processor;
+  - retain outer `ExternalType` and `ExternalType.Static` behaviour/retention unchanged.
+
+  Update `btrace-core/src/main/java/io/btrace/extension/processor/ExternalTypeProcessor.java` to support both canonical annotation names through `@SupportedAnnotationTypes`. Do not alter Gradle processor registration. Use `AnnotationMirror`/`AnnotationValue` plus `TypeMirror`, not reflective access to `Class<?>` annotation values.
+
+  **Gate:** A source using only an invalid `@ExternalType.Type` causes this processor to run and reports its own diagnostic; an external source can compile a valid marker once the published masked JAR is rebuilt.
+
+- [ ] **3. Implement complete marker discovery and validation before adapter emission.**
+
+  In `ExternalTypeProcessor.java`, introduce focused private declaration-marker helpers rather than widening the public API. The process flow must:
+
+  1. Discover candidates from `roundEnv.getElementsAnnotatedWith(ExternalType.Type.class)`. This is exhaustive under the chosen `METHOD`/`PARAMETER` targets; body-local/cast/new type-use attempts are rejected by javac before processor handling.
+  2. While building a valid outer-`ExternalType` method spec, consume a marker only when its annotated `ExecutableElement` return or `VariableElement` formal parameter has direct erased `java.lang.Object` type. Decode the class-valued marker element to a `TypeMirror`; verify interface kind and non-empty outer `ExternalType.value`; retain the referenced target FQN and source position.
+  3. After all adapted methods are processed, emit one clear, source-positioned error for each marker not consumed: outside an adapted interface, on a skipped default/static method, or on a non-`Object` return/parameter declaration. Avoid a second catch-all error for a marker already consumed or directly diagnosed.
+  4. Let javac diagnose repeated `Type` annotations as non-repeatable. Let javac reject generic-argument, array-component, local, cast, and `new` type-use placements because `Type` is not applicable there. Retain existing duplicate-method-name overload diagnostics and ordinary generic-erasure behaviour.
+  5. If any processor-owned marker error makes an interface invalid, do not emit that interface’s adapter.
+
+  The diagnostics must tell an author the permitted form, `@ExternalType.Type(OtherContract.class) Object`, and identify why the marker is invalid. Do not silently ignore unsupported placements.
+
+  **Gate:** Valid direct markers are consumed exactly once and stay diagnostic-free; malformed declarations have one processor diagnostic/no partial adapter; repeated/type-use misuse fixtures assert javac's native diagnostics rather than a processor duplicate diagnostic.
+
+- [ ] **4. Carry lookup metadata through emission without changing public adapter types.**
+
+  Refactor `btrace-core/src/main/java/io/btrace/extension/processor/MethodSpec.java` to model each return/parameter position as an emitted Java erased type plus lookup metadata: either the existing literal-ready erased type or a target FQN sourced from `ExternalType.Type`. Update `AdapterSpec.java` only if a small immutable type-position model needs placement there; preserve its adapter name/package behaviour.
+
+  Update `AdapterEmitter.java` so `methodTypeLiteral` becomes owner-aware generated construction for marked positions. In each existing `ClassValue<ResolvedCall>.computeValue`:
+
+  - retain the current owner resolution policy, then load each marked target FQN with `Class.forName(fqn, false, owner.getClassLoader())`;
+  - build the exact `MethodType` using that resolved class for marked return/parameter positions and existing `.class` literals for all other positions;
+  - preserve `findVirtual`/`findStatic`, `publicLookup`, resolution-attempt counter, exception wrapping, `sneak`, and target invocation behaviour;
+  - emit `Object` for every marked dispatcher return/argument and invoke the handle with those opaque values. It must not emit `OtherContract.class`, `target.package.Type.class`, a contract cast, or a wrapper.
+
+  For static members, leave `$resolveStatic(ClassLoader)`, `$legacyStaticLoader()`, null checking, monitor, weak loader index, and successful-only insertion intact. The shared resolver obtains the owner first; its owner-keyed `ClassValue` computation resolves target signature types through `owner.getClassLoader()`. For virtual members, preserve the existing receiver-keyed `ClassValue` and resolve types from the resolved owner rather than independently from the receiver/TCCL.
+
+  **Gate:** Existing unmarked generated source remains semantically identical; a marked generated source visibly declares `Object` boundary types but contains owner-loader `Class.forName` lookup for the target FQN. The only new published source API is the nested annotation.
+
+- [ ] **5. Add focused processor, runtime, failure, and isolation coverage.**
+
+  Extend `btrace-core/src/test/java/io/btrace/core/extensions/ExternalTypeAnnotationTest.java` for `Type` retention/target/value, and extend `btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java`. Extend `CompileTestHarness.java` only when an in-memory class-byte/loader fixture cannot express a case. Keep current Phase 1/2 tests intact.
+
+  Add fixtures/tests for:
+
+  1. **Source and API shape:** parent/child contracts with marked direct return and parameter positions compile. Generated declarations/reflection are `Object`-based; generated source contains no `ChildApi.class`/`ChildApi` signature and no target `Child.class` literal, while its generated `MethodType` resolves the target FQN. The normal `Object` contract remains an exact `Object` lookup.
+  2. **Validation scan:** invalid non-contract reference, empty target contract, marker outside an adapted contract, marker on a default/static interface method, and non-`Object` declaration each fail with one useful processor diagnostic and no generated adapter. A valid direct marker must compile without a duplicate processor diagnostic. Separately assert javac's native non-repeatable diagnostic for duplicate markers and native annotation-target applicability diagnostics for generic-argument, array-component, local, cast, and `new` type-use misuse. Retain the current duplicate-method-name error.
+  3. **Virtual chain:** an isolated parent returns a child and accepts a child; `ParentApi$Ext.child(parent)` feeds `ChildApi$Ext.label(child)` and `ParentApi$Ext.replaceChild(parent, child)`. The target classes exist only in the in-memory application loader, not as extension compile-time types.
+  4. **Same-name loader identity:** two hostile isolated loaders define identical parent/child FQNs but return loader-specific markers. Each chain succeeds only within its own loader; passing loader-B child to loader-A parent fails transparently. Hostile `equals`/`hashCode` must never be called.
+  5. **Owner-defining-loader type selection:** a selected static child loader delegates parent owner resolution to a parent loader while exposing a conflicting same-FQN child itself. Both legacy-TCCL and explicit-loader forms must resolve the signature child through the owner parent loader. Assert the target member succeeds only with that identity and the explicit control loader is absent from generated `MethodType`/invoke arguments.
+  6. **Null and retry:** a marked return null propagates; a marked null parameter reaches the target after signature resolution; using null as a virtual chained receiver preserves the current NPE. A mutable loader initially hides the marked child class, producing `ExternalTypeResolutionException` with `ClassNotFoundException`, then exposes it and succeeds on the same loader with no negative cache. Preserve missing-member/access and target-thrown-exception tests.
+  7. **Regression/negative evidence:** malformed marker fixtures must be run as assertions, not merely compiled as incidental sources. Record that the new direct-marker runtime test cannot pass against the pre-Phase-3 processor/emitter, and ensure every new positive case has a rejected input, wrong-loader, missing-type, or cross-loader counterexample that proves the check can fail.
+
+  **Stop:** Do not relax a failing test by accepting `ChildApi` in an adapter signature, looking up a target type through a different loader, caching a failed type resolution, or wrapping a target object.
+
+- [ ] **6. Add the real staged extension/client/agent/target chain.**
+
+  Preserve `integration-tests/build.gradle` staging and its release-isolation assertion. Modify only the relevant fixtures:
+
+  - add `integration-tests/src/test/java/resources/ExternalChild.java` as the application-only child target;
+  - extend `integration-tests/src/test/java/resources/ExternalData.java` with a public method returning that child and, if needed, a public method accepting it to exercise an annotated parameter;
+  - extend `btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalDataType.java` with `@ExternalType.Type(ExternalChildType.class) Object child()` (and marked direct parameter only if used);
+  - add `ExternalChildType.java` under the same extension source directory, annotated for the child target and exposing its public virtual marker method;
+  - extend `ExternalTypeTestService.java` and `ExternalTypeTestServiceImpl.java` with a method that chains the two generated adapters while accepting/returning only `Object` at the service boundary;
+  - extend `integration-tests/src/test/btrace/ExternalTypeAdapterTest.java` and `ExternalTypeAdapterIntegrationTest.java` to emit, wait for, and assert the target-owned chained marker.
+
+  Keep the current `ExternalTypeAdapterExplicitTest.java` and explicit-loader integration test independent: its deterministic decoy TCCL continues to test Phase 2 only. Keep the legacy static/virtual scenario’s current `tag` and `value` markers while adding the chain marker to that scenario, rather than mixing it with the explicit TCCL assumptions.
+
+  **Gate:** The external child is absent from the extension compile classpath; the real staged extension, client, agent, target JVM, instrumentation, and protocol produce the nested marker; `btrace-ext-test` remains absent from release extensions.
+
+- [ ] **7. Make the masked-JAR proof genuinely two-stage.**
+
+  Replace the flat inputs beneath `btrace-dist/src/test/resources/external-type-processor-smoke/` with deliberately separated resource trees, for example:
+
+  - `target-src/example/target/ExternalParent.java` and `ExternalChild.java`, compiled into runtime-only classes without BTrace;
+  - `extension-src/example/ParentApi.java`, `ChildApi.java`, and `ExternalTypeSmoke.java`, compiled in a separate invocation with no target sources/classes on its classpath.
+
+  The driver must call a generated static or virtual parent adapter and then a child adapter, printing a stable chain marker. The extension source declares only `Object` at marked positions and references only the contract interface in `@ExternalType.Type`; it must never import a target source type.
+
+  After clean `:btrace-dist:btraceJar`, inspect the one versioned `btrace.jar` for root-visible `ExternalType.class`, `ExternalType$Type.class`, `ExternalTypeResolutionException.class`, `ExternalTypeProcessor.class`, processor support, and the processor service entry. Then:
+
+  1. compile only `target-src` with `javac --release 8` into `$SMOKE/target-classes`, with no BTrace dependency;
+  2. compile only `extension-src` with `javac --release 8` into `$SMOKE/extension-classes` and generated source using the masked JAR as both `-cp` and `-processorpath`; target source/class paths must be absent;
+  3. assert generated `ParentApi$Ext.java`/`ChildApi$Ext.java` and classes exist, their public declarations use `Object`, and generated source does not contain `ChildApi.class`, `ParentApi.class`, `example.target.ExternalChild.class`, or `example.target.ExternalParent.class`;
+  4. run with exactly extension classes, target classes, and masked JAR, then assert the stable marker.
+
+  Do not alter `btrace-dist/build.gradle` or package a test extension unless inspection proves a particular annotation/service/processor class is missing. Rebuild clean and repeat every inspection/compile/run step after any narrow packaging correction.
+
+  **Stop:** If target sources/classes leak into the contracts compilation classpath, if the proof uses `btrace-core` output/extension implementation JAR, or if it needs broad masked-JAR exposure, stop for distribution compatibility review.
+
+- [ ] **8. Consolidate the user documentation.**
+
+  Update `docs/BTraceExtensionDevelopmentGuide.md` as the normative contract. Add the exact `@ExternalType.Type(ChildApi.class) Object` example, explain direct-position-only validation, opaque `Object` public boundary, owner-defining-loader resolution, nesting/chaining, null behaviour, same-name loader identity, retry/failure contract, and the continuing Phase 2 legacy/explicit static distinction. State that generic elements/arrays and later operation families remain unsupported; preserve public-lookup/module rules.
+
+  Update `docs/architecture/provided-style-extensions.md` to point to the canonical explanation and retain manual linking for unsupported generic/array, overload, fields/constructors, casts/predicates, and access needs. Do not duplicate the complete support table. Touch `BTraceTutorial.md` or `GettingStarted.md` only if a targeted search finds a contradictory target-type claim.
+
+  **Gate:** Documentation never says that a target object implements its contract interface, never promises generic-element/array support, and contains no generated-adapter workaround that changes TCCL or guesses a loader.
+
+- [ ] **9. Run verification in dependency order and review the release surface.**
+
+  All Gradle commands run from `/private/tmp/btrace-issue-931-phase3` with a worktree-local cache, redirect before reading, and stop on nonzero exit, `BUILD FAILED`, a test/format failure, missing artifact entry, compiler diagnostic mismatch, or wrong integration marker. Build distribution before integration. On the documented address-selection failure only, rerun the affected command with `JAVA_TOOL_OPTIONS="-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false"`.
+
+  ```bash
+  GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-core:test > /tmp/btrace-issue-931-phase3-core-test.log 2>&1
+  rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|ExternalType" /tmp/btrace-issue-931-phase3-core-test.log
+
+  GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-core:spotlessCheck > /tmp/btrace-issue-931-phase3-core-spotless.log 2>&1
+  rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase3-core-spotless.log
+
+  GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew clean :btrace-dist:btraceJar > /tmp/btrace-issue-931-phase3-masked-jar.log 2>&1
+  rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|btraceJar" /tmp/btrace-issue-931-phase3-masked-jar.log
+
+  rg --files btrace-dist/build/resources/main | rg '^btrace-dist/build/resources/main/v[^/]+/libs/btrace\.jar$' > /tmp/btrace-issue-931-phase3-jar-path.log
+  test "$(rg -c '^' /tmp/btrace-issue-931-phase3-jar-path.log)" = 1
+  BTRACE_931_PHASE3_JAR="$(rg -x 'btrace-dist/build/resources/main/v[^/]+/libs/btrace\.jar' /tmp/btrace-issue-931-phase3-jar-path.log)"
+  jar tf "$BTRACE_931_PHASE3_JAR" > /tmp/btrace-issue-931-phase3-jar-entries.log
+  rg -n 'io/btrace/core/extensions/ExternalType(\$Type|ResolutionException)?\.class|io/btrace/extension/processor/ExternalTypeProcessor\.class|io/btrace/extension/processor/|META-INF/services/javax.annotation.processing.Processor' /tmp/btrace-issue-931-phase3-jar-entries.log
+  unzip -p "$BTRACE_931_PHASE3_JAR" META-INF/services/javax.annotation.processing.Processor > /tmp/btrace-issue-931-phase3-processor-service.log
+  rg -n '^io\.btrace\.extension\.processor\.ExternalTypeProcessor$' /tmp/btrace-issue-931-phase3-processor-service.log
+
+  BTRACE_931_PHASE3_SMOKE=$(mktemp -d /tmp/btrace-issue-931-phase3-smoke.XXXXXX)
+  mkdir -p "$BTRACE_931_PHASE3_SMOKE/target-classes" "$BTRACE_931_PHASE3_SMOKE/extension-classes" "$BTRACE_931_PHASE3_SMOKE/generated"
+  javac --release 8 -d "$BTRACE_931_PHASE3_SMOKE/target-classes" btrace-dist/src/test/resources/external-type-processor-smoke/target-src/example/target/*.java > /tmp/btrace-issue-931-phase3-target-javac.log 2>&1
+  rg -n "error:|warning:|External" /tmp/btrace-issue-931-phase3-target-javac.log || true
+  javac --release 8 -cp "$BTRACE_931_PHASE3_JAR" -processorpath "$BTRACE_931_PHASE3_JAR" -d "$BTRACE_931_PHASE3_SMOKE/extension-classes" -s "$BTRACE_931_PHASE3_SMOKE/generated" btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/*.java > /tmp/btrace-issue-931-phase3-extension-javac.log 2>&1
+  rg -n "error:|warning:|ExternalType|ParentApi|ChildApi" /tmp/btrace-issue-931-phase3-extension-javac.log || true
+  test -f "$BTRACE_931_PHASE3_SMOKE/generated/example/ParentApi\$Ext.java"
+  test -f "$BTRACE_931_PHASE3_SMOKE/generated/example/ChildApi\$Ext.java"
+  test -f "$BTRACE_931_PHASE3_SMOKE/extension-classes/example/ParentApi\$Ext.class"
+  test -f "$BTRACE_931_PHASE3_SMOKE/extension-classes/example/ChildApi\$Ext.class"
+  rg -n "public static java\.lang\.Object child\(java\.lang\.Object self\)|public static java\.lang\.String label\(java\.lang\.Object self\)" "$BTRACE_931_PHASE3_SMOKE/generated/example/ParentApi\$Ext.java" "$BTRACE_931_PHASE3_SMOKE/generated/example/ChildApi\$Ext.java"
+  ! rg -n "ChildApi\.class|ParentApi\.class|example\.target\.ExternalChild\.class|example\.target\.ExternalParent\.class" "$BTRACE_931_PHASE3_SMOKE/generated"
+  java -cp "$BTRACE_931_PHASE3_SMOKE/extension-classes:$BTRACE_931_PHASE3_SMOKE/target-classes:$BTRACE_931_PHASE3_JAR" example.ExternalTypeSmoke > /tmp/btrace-issue-931-phase3-external-run.log 2>&1
+  rg -n '^external-type-chain-ok$' /tmp/btrace-issue-931-phase3-external-run.log
+
+  GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-dist:build > /tmp/btrace-issue-931-phase3-dist-build.log 2>&1
+  rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Test" /tmp/btrace-issue-931-phase3-dist-build.log
+
+  GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-extensions:btrace-ext-test:spotlessCheck > /tmp/btrace-issue-931-phase3-ext-spotless.log 2>&1
+  rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase3-ext-spotless.log
+
+  GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:spotlessCheck > /tmp/btrace-issue-931-phase3-integration-spotless.log 2>&1
+  rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase3-integration-spotless.log
+
+  GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:test -Pintegration --tests tests.ExternalTypeAdapterIntegrationTest > /tmp/btrace-issue-931-phase3-integration.log 2>&1
+  rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|ExternalTypeAdapterIntegrationTest|timed out" /tmp/btrace-issue-931-phase3-integration.log
+
+  git diff --check
+  git status --short
+  ```
+
+  Confirm the intended negative evidence before claiming completion: malformed marker test inputs fail with their exact diagnostics, mismatched loader child inputs fail, hidden marked types retry only after availability, and the two-stage smoke fails if target classes are added neither to run classpath nor to the extension compiler path. Do not commit until every required gate passes and the user authorizes it.
+
+## Completion criteria
+
+Phase 3 is complete only when `ExternalType.Type` provides the direct-`Object` declaration contract; every supported declaration marker is consumed once or diagnosed once, while javac rejects inapplicable type-use/repeated forms; exact type classes resolve from the already-resolved owner’s defining loader; generated public APIs remain opaque and binary-compatible; chains, same-name isolated loaders, nulls, retry/failure semantics, and Phase 2 static forms pass; the staged real client-agent-target flow proves a nested target-only chain; and a genuinely separated masked-JAR smoke compiles contracts without target sources/classes using Java 8, then runs them only with target runtime classes. No Phase 4+ capability is implied.

--- a/internal/specs/2026-08-07-issue-931-phase-3-target-type-signatures.md
+++ b/internal/specs/2026-08-07-issue-931-phase-3-target-type-signatures.md
@@ -1,0 +1,326 @@
+# Issue #931, Phase 3: target-type signatures and chained `@ExternalType` adapters
+
+Date: 2026-08-07
+Status: design proposal; implementation and planning must wait for a CLEAN design review
+Baseline: `develop` at `a6a7ed57` (#941 and #942 merged)
+
+## Problem and goal
+
+Phase 1 supports target methods only when their erased Java signatures can be written directly by
+the extension. `Object` is deliberately not a coercion escape hatch: an adapter declaration
+returning or accepting `Object` cannot resolve a target member that returns or accepts an
+application-library type. For example, `Parent.child(): vendor.Child` still needs manual
+`ClassLoadingUtil` and `MethodHandleCache` code even if both types are public external types.
+
+Phase 3 adds an explicit declaration for direct target-library parameter and return positions.
+Generated code resolves those target `Class<?>` values in the resolved owner's defining
+application loader and substitutes them into the exact `MethodType`. The Java dispatcher boundary
+remains `Object`, allowing opaque target objects to flow directly into another generated adapter:
+no wrapper, proxy, target-library compile dependency, or loader lookup by name alone.
+
+This phase is limited to method signatures and chains. It does not add overload selection, fields,
+constructors, casts/predicates, automatic loader selection, non-public access, module rewrites, or
+a general reflection language.
+
+## Decision: `@ExternalType.Type(Contract.class) Object`
+
+Add the nested public source annotation:
+
+```java
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.METHOD, ElementType.PARAMETER})
+public @interface Type {
+  Class<?> value();
+}
+```
+
+It is legal only as a method declaration annotation for a **direct** `Object` return, or as a
+formal-parameter declaration annotation for a direct `Object` parameter, in an `@ExternalType`
+interface. Its value names another interface (the enclosing contract is allowed) that has a
+non-empty `@ExternalType("target.fqn")`. Java syntax remains the natural
+`@ExternalType.Type(ChildApi.class) Object child()` and
+`void replace(@ExternalType.Type(ChildApi.class) Object child)` forms. The processor reads the
+contract's target FQN from the compiler model and treats it solely as generated lookup metadata.
+
+```java
+@ExternalType("vendor.Child")
+public interface ChildApi {
+  String label();
+}
+
+@ExternalType("vendor.Parent")
+public interface ParentApi {
+  @ExternalType.Type(ChildApi.class)
+  Object child();
+
+  void replaceChild(@ExternalType.Type(ChildApi.class) Object child);
+}
+```
+
+The target descriptors are `()Lvendor/Child;` and `(Lvendor/Child;)V`, while generated Java
+methods remain `Object child(Object self)` and `void replaceChild(Object self, Object child)`.
+The extension can chain without a target-library dependency or cast:
+
+```java
+Object child = ParentApi$Ext.child(parent);
+String label = ChildApi$Ext.label(child);
+```
+
+The first call resolves `vendor.Child` to construct `Parent.child`'s exact `MethodType`; the
+second derives its owner from the returned object's defining loader. The actual object is never
+wrapped or transformed.
+
+### Options assessed
+
+| Option | Decision | Reason |
+| --- | --- | --- |
+| `@ExternalType.Type(ChildApi.class) Object` declaration marker | Chosen | It is explicit at the only JVM-signature position needing it, while `METHOD`/`PARAMETER` targets make exhaustive JSR-269 validation possible. The class literal is compiler-refactor-safe and links to the existing external contract; the adapter API remains opaque `Object`. |
+| Use an annotated contract interface directly in method signatures | Rejected | `vendor.Child` does not implement `ChildApi`; generated return casts fail and dispatcher descriptors would leak extension contract types. |
+| A string marker such as `@Type("vendor.Child")` | Rejected | It duplicates the target FQN owned by `ChildApi`, is typo/refactor-prone, and cannot validate an available chained contract. |
+| Wrapper/proxy result objects | Rejected | They add allocation, identity, null, lifecycle, cross-loader, and runtime-public-API problems unrelated to exact method lookup. |
+| A method-level signature string | Rejected | It duplicates Java declarations and becomes an overload-selection language; selectors remain Phase 4. |
+
+`SOURCE` retention is intentional: this is processor input, not runtime policy. The published
+masked JAR must contain `ExternalType$Type.class` for external compilation, but generated adapters
+must never reference `ChildApi.class` or inspect this annotation at runtime.
+
+## Processor and generated-code contract
+
+### Validation and Java 8 annotation processing
+
+Update `ExternalTypeProcessor`'s supported annotation types to claim both
+`io.btrace.core.extensions.ExternalType` and `io.btrace.core.extensions.ExternalType.Type`; there
+is no new processor option or Gradle DSL. It must read declaration annotation mirrors through the
+Java 8 annotation-processing model rather than class-loading annotation values (which risks
+`MirroredTypeException`).
+
+For each selected interface method, the processor must:
+
+1. Retain Phase 1/2 validation: interface/non-empty owner, duplicate method-name rejection,
+   default/static interface method skipping, and exact erased ordinary types.
+2. Consume the non-repeatable `@ExternalType.Type` annotation only from an `ExecutableElement`
+   return declaration or `VariableElement` formal-parameter declaration. The corresponding erased
+   source type must be exactly `java.lang.Object`; reject any declared return/parameter type other
+   than direct `Object`.
+3. Resolve the marker's class-valued element to a `TypeMirror`. It must name an interface annotated
+   with non-empty `@ExternalType`; otherwise issue a source-positioned diagnostic and emit no
+   partial adapter.
+4. Retain ordinary generic erasure. Unannotated `List<String>` remains `java.util.List`; a target
+   method erased to `List` does not need a marker. Phase 3 does not model generic elements.
+
+`Type` intentionally is not a `TYPE_USE` annotation. Generic-argument, array-component, local,
+cast, and `new`-expression type-use attempts are javac annotation-target applicability errors
+before processor validation. A declaration annotation such as
+`@ExternalType.Type(ChildApi.class) Object[] child()` is legal as a method annotation but fails
+the processor's direct-`Object` rule. Repeated `@ExternalType.Type` annotations are a native javac
+non-repeatable-annotation error, not a processor-owned diagnostic.
+
+The processor must diagnose every declaration marker it receives that is not consumed by the
+allowed direct-`Object` return/parameter path. In each round, iterate
+`roundEnv.getElementsAnnotatedWith(ExternalType.Type.class)`, which is exhaustive for the chosen
+`METHOD`/`PARAMETER` targets. Track consumed annotation mirrors/elements while adapting valid
+interface methods; after validation, emit one source-positioned diagnostic for each unconsumed
+marker: outside an adapted `@ExternalType` interface, on a skipped default/static interface method,
+or on a non-`Object` return/parameter declaration. Do not rely only on the outer-`ExternalType`
+scan, and do not emit a second catch-all error for a marker already consumed or directly diagnosed.
+The supported-annotation declaration ensures javac invokes the processor even when invalid source
+contains only `@ExternalType.Type`.
+
+`MethodSpec` (and `AdapterSpec` if useful) must represent both the emitted Java type and lookup
+type for each position: `Object` plus a referenced target FQN for a marked position, and the
+existing erased source type/class literal otherwise. Generated source must not refer to the
+referenced contract interface. This preserves Java 8 source compatibility and prevents the
+contract from entering generated public descriptors or runtime linkage.
+
+### Exact runtime lookup and static forms
+
+Within each existing `ClassValue<ResolvedCall>` computation, resolve the owner first under the
+current policy, then resolve every marked type before `findVirtual`/`findStatic` with:
+
+```java
+Class.forName(targetTypeFqn, false, owner.getClassLoader())
+```
+
+Build the `MethodType` from those resolved return/parameter classes and ordinary class literals
+for unmarked positions. The `false` initialization flag is required.
+
+Resolving via `owner.getClassLoader()` is essential. An explicit static call can be given a child
+loader which delegates the owner to a parent; resolving a same-named target type via the child
+would create a different identity than the owner's method descriptor. For a bootstrap owner,
+`owner.getClassLoader()` is null and `Class.forName(..., false, null)` resolves in bootstrap. There
+is no fallback to TCCL, selected static loader, extension implementation loader, or loader search.
+
+Phase 2 static public forms stay exact:
+
+- `method(targetArguments...)` selects TCCL then system only for null TCCL.
+- `method(ClassLoader applicationLoader, targetArguments...)` rejects null before cache access and
+  resolves the owner only through that loader.
+
+After either resolves the owner, marked target types use the owner's defining loader. The leading
+control loader remains absent from `MethodType` and target invocation arguments.
+
+### Chaining and null semantics
+
+Generated adapters neither wrap a marked value nor cast it to the referenced contract interface.
+Marked returns and parameters are emitted as `Object`; `MethodHandle.invoke` performs ordinary
+runtime conversion to the resolved target class needed by the exact descriptor.
+
+- An object from loader A chains only into a method whose resolved target class has loader-A
+  identity. A same-FQN object from loader B must fail transparently with normal invocation
+  `ClassCastException`/`WrongMethodTypeException`, not trigger coercion or another loader search.
+- A marked parameter may be null. Its target class is still resolved to form `MethodType`, then
+  null is forwarded unchanged and target code controls the outcome.
+- A marked return may be null and returns as null. Passing it as a marked parameter is normal.
+  Passing it as `self` to a subsequent virtual adapter preserves the current null-receiver failure
+  at `self.getClass()`; no sentinel/wrapper or virtual-null semantic change is authorized.
+
+Self references and repeated nested chains are supported because no chain graph or adapter instance
+is retained.
+
+## Cache, lifecycle, and concurrency
+
+Phase 3 creates no second cache or global type-name map.
+
+- Virtual `ClassValue<ResolvedCall>` remains keyed by `self.getClass()`. The resolved handle
+  naturally retains the owner and exact type identities until that class-value entry is releasable.
+- Static dispatch retains the Phase 1/2 monitor, weak-identity loader-to-owner index, and
+  owner-keyed `ClassValue`; legacy and explicit forms share it. The index never contains a
+  `ResolvedCall` or marked target-type cache.
+- Marked type lookup is inside the existing `ClassValue` computation before publication. Owner,
+  target-type, or member failure publishes no class value/index entry and the next call retries.
+  Static calls remain single-flight under the current member monitor; Phase 3 adds no virtual
+  single-flight promise.
+- No `Map<String, Class<?>>`, thread-local type cache, FQN-only key, or strong loader key is
+  permitted. Isolated loaders with identical FQNs retain separate classes/handles; existing weak
+  index expunging and VM `ClassValue` lifecycle continue to govern unloadability.
+
+## Failure, access, and security boundary
+
+The established `ExternalTypeResolutionException` boundary includes a marked target class missing
+during `MethodType` construction: it keeps the adapted owner/member message and the original
+`ClassNotFoundException` cause. Exact member `NoSuchMethodException` and public-lookup
+`IllegalAccessException` retain the same treatment; all are retryable and never negatively cached.
+
+Only those resolution failures are translated. Target-thrown exceptions (including a target-thrown
+`ExternalTypeResolutionException`), wrong-loader argument failures, `SecurityException`, linkage
+errors, and target-code errors propagate unchanged. Generated code must not set TCCL, initialize a
+target class, modify classpaths, use an implementation loader, `privateLookupIn`, `setAccessible`,
+`--add-opens`, module reads/exports, or privileged lookup. `MethodHandles.publicLookup()` remains
+the public/exported-module boundary; Phase 3 does not make inaccessible types/members available.
+
+## Compatibility and release surface
+
+- Existing contracts without `@ExternalType.Type` retain Phase 1/2 output and behaviour.
+- New source opts in only by annotating a direct `Object`; writing `ChildApi` as a parameter or
+  return is invalid because it falsely claims a target object implements that contract.
+- An opted-in regenerated adapter still exposes `Object` in its descriptor, so existing consumers
+  of that generated method remain binary-compatible. Its lookup semantics change only after an
+  extension rebuild. Existing already-built adapters remain unchanged until regenerated.
+- `ExternalType.Type` is the only new public API. It is source-retained and carries a contract
+  class only at source processing; generated public methods/fields/class literals expose neither
+  target-library types nor contract interfaces. The generated owner/type FQN strings are normal
+  internal resolution metadata.
+- The actual published `io.btrace:btrace` masked JAR must expose `ExternalType$Type.class`,
+  `ExternalType`, the processor service/implementation, and required processor support to external
+  `javac`. Validate that JAR rather than `btrace-core` output. No packaging/plugin/DSL change is
+  expected unless this concrete artifact proof detects one.
+
+## Affected components
+
+- `btrace-core`: `ExternalType` nested annotation/Javadoc, `ExternalTypeProcessor`, `MethodSpec`,
+  optionally `AdapterSpec`, `AdapterEmitter`, and focused processor/runtime tests. Generated output
+  remains Java 8.
+- `btrace-dist`: external processor smoke sources and masked-artifact assertions only, unless a
+  demonstrated narrow packaging omission requires a build-script correction.
+- `btrace-extensions:btrace-ext-test` and `integration-tests`: nested application-only parent/
+  child path through staged extension, real client, agent, target JVM, and protocol.
+- `docs/BTraceExtensionDevelopmentGuide.md` (normative) and
+  `docs/architecture/provided-style-extensions.md` (pointer/manual boundary). Change tutorial or
+  getting-started only if targeted search finds contradictory behaviour claims.
+- `btrace-gradle-plugin`: validation only; no new DSL/options.
+
+## Acceptance criteria
+
+1. External contracts compile with direct `@ExternalType.Type(OtherContract.class) Object`
+   parameter/return positions. Generated source retains an `Object` public boundary but resolves
+   the referenced target FQN in its `MethodType`, without `OtherContract` public signatures,
+   descriptors, or runtime class literals.
+2. Compiler diagnostics reject non-`@ExternalType` references, empty target FQNs, and non-`Object`
+   declarations while preserving duplicate-name overload rejection. Generic-argument, array-
+   component, local, cast, and `new` type-use attempts fail through javac annotation-target
+   applicability; repeated markers fail through javac's native non-repeatable-annotation diagnostic.
+3. A virtual public target returning and accepting `Child` resolves/invokes exactly and returns
+   the opaque object; it chains into a `Child` virtual adapter without wrapper, cast, or target
+   library on the extension compile classpath.
+4. Two hostile isolated loaders defining the same owner/child FQNs produce their own chain values.
+   A loader-A handle never accepts loader-B child identity; loader `equals`/`hashCode` are unused.
+5. Static target methods with marked parameter/return types pass through legacy TCCL and explicit
+   loader forms. A selected child loader delegating the owner to a parent proves type resolution
+   follows `owner.getClassLoader()`, not the selected child. The control loader is absent from
+   target `MethodType` and invocation arguments.
+6. A missing marked target class gives cause-preserving `ExternalTypeResolutionException`, leaves
+   no successful cache entry, and succeeds after the same mutable loader exposes it. Missing
+   member/access and target-thrown failure semantics stay unchanged.
+7. Marked null returns/arguments and null virtual chaining follow the documented rules; wrong-loader
+   objects fail transparently rather than being coerced.
+8. Existing unmarked `Object`, primitive/JDK/generic-erasure, virtual, legacy null-TCCL, and
+   explicit null-loader coverage remains green.
+9. The staged extension/client/agent/target path runs a nested parent-returning-child call and a
+   child adapter call, emitting a target-owned marker while retaining separate Phase 2 legacy and
+   explicit static scenarios and release-extension isolation.
+10. A clean masked JAR contains `ExternalType$Type.class` plus processor service/implementation.
+    Compile parent/child **target** classes into a runtime-only output separately. In a distinct
+    `javac --release 8` invocation, compile external parent/child contracts and their driver with only the masked
+    JAR as both classpath and processorpath--with neither target sources nor target classes on that
+    compilation path. Assert generated source declarations retain `Object` and contain neither an
+    `OtherContract.class` reference nor a target-library `.class` literal. Run with extension
+    classes, the separately compiled target output, and the masked JAR only; the chain must emit
+    its target marker without `btrace-core` output or an extension implementation JAR.
+11. Docs state direct target-type support precisely and keep generic elements/arrays, overload
+    selectors, fields/constructors, casts/predicates, and non-public/JPMS access out of scope.
+
+## Verification gates
+
+Implementation must redirect Gradle output to `/tmp` before filtering, use
+`GRADLE_USER_HOME=$(pwd)/.gradle-user`, build `btrace-dist` before integration, and inspect:
+
+```text
+:btrace-core:test
+:btrace-core:spotlessCheck
+clean :btrace-dist:btraceJar
+:btrace-dist:build
+:btrace-extensions:btrace-ext-test:spotlessCheck
+:integration-tests:spotlessCheck
+:integration-tests:test -Pintegration --tests tests.ExternalTypeAdapterIntegrationTest
+```
+
+The implementation plan must turn these into redirected Gradle commands with relevant `rg` reads;
+inspect the clean masked JAR and processor service; and run this separated external smoke proof:
+
+1. compile target-only `Parent`/`Child` sources with `javac --release 8` to a runtime directory
+   without putting them on the contracts compiler classpath;
+2. compile only extension contracts plus driver with the masked JAR as both `-cp` and
+   `-processorpath` using `javac --release 8`, writing generated source/classes to separate
+   directories;
+3. assert generated declarations are `Object`-based and that generated source does not contain
+   `OtherContract.class` or target-library `.class` literals; and
+4. run the driver with extension classes, target runtime classes, and the masked JAR.
+
+The compiler tests must also include a `@ExternalType.Type` marker outside an adapted contract and
+one non-`Object` declaration, asserting one useful processor diagnostic each, while a valid direct
+marker emits no duplicate diagnostic. Type-use misuse and repeated-marker fixtures must assert the
+native javac applicability/non-repeatable diagnostics. Each new positive test needs a
+discriminating rejected-input or unfixed-behaviour proof. Use the documented IPv4
+`JAVA_TOOL_OPTIONS` retry only for the known restricted-environment address-selection failure.
+
+## Non-goals and completion boundary
+
+Phase 3 excludes target types inside generic containers or arrays, target-type fields,
+constructors/casts/predicates, overload selection, target classpath dependencies, wrappers/proxies,
+fallback loader search, `MethodHandleCache` redesign, static-policy changes, and private/JPMS
+bypasses.
+
+It is complete only when opt-in declaration metadata creates exact owner-loader-resolved `MethodType`s,
+opaque values chain safely, loader/null/cache/failure compatibility holds, the published artifact
+supports external compilation/execution, and the real integration path proves nested
+application-only types. It does not authorize Phase 4 or later work.


### PR DESCRIPTION
Closes #931.

## Summary

- Add `@ExternalType.Type(Contract.class)` for direct opaque target-library parameter and return positions.
- Resolve marked signature classes through the resolved owner’s defining loader while preserving existing adapter descriptors and static-loader policy.
- Cover chained calls, loader identity, retries, nulls, malformed declarations, masked-JAR external compilation, and real marked return/parameter integration paths.
- Document the supported boundary and retain the manual path for unsupported shapes.

## Compatibility

The opt-in marker is source-retained. Generated adapter APIs keep `Object` at marked boundaries; target-library classes and contract interfaces do not leak into generated public descriptors.

## Verification

- `:btrace-extensions:btrace-ext-test:spotlessCheck`
- `:integration-tests:spotlessCheck`
- `git diff --check`

The full core, distribution, masked-artifact, and client-agent-target test runs remain pending local validation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/943)
<!-- Reviewable:end -->
