### PR TITLE
feat(extensions): add overload selectors

### DIFF
--- a/btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java
+++ b/btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java
@@ -63,7 +63,13 @@ public @interface ExternalType {
     Class<?> value();
   }
 
-  /** Selects the target name for every member of an opt-in overload group. */
+  /**
+   * Selects one overloaded target member name for every method in an opt-in group.
+   *
+   * <p>Apply this annotation, with the same value, to at least two abstract methods in one
+   * contract. The methods may use distinct local names; their declared exact signatures select the
+   * target overload. This annotation does not perform runtime overload search or coercion.
+   */
   @Retention(RetentionPolicy.SOURCE)
   @Target(ElementType.METHOD)
   @interface Overload {

--- a/btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java
+++ b/btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java
@@ -62,4 +62,11 @@ public @interface ExternalType {
     /** The external contract that supplies the target type name. */
     Class<?> value();
   }
+
+  /** Selects the target name for every member of an opt-in overload group. */
+  @Retention(RetentionPolicy.SOURCE)
+  @Target(ElementType.METHOD)
+  @interface Overload {
+    String value();
+  }
 }

--- a/btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java
@@ -134,27 +134,29 @@ final class AdapterEmitter {
     if (m.isStatic) {
       w.println(
           "            return new ResolvedCall(owner, MethodHandles.publicLookup().findStatic(owner, \""
-              + m.name
+              + m.targetName
               + "\", "
               + methodTypeLiteral(m, ordinal)
               + ")); ");
     } else {
       w.println(
           "            return new ResolvedCall(owner, MethodHandles.publicLookup().findVirtual(owner, \""
-              + m.name
+              + m.targetName
               + "\", "
               + methodTypeLiteral(m, ordinal)
               + ")); ");
     }
     w.println("          } catch (" + resolutionExceptions(m) + " e) {");
     w.println(
-        "            throw new ExternalTypeResolutionException(OWNER, \"" + m.name + "\", e);");
+        "            throw new ExternalTypeResolutionException(OWNER, \""
+            + m.targetName
+            + "\", e);");
     w.println("          }");
     w.println("        }");
     w.println("      };");
     if (m.isStatic) renderStaticSupport(w, m, ordinal, cache);
     w.println();
-    w.println("  public static " + m.returnType + " " + m.name + "(" + paramList + ") {");
+    w.println("  public static " + m.returnType + " " + m.adapterName + "(" + paramList + ") {");
     w.println("    try {");
     if (m.isStatic) {
       w.println(
@@ -175,7 +177,14 @@ final class AdapterEmitter {
       String explicitParamList = "ClassLoader applicationLoader";
       if (!paramList.isEmpty()) explicitParamList += ", " + paramList;
       w.println();
-      w.println("  public static " + m.returnType + " " + m.name + "(" + explicitParamList + ") {");
+      w.println(
+          "  public static "
+              + m.returnType
+              + " "
+              + m.adapterName
+              + "("
+              + explicitParamList
+              + ") {");
       w.println(
           "    if (applicationLoader == null) throw new NullPointerException(\"applicationLoader\");");
       w.println("    try {");
@@ -225,7 +234,8 @@ final class AdapterEmitter {
     w.println("      try {");
     w.println("        owner = Class.forName(OWNER, false, loader);");
     w.println("      } catch (ClassNotFoundException e) {");
-    w.println("        throw new ExternalTypeResolutionException(OWNER, \"" + m.name + "\", e);");
+    w.println(
+        "        throw new ExternalTypeResolutionException(OWNER, \"" + m.targetName + "\", e);");
     w.println("      }");
     w.println("      ResolvedCall call = " + cache + ".get(owner);");
     w.println(

--- a/btrace-core/src/main/java/io/btrace/extension/processor/ExternalTypeProcessor.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/ExternalTypeProcessor.java
@@ -20,8 +20,10 @@ import io.btrace.core.extensions.ExternalType;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
@@ -39,7 +41,8 @@ import javax.tools.JavaFileObject;
 
 @SupportedAnnotationTypes({
   "io.btrace.core.extensions.ExternalType",
-  "io.btrace.core.extensions.ExternalType.Type"
+  "io.btrace.core.extensions.ExternalType.Type",
+  "io.btrace.core.extensions.ExternalType.Overload"
 })
 public final class ExternalTypeProcessor extends AbstractProcessor {
 
@@ -53,6 +56,9 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
     Set<Element> markers =
         new HashSet<>(roundEnv.getElementsAnnotatedWith(ExternalType.Type.class));
     Set<Element> consumedMarkers = new HashSet<>();
+    Set<Element> selectors =
+        new HashSet<>(roundEnv.getElementsAnnotatedWith(ExternalType.Overload.class));
+    Set<Element> consumedSelectors = new HashSet<>();
     for (Element e : roundEnv.getElementsAnnotatedWith(ExternalType.class)) {
       if (e.getKind() != ElementKind.INTERFACE) {
         processingEnv
@@ -76,7 +82,8 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
         continue;
       }
       try {
-        AdapterSpec spec = buildSpec(iface, externalFqn, markers, consumedMarkers);
+        AdapterSpec spec =
+            buildSpec(iface, externalFqn, markers, consumedMarkers, selectors, consumedSelectors);
         if (spec != null) emit(spec, iface);
       } catch (Exception ex) {
         processingEnv
@@ -87,6 +94,10 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
                 iface);
       }
     }
+    reportUnconsumed(
+        selectors,
+        consumedSelectors,
+        "@ExternalType.Overload is only valid on an abstract method of an @ExternalType interface.");
     for (Element marker : markers) {
       if (consumedMarkers.contains(marker)) continue;
       processingEnv
@@ -101,30 +112,36 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
   }
 
   private AdapterSpec buildSpec(
-      TypeElement iface, String externalFqn, Set<Element> markers, Set<Element> consumedMarkers) {
+      TypeElement iface,
+      String externalFqn,
+      Set<Element> markers,
+      Set<Element> consumedMarkers,
+      Set<Element> selectors,
+      Set<Element> consumedSelectors) {
     String pkg = processingEnv.getElementUtils().getPackageOf(iface).getQualifiedName().toString();
     String simple = iface.getSimpleName().toString();
     List<MethodSpec> methods = new ArrayList<>();
-    Set<String> seen = new HashSet<>();
+    Map<String, List<MethodSpec>> localGroups = new HashMap<>();
+    Map<String, List<MethodSpec>> targetGroups = new HashMap<>();
+    Map<MethodSpec, Boolean> selected = new HashMap<>();
+    Map<MethodSpec, ExecutableElement> origins = new HashMap<>();
     boolean invalid = false;
     for (Element m : iface.getEnclosedElements()) {
       if (m.getKind() != ElementKind.METHOD) continue;
       ExecutableElement em = (ExecutableElement) m;
       if (em.isDefault() || em.getModifiers().contains(Modifier.STATIC)) continue;
       String methodName = em.getSimpleName().toString();
-      if (!seen.add(methodName)) {
-        processingEnv
-            .getMessager()
-            .printMessage(
-                Diagnostic.Kind.ERROR,
-                "@ExternalType does not support overloaded methods: '"
-                    + methodName
-                    + "' is declared more than once in "
-                    + iface.getQualifiedName()
-                    + ". Rename the methods or use MethodHandleCache directly for overloaded dispatch.",
-                em);
-        invalid = true;
-        continue;
+      String selector = null;
+      if (selectors.contains(em)) {
+        consumedSelectors.add(em);
+        selector = selectorValue(em);
+        if (!validTargetName(selector)) {
+          processingEnv
+              .getMessager()
+              .printMessage(
+                  Diagnostic.Kind.ERROR, "Invalid @ExternalType.Overload target name.", em);
+          invalid = true;
+        }
       }
       boolean isStatic = em.getAnnotation(ExternalType.Static.class) != null;
       String rt = processingEnv.getTypeUtils().erasure(em.getReturnType()).toString();
@@ -147,11 +164,175 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
         }
         paramTargetFqns.add(targetFqn);
       }
-      methods.add(
-          new MethodSpec(methodName, rt, returnTargetFqn, params, paramTargetFqns, isStatic));
+      String targetName = selector != null ? selector : methodName;
+      MethodSpec spec =
+          new MethodSpec(
+              methodName, targetName, rt, returnTargetFqn, params, paramTargetFqns, isStatic);
+      methods.add(spec);
+      origins.put(spec, em);
+      selected.put(spec, selector != null);
+      localGroups.computeIfAbsent(methodName, ignored -> new ArrayList<>()).add(spec);
+      targetGroups.computeIfAbsent(targetName, ignored -> new ArrayList<>()).add(spec);
+    }
+    for (Map.Entry<String, List<MethodSpec>> entry : localGroups.entrySet()) {
+      if (entry.getValue().size() > 1
+          && entry.getValue().stream().anyMatch(m -> !selected.get(m))) {
+        processingEnv
+            .getMessager()
+            .printMessage(
+                Diagnostic.Kind.ERROR,
+                "@ExternalType does not support overloaded methods: '"
+                    + entry.getKey()
+                    + "' is declared more than once in "
+                    + iface.getQualifiedName()
+                    + ". Rename the methods or select every member.",
+                origins.get(entry.getValue().get(0)));
+        invalid = true;
+      }
+    }
+    for (Map.Entry<String, List<MethodSpec>> entry : targetGroups.entrySet()) {
+      if (entry.getValue().size() == 1 && selected.get(entry.getValue().get(0))) {
+        processingEnv
+            .getMessager()
+            .printMessage(
+                Diagnostic.Kind.ERROR,
+                "@ExternalType.Overload requires at least two methods selecting '"
+                    + entry.getKey()
+                    + "'.",
+                origins.get(entry.getValue().get(0)));
+        invalid = true;
+      }
+      if (entry.getValue().size() > 1
+          && entry.getValue().stream().anyMatch(m -> !selected.get(m))) {
+        processingEnv
+            .getMessager()
+            .printMessage(
+                Diagnostic.Kind.ERROR,
+                "Every method selecting target '"
+                    + entry.getKey()
+                    + "' must use @ExternalType.Overload.",
+                origins.get(entry.getValue().get(0)));
+        invalid = true;
+      }
+    }
+    Map<TargetKey, MethodSpec> targetKeys = new HashMap<>();
+    Map<String, MethodSpec> generatedDescriptors = new HashMap<>();
+    for (MethodSpec method : methods) {
+      TargetKey targetKey = targetKey(method);
+      if (targetKeys.put(targetKey, method) != null) {
+        processingEnv
+            .getMessager()
+            .printMessage(
+                Diagnostic.Kind.ERROR,
+                "@ExternalType selected methods must have distinct exact target signatures.",
+                origins.get(method));
+        invalid = true;
+      }
+      for (String descriptor : generatedDescriptors(method)) {
+        if (generatedDescriptors.put(descriptor, method) != null) {
+          processingEnv
+              .getMessager()
+              .printMessage(
+                  Diagnostic.Kind.ERROR,
+                  "@ExternalType selected methods collide in generated adapter descriptors; rename the local method.",
+                  origins.get(method));
+          invalid = true;
+        }
+      }
     }
     if (invalid) return null;
     return new AdapterSpec(pkg, simple, externalFqn, methods);
+  }
+
+  private TargetKey targetKey(MethodSpec method) {
+    List<String> params = new ArrayList<>();
+    for (int i = 0; i < method.paramTypes.size(); i++)
+      params.add(
+          method.paramTargetFqns.get(i) != null
+              ? method.paramTargetFqns.get(i)
+              : method.paramTypes.get(i));
+    return new TargetKey(
+        method.targetName,
+        method.isStatic,
+        method.returnTargetFqn != null ? method.returnTargetFqn : method.returnType,
+        params);
+  }
+
+  private static final class TargetKey {
+    final String name;
+    final boolean statik;
+    final String result;
+    final List<String> params;
+
+    TargetKey(String name, boolean statik, String result, List<String> params) {
+      this.name = name;
+      this.statik = statik;
+      this.result = result;
+      this.params = params;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof TargetKey)) return false;
+      TargetKey k = (TargetKey) o;
+      return statik == k.statik
+          && name.equals(k.name)
+          && result.equals(k.result)
+          && params.equals(k.params);
+    }
+
+    @Override
+    public int hashCode() {
+      return java.util.Objects.hash(name, statik, result, params);
+    }
+  }
+
+  private List<String> generatedDescriptors(MethodSpec method) {
+    List<String> descriptors = new ArrayList<>();
+    StringBuilder legacy = new StringBuilder(method.adapterName).append('(');
+    if (!method.isStatic) legacy.append("java.lang.Object,");
+    for (String param : method.paramTypes) legacy.append(param).append(',');
+    descriptors.add(legacy.append(')').toString());
+    if (method.isStatic) {
+      StringBuilder explicit =
+          new StringBuilder(method.adapterName).append("(java.lang.ClassLoader,");
+      for (String param : method.paramTypes) explicit.append(param).append(',');
+      descriptors.add(explicit.append(')').toString());
+    }
+    return descriptors;
+  }
+
+  private void reportUnconsumed(Set<Element> values, Set<Element> consumed, String message) {
+    for (Element value : values)
+      if (!consumed.contains(value))
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, value);
+  }
+
+  private String selectorValue(Element element) {
+    return annotationStringValue(element, "io.btrace.core.extensions.ExternalType.Overload");
+  }
+
+  private boolean validTargetName(String name) {
+    return name != null
+        && !name.trim().isEmpty()
+        && !name.equals("<init>")
+        && !name.equals("<clinit>")
+        && name.indexOf('.') < 0
+        && name.indexOf(';') < 0
+        && name.indexOf('[') < 0
+        && name.indexOf('/') < 0;
+  }
+
+  private String annotationStringValue(Element marker, String annotationName) {
+    for (javax.lang.model.element.AnnotationMirror annotation : marker.getAnnotationMirrors()) {
+      if (!annotation.getAnnotationType().toString().equals(annotationName)) continue;
+      for (javax.lang.model.element.AnnotationValue value :
+          processingEnv.getElementUtils().getElementValuesWithDefaults(annotation).values()) {
+        Object raw = value.getValue();
+        if (raw instanceof String) return (String) raw;
+      }
+    }
+    return null;
   }
 
   private String targetFqn(Element marker, String erasedType) {

--- a/btrace-core/src/main/java/io/btrace/extension/processor/MethodSpec.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/MethodSpec.java
@@ -20,7 +20,8 @@ import java.util.Collections;
 import java.util.List;
 
 final class MethodSpec {
-  final String name;
+  final String adapterName;
+  final String targetName;
   final String returnType;
   final String returnTargetFqn;
   final List<String> paramTypes;
@@ -28,13 +29,15 @@ final class MethodSpec {
   final boolean isStatic;
 
   MethodSpec(
-      String name,
+      String adapterName,
+      String targetName,
       String returnType,
       String returnTargetFqn,
       List<String> paramTypes,
       List<String> paramTargetFqns,
       boolean isStatic) {
-    this.name = name;
+    this.adapterName = adapterName;
+    this.targetName = targetName;
     this.returnType = returnType;
     this.returnTargetFqn = returnTargetFqn;
     this.paramTypes = Collections.unmodifiableList(new java.util.ArrayList<>(paramTypes));

--- a/btrace-core/src/test/java/io/btrace/extension/processor/CompileTestHarness.java
+++ b/btrace-core/src/test/java/io/btrace/extension/processor/CompileTestHarness.java
@@ -66,6 +66,10 @@ public final class CompileTestHarness {
   }
 
   public static Result compile(Map<String, String> sources) throws IOException {
+    return compile(sources, null);
+  }
+
+  public static Result compile(Map<String, String> sources, Integer release) throws IOException {
     JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     if (compiler == null) {
       throw new IllegalStateException("No JavaCompiler available — run tests on a JDK, not JRE");
@@ -81,12 +85,21 @@ public final class CompileTestHarness {
     }
 
     String cp = System.getProperty("java.class.path");
-    List<String> options =
-        Arrays.asList("-classpath", cp, "-processor", ExternalTypeProcessor.class.getName());
+    List<String> options = new ArrayList<>();
+    if (release != null) {
+      options.add("--release");
+      options.add(release.toString());
+    }
+    options.addAll(
+        Arrays.asList("-classpath", cp, "-processor", ExternalTypeProcessor.class.getName()));
 
     JavaCompiler.CompilationTask task = compiler.getTask(null, mgr, diags, options, null, units);
     boolean ok = task.call();
     return new Result(ok, mgr.generatedSources(), diags.getDiagnostics());
+  }
+
+  public static Result compile(Map<String, String> sources, int release) throws IOException {
+    return compile(sources, Integer.valueOf(release));
   }
 
   public static final class RunnableResult {

--- a/btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java
+++ b/btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java
@@ -216,12 +216,6 @@ class ExternalTypeProcessorTest {
             + "  long currentTimeMillis();\n"
             + "}\n");
 
-    CompileTestHarness.Result sourceResult = CompileTestHarness.compile(sources);
-    assertTrue(sourceResult.success, sourceResult.errors());
-    String generated = sourceResult.generatedSources.get("com.example.adapter.ParentApi$Ext");
-    assertTrue(generated.contains("findVirtual(owner, \"describe\""), generated);
-    assertTrue(generated.contains("Class.forName(\"com.example.target.Child\""), generated);
-    assertFalse(generated.contains("ChildApi.class"), generated);
     CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
     assertTrue(r.success, r.errors());
 
@@ -688,6 +682,12 @@ class ExternalTypeProcessorTest {
             + "@ExternalType(\"com.example.target.Parent\") public interface ParentApi { "
             + "@ExternalType.Overload(\"describe\") String text(String value); "
             + "@ExternalType.Overload(\"describe\") String child(@ExternalType.Type(ChildApi.class) Object value); }");
+    CompileTestHarness.Result sourceResult = CompileTestHarness.compile(sources);
+    assertTrue(sourceResult.success, sourceResult.errors());
+    String generated = sourceResult.generatedSources.get("com.example.adapter.ParentApi$Ext");
+    assertTrue(generated.contains("findVirtual(owner, \"describe\""), generated);
+    assertTrue(generated.contains("Class.forName(\"com.example.target.Child\""), generated);
+    assertFalse(generated.contains("ChildApi.class"), generated);
     CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
     assertTrue(r.success, r.errors());
     Object parent = r.loader.loadClass("com.example.target.Parent").getConstructor().newInstance();

--- a/btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java
+++ b/btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java
@@ -43,7 +43,7 @@ class ExternalTypeProcessorTest {
             + "  int jobId();\n"
             + "}\n");
 
-    CompileTestHarness.Result r = CompileTestHarness.compile(sources);
+    CompileTestHarness.Result r = CompileTestHarness.compile(sources, 8);
     assertTrue(r.success, "compile failed:\n" + r.errors());
     assertTrue(
         r.generatedSources.containsKey("com.example.JobStart$Ext"),
@@ -216,6 +216,12 @@ class ExternalTypeProcessorTest {
             + "  long currentTimeMillis();\n"
             + "}\n");
 
+    CompileTestHarness.Result sourceResult = CompileTestHarness.compile(sources);
+    assertTrue(sourceResult.success, sourceResult.errors());
+    String generated = sourceResult.generatedSources.get("com.example.adapter.ParentApi$Ext");
+    assertTrue(generated.contains("findVirtual(owner, \"describe\""), generated);
+    assertTrue(generated.contains("Class.forName(\"com.example.target.Child\""), generated);
+    assertFalse(generated.contains("ChildApi.class"), generated);
     CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
     assertTrue(r.success, r.errors());
 
@@ -659,6 +665,170 @@ class ExternalTypeProcessorTest {
             InvocationTargetException.class,
             () -> childAdapter.getMethod("label", Object.class).invoke(null, new Object[] {null}));
     assertInstanceOf(NullPointerException.class, nullReceiver.getCause());
+  }
+
+  @Test
+  void overloadSelectorsUseExactTargetNamesAndOpaqueMarkedTypes() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.target.Child",
+        "package com.example.target; public class Child { public String label() { return \"child\"; } }");
+    sources.put(
+        "com.example.target.Parent",
+        "package com.example.target; public class Parent { "
+            + "public String describe(String text) { return \"text-\" + text; } "
+            + "public String describe(Child child) { return \"child-\" + child.label(); } }");
+    sources.put(
+        "com.example.adapter.ChildApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Child\") public interface ChildApi { String label(); }");
+    sources.put(
+        "com.example.adapter.ParentApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Parent\") public interface ParentApi { "
+            + "@ExternalType.Overload(\"describe\") String text(String value); "
+            + "@ExternalType.Overload(\"describe\") String child(@ExternalType.Type(ChildApi.class) Object value); }");
+    CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(r.success, r.errors());
+    Object parent = r.loader.loadClass("com.example.target.Parent").getConstructor().newInstance();
+    Object child = r.loader.loadClass("com.example.target.Child").getConstructor().newInstance();
+    Class<?> adapter = r.loader.loadClass("com.example.adapter.ParentApi$Ext");
+    assertEquals(
+        "text-ok",
+        adapter.getMethod("text", Object.class, String.class).invoke(null, parent, "ok"));
+    assertEquals(
+        "child-child",
+        adapter.getMethod("child", Object.class, Object.class).invoke(null, parent, child));
+  }
+
+  @Test
+  void selectorValidationRetainsLegacyOverloadErrorAndRejectsIllegalGroups() throws Exception {
+    Map<String, String> legacy = new LinkedHashMap<>();
+    legacy.put(
+        "com.example.Api",
+        "package com.example; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"target.Api\") public interface Api { int read(); int read(String value); }");
+    CompileTestHarness.Result legacyResult = CompileTestHarness.compile(legacy);
+    assertFalse(legacyResult.success);
+    assertTrue(legacyResult.errors().contains("@ExternalType does not support overloaded methods"));
+
+    for (String selector : new String[] {"", "<init>", "<clinit>", "x/y"}) {
+      Map<String, String> invalid = new LinkedHashMap<>();
+      invalid.put(
+          "com.example.Api",
+          "package com.example; import io.btrace.core.extensions.ExternalType; "
+              + "@ExternalType(\"target.Api\") public interface Api { "
+              + "@ExternalType.Overload(\""
+              + selector
+              + "\") int local(); }");
+      CompileTestHarness.Result result = CompileTestHarness.compile(invalid);
+      assertFalse(result.success, selector);
+      assertTrue(
+          result.errors().contains("Invalid @ExternalType.Overload target name"), result.errors());
+    }
+  }
+
+  @Test
+  void selectorGroupsRejectMixedMembersAndStaticGeneratedDescriptorCollisions() throws Exception {
+    Map<String, String> mixed = new LinkedHashMap<>();
+    mixed.put(
+        "com.example.Api",
+        "package com.example; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"target.Api\") public interface Api { "
+            + "@ExternalType.Overload(\"read\") int one(); int read(String value); }");
+    CompileTestHarness.Result mixedResult = CompileTestHarness.compile(mixed);
+    assertFalse(mixedResult.success);
+    assertTrue(mixedResult.errors().contains("Every method selecting target 'read'"));
+
+    Map<String, String> collision = new LinkedHashMap<>();
+    collision.put(
+        "com.example.Api",
+        "package com.example; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"target.Api\") public interface Api { "
+            + "@ExternalType.Static @ExternalType.Overload(\"read\") int read(); "
+            + "@ExternalType.Static @ExternalType.Overload(\"read\") int read(ClassLoader loader); }");
+    CompileTestHarness.Result collisionResult = CompileTestHarness.compile(collision);
+    assertFalse(collisionResult.success);
+    assertTrue(collisionResult.errors().contains("collide in generated adapter descriptors"));
+  }
+
+  @Test
+  void selectedStaticOverloadKeepsLegacyAndExplicitLoaderForms() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.target.Api",
+        "package com.example.target; public class Api { "
+            + "public static String read() { return \"none\"; } "
+            + "public static String read(String value) { return value; } }");
+    sources.put(
+        "com.example.adapter.Api",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Api\") public interface Api { "
+            + "@ExternalType.Static @ExternalType.Overload(\"read\") String noArg(); "
+            + "@ExternalType.Static @ExternalType.Overload(\"read\") String text(String value); }");
+    CompileTestHarness.RunnableResult r = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(r.success, r.errors());
+    Class<?> adapter = r.loader.loadClass("com.example.adapter.Api$Ext");
+    ClassLoader saved = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(r.loader);
+      assertEquals("none", adapter.getMethod("noArg").invoke(null));
+      assertEquals("ok", adapter.getMethod("text", String.class).invoke(null, "ok"));
+    } finally {
+      Thread.currentThread().setContextClassLoader(saved);
+    }
+    assertEquals("none", adapter.getMethod("noArg", ClassLoader.class).invoke(null, r.loader));
+    assertEquals(
+        "ok",
+        adapter.getMethod("text", ClassLoader.class, String.class).invoke(null, r.loader, "ok"));
+  }
+
+  @Test
+  void selectorDiagnosticsAreSourcePositionedAndRejectAllInvalidGroups() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.Outside",
+        "package com.example; import io.btrace.core.extensions.ExternalType; "
+            + "public interface Outside { @ExternalType.Overload(\"read\") int read(); }");
+    sources.put(
+        "com.example.Api",
+        "package com.example;\n"
+            + "import io.btrace.core.extensions.ExternalType;\n"
+            + "@ExternalType(\"target.Api\")\n"
+            + "public interface Api {\n"
+            + "  @ExternalType.Overload(\"one\") int one();\n"
+            + "  @ExternalType.Overload(\"same\") int first();\n"
+            + "  @ExternalType.Overload(\"same\") int second();\n"
+            + "  default @ExternalType.Overload(\"read\") int skipped() { return 0; }\n"
+            + "  static @ExternalType.Overload(\"read\") int staticSkipped() { return 0; }\n"
+            + "}\n");
+    CompileTestHarness.Result r = CompileTestHarness.compile(sources);
+    assertFalse(r.success);
+    assertTrue(r.errors().contains("only valid on an abstract method"), r.errors());
+    assertTrue(r.errors().contains("requires at least two methods selecting 'one'"), r.errors());
+    assertTrue(r.errors().contains("distinct exact target signatures"), r.errors());
+    assertTrue(
+        r.diagnostics.stream()
+            .anyMatch(
+                d ->
+                    d.getMessage(java.util.Locale.ROOT).contains("requires at least two methods")
+                        && d.getLineNumber() == 5));
+  }
+
+  @Test
+  void selectorUnderscoreIsAcceptedAsAJvmName() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.target.Api",
+        "package com.example.target; public class Api { public String _() { return \"ok\"; } public String _(String s) { return s; } }");
+    sources.put(
+        "com.example.Api",
+        "package com.example; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Api\") public interface Api { "
+            + "@ExternalType.Overload(\"_\") String first(); "
+            + "@ExternalType.Overload(\"_\") String second(String value); }");
+    CompileTestHarness.Result r = CompileTestHarness.compile(sources, 8);
+    assertTrue(r.success, r.errors());
   }
 
   @Test

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/ExternalTypeSmoke.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/ExternalTypeSmoke.java
@@ -8,7 +8,18 @@ public final class ExternalTypeSmoke {
   public static void main(String[] args) throws Exception {
     Class<?> parentType = Class.forName("example.target.ExternalParent");
     Constructor<?> constructor = parentType.getConstructor();
-    Object child = ParentApi$Ext.child(constructor.newInstance());
+    Object parent = constructor.newInstance();
+    Object child = ParentApi$Ext.child(parent);
+    if (!"external-type-overload-text-ok".equals(ParentApi$Ext.describeText(parent, "text"))) {
+      throw new AssertionError();
+    }
+    if (!"external-type-overload-child-ok".equals(ParentApi$Ext.describeChild(parent, child))) {
+      throw new AssertionError();
+    }
+    if (!"external-type-overload-underscore-ok".equals(ParentApi$Ext.underscore(parent))) {
+      throw new AssertionError();
+    }
     System.out.println(ChildApi$Ext.marker(child));
+    System.out.println("external-type-overload-text-ok");
   }
 }

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/ParentApi.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/ParentApi.java
@@ -6,4 +6,16 @@ import io.btrace.core.extensions.ExternalType;
 public interface ParentApi {
   @ExternalType.Type(ChildApi.class)
   Object child();
+
+  @ExternalType.Overload("describe")
+  String describeText(String text);
+
+  @ExternalType.Overload("describe")
+  String describeChild(@ExternalType.Type(ChildApi.class) Object child);
+
+  @ExternalType.Overload("_")
+  String underscore();
+
+  @ExternalType.Overload("_")
+  String underscoreWithText(String ignored);
 }

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/target-src/example/target/ExternalParent.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/target-src/example/target/ExternalParent.java
@@ -4,4 +4,20 @@ public final class ExternalParent {
   public ExternalChild child() {
     return new ExternalChild();
   }
+
+  public String describe(String text) {
+    return "external-type-overload-text-ok";
+  }
+
+  public String describe(ExternalChild child) {
+    return "external-type-overload-child-ok";
+  }
+
+  public String _() {
+    return "external-type-overload-underscore-ok";
+  }
+
+  public String _(String ignored) {
+    return "external-type-overload-underscore-ok";
+  }
 }

--- a/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalDataType.java
+++ b/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalDataType.java
@@ -34,6 +34,12 @@ public interface ExternalDataType {
   /** Maps to ExternalData.acceptChild(ExternalChild) through an opaque Object boundary. */
   String acceptChild(@ExternalType.Type(ExternalChildType.class) Object child);
 
+  @ExternalType.Overload("describe")
+  String describeText(String text);
+
+  @ExternalType.Overload("describe")
+  String describeChild(@ExternalType.Type(ExternalChildType.class) Object child);
+
   /** Maps to ExternalData.tag() — static dispatch via TCCL. */
   @ExternalType.Static
   String tag();

--- a/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestService.java
+++ b/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestService.java
@@ -30,6 +30,8 @@ public interface ExternalTypeTestService {
   /** Chains the opaque ExternalData child result into the child adapter. */
   String childMarker(Object externalData);
 
+  String overloadMarkers(Object externalData);
+
   /** Passes an opaque child back through a target-type adapter parameter. */
   String acceptedChildMarker(Object externalData);
 

--- a/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestServiceImpl.java
+++ b/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestServiceImpl.java
@@ -40,6 +40,14 @@ public final class ExternalTypeTestServiceImpl extends Extension
   }
 
   @Override
+  public String overloadMarkers(Object externalData) {
+    Object child = ExternalDataType$Ext.child(externalData);
+    return ExternalDataType$Ext.describeText(externalData, "ok")
+        + ","
+        + ExternalDataType$Ext.describeChild(externalData, child);
+  }
+
+  @Override
   public String acceptedChildMarker(Object externalData) {
     Object child = ExternalDataType$Ext.child(externalData);
     return ExternalDataType$Ext.acceptChild(externalData, child);

--- a/docs/BTraceExtensionDevelopmentGuide.md
+++ b/docs/BTraceExtensionDevelopmentGuide.md
@@ -248,6 +248,67 @@ require rewriting every extension call site or introducing wrappers/proxies, whi
 class-loader, identity, and lifecycle problems. The marker supplies the exact lookup type while
 keeping the runtime value honest and directly usable by another generated adapter.
 
+### Overload groups: map local aliases to one target name
+
+Use an overload group only when the target class exposes two or more public methods with the same
+name. The local contract methods may need distinct Java names—especially when two target-library
+types are both represented as `Object`—so give every member the same `@ExternalType.Overload`
+value. That value is the **target method name**, not a new adapter name.
+
+For example, assume the application library has these two methods:
+
+```java
+// Application code; it is not on the extension compile class path.
+public final class Parent {
+    public String describe(String value) { ... }
+    public String describe(Child value) { ... }
+}
+```
+
+Declare the generated-adapter contract as follows:
+
+```java
+@ExternalType("vendor.Child")
+interface ChildApi {
+    String label();
+}
+
+@ExternalType("vendor.Parent")
+interface ParentApi {
+    @ExternalType.Overload("describe")
+    String describeText(String value);
+
+    @ExternalType.Overload("describe")
+    String describeChild(@ExternalType.Type(ChildApi.class) Object value);
+}
+```
+
+The local names make the generated Java API unambiguous. At runtime, each dispatcher performs one
+exact `MethodHandles` lookup; it does not inspect the value and choose a compatible candidate.
+
+| Contract declaration | Generated call | Exact target member |
+| --- | --- | --- |
+| `describeText(String)` | `ParentApi$Ext.describeText(parent, text)` | `Parent.describe(String)` |
+| `describeChild(@ExternalType.Type(ChildApi.class) Object)` | `ParentApi$Ext.describeChild(parent, child)` | `Parent.describe(vendor.Child)` |
+
+`@ExternalType.Type(ChildApi.class)` changes the lookup signature from the extension-side
+`Object` to `vendor.Child`; it does not cast or wrap `child`. As a result, a child object from a
+different application loader is not silently accepted as the other overload.
+
+An overload group has three required properties:
+
+1. It contains at least two abstract adapter methods.
+2. Every method that selects that target name has `@ExternalType.Overload("describe")`; do not mix
+   selected and unselected methods for the same target name.
+3. Each member has a distinct exact target signature (name, static/virtual kind, return type, and
+   parameter types). The normal declared types—and `@ExternalType.Type` where needed—provide that
+   signature.
+
+Do not use `@ExternalType.Overload` for a one-method rename. A uniquely named contract method
+already binds to the target method with the same name. It also cannot enable fields, constructors,
+private members, generic/array target types, coercion, or fallback lookup; use the manual
+`MethodHandleCache` path for those cases.
+
 ### Rules
 
 - **Target:** interfaces only (`ElementType.TYPE`). The processor emits a compile error for classes.
@@ -255,7 +316,7 @@ keeping the runtime value honest and directly usable by another generated adapte
 - **Method types:** declared erased parameter and return types must exactly match the target member's JVM signature. For a direct target-library position, use `@ExternalType.Type(ChildApi.class) Object`; it keeps the adapter boundary opaque while resolving the child's target class from the resolved owner's defining loader. The returned value does not implement `ChildApi`, but can flow into `ChildApi$Ext` directly. Markers are valid only on direct `Object` returns/parameters, not generic elements or arrays.
 - **Access:** dispatch uses `MethodHandles.publicLookup()`. Only public members of public, accessible types are supported; do not add module-opening flags implicitly.
 - **Static methods:** add `@ExternalType.Static` on the interface method. `version()` preserves legacy TCCL-based class loading with the documented null-TCCL system-loader fallback. `version(ClassLoader applicationLoader)` resolves with that non-null loader exactly; it rejects null immediately with `NullPointerException("applicationLoader")`. The control argument is not a target argument. Neither form changes the target's observed TCCL.
-- **Overload groups:** use `@ExternalType.Overload("targetName")` on every member of a group of at least two local methods. The selector changes only the target name; declared exact types, including `Type` markers, select the overload. It is not a single-method alias or runtime coercion/search facility.
+- **Overload groups:** follow [the overload-group pattern above](#overload-groups-map-local-aliases-to-one-target-name). The selector changes only the target name; declared exact types, including `Type` markers, select the overload. It is not a single-method alias or runtime coercion/search facility.
 - **Default methods and static interface methods:** skipped (they already have bodies).
 - **Failures:** class lookup, missing member, and inaccessible-member failures throw `ExternalTypeResolutionException` with the original cause. Exceptions thrown by the target method propagate unchanged.
 

--- a/docs/BTraceExtensionDevelopmentGuide.md
+++ b/docs/BTraceExtensionDevelopmentGuide.md
@@ -255,6 +255,7 @@ keeping the runtime value honest and directly usable by another generated adapte
 - **Method types:** declared erased parameter and return types must exactly match the target member's JVM signature. For a direct target-library position, use `@ExternalType.Type(ChildApi.class) Object`; it keeps the adapter boundary opaque while resolving the child's target class from the resolved owner's defining loader. The returned value does not implement `ChildApi`, but can flow into `ChildApi$Ext` directly. Markers are valid only on direct `Object` returns/parameters, not generic elements or arrays.
 - **Access:** dispatch uses `MethodHandles.publicLookup()`. Only public members of public, accessible types are supported; do not add module-opening flags implicitly.
 - **Static methods:** add `@ExternalType.Static` on the interface method. `version()` preserves legacy TCCL-based class loading with the documented null-TCCL system-loader fallback. `version(ClassLoader applicationLoader)` resolves with that non-null loader exactly; it rejects null immediately with `NullPointerException("applicationLoader")`. The control argument is not a target argument. Neither form changes the target's observed TCCL.
+- **Overload groups:** use `@ExternalType.Overload("targetName")` on every member of a group of at least two local methods. The selector changes only the target name; declared exact types, including `Type` markers, select the overload. It is not a single-method alias or runtime coercion/search facility.
 - **Default methods and static interface methods:** skipped (they already have bodies).
 - **Failures:** class lookup, missing member, and inaccessible-member failures throw `ExternalTypeResolutionException` with the original cause. Exceptions thrown by the target method propagate unchanged.
 
@@ -267,7 +268,7 @@ Use generated adapters only for the supported row below. The manual path is the 
 | Public, uniquely named static or virtual methods with exact erased signatures | Supported | Use `@ExternalType`; use `Object` only where the target member itself uses `Object`. |
 | A direct target-library `Object` parameter or return type | Supported | Mark it with `@ExternalType.Type(OtherContract.class) Object`; chain opaque results into another generated adapter. |
 | Target types in generic elements or arrays | Unsupported | Use `ClassLoadingUtil` and `MethodHandleCache` directly. |
-| Overloads | Unsupported; processor error | Use `MethodHandleCache` with the exact return and parameter `Class` values. |
+| Explicit target overload groups | Supported | Mark every group member with `@ExternalType.Overload("targetName")`; local names may differ. |
 | Fields, constructors, `instanceof`, and casts | Unsupported | Use `ClassLoadingUtil` plus the appropriate direct `MethodHandles.publicLookup()` or `Class` operation. `MethodHandleCache` caches virtual and static method lookups only. |
 | Non-public or non-exported named-module members | Unsupported | Use a public supported API or explicitly configure the target JVM outside BTrace. |
 

--- a/docs/architecture/provided-style-extensions.md
+++ b/docs/architecture/provided-style-extensions.md
@@ -68,7 +68,7 @@ public final class SparkApiImpl implements SparkApi {
 
 ## External Type Adapters
 
-`@ExternalType` supports public, uniquely named methods with exact erased signatures, including direct opaque target-type positions declared as `@ExternalType.Type(ChildApi.class) Object`. The normative support table, owner-defining-loader chain semantics, failure contract, and virtual-defining-loader/static-loader-selection distinction are in the [Extension Development Guide](../BTraceExtensionDevelopmentGuide.md#app-type-adapters-with-externaltype). Keep the manual pattern in this guide for target types in generic elements/arrays, overloads, fields, constructors, and type predicates.
+`@ExternalType` supports exact public methods, opaque target-type positions, and explicit complete overload groups declared with `@ExternalType.Overload("targetName")`. The canonical selector, owner-loader, failure, and static-loader rules are in the [Extension Development Guide](../BTraceExtensionDevelopmentGuide.md#app-type-adapters-with-externaltype). Keep the manual pattern here for target types in generic elements/arrays, fields, constructors, and type predicates.
 
 For a generated static target call where the application loader is known, pass it directly:
 

--- a/integration-tests/src/test/btrace/ExternalTypeAdapterTest.java
+++ b/integration-tests/src/test/btrace/ExternalTypeAdapterTest.java
@@ -27,6 +27,7 @@ public class ExternalTypeAdapterTest {
     println("value=" + extSvc.value(data));
     println("child=" + extSvc.childMarker(data));
     println("accepted-child=" + extSvc.acceptedChildMarker(data));
+    println("overloads=" + extSvc.overloadMarkers(data));
     exit(0);
   }
 }

--- a/integration-tests/src/test/java/resources/ExternalData.java
+++ b/integration-tests/src/test/java/resources/ExternalData.java
@@ -41,6 +41,14 @@ public final class ExternalData {
     return child != null ? child.marker() : "ext-child-parameter-null";
   }
 
+  public String describe(String text) {
+    return "ext-overload-text-" + text;
+  }
+
+  public String describe(ExternalChild child) {
+    return "ext-overload-child-" + child.marker();
+  }
+
   public static String tag() {
     return "ext-data-ok";
   }

--- a/integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java
+++ b/integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java
@@ -65,7 +65,8 @@ public class ExternalTypeAdapterIntegrationTest extends RuntimeTest {
             "tag=ext-data-ok",
             "value=42",
             "child=ext-child-chain-ok",
-            "accepted-child=ext-child-chain-ok"),
+            "accepted-child=ext-child-chain-ok",
+            "overloads=ext-overload-text-ok,ext-overload-child-ext-child-chain-ok"),
         new ResultValidator() {
           @Override
           public void validate(String stdout, String stderr, int retcode, String jfrFile) {
@@ -83,6 +84,10 @@ public class ExternalTypeAdapterIntegrationTest extends RuntimeTest {
             assertTrue(
                 stdout.contains("accepted-child=ext-child-chain-ok"),
                 "@ExternalType target-type parameter dispatch failed. stdout: " + stdout);
+            assertTrue(
+                stdout.contains(
+                    "overloads=ext-overload-text-ok,ext-overload-child-ext-child-chain-ok"),
+                "@ExternalType overload dispatch failed. stdout: " + stdout);
           }
         });
   }

--- a/internal/plans/2026-08-08-issue-931-phase-4-overload-selectors-plan.md
+++ b/internal/plans/2026-08-08-issue-931-phase-4-overload-selectors-plan.md
@@ -1,0 +1,299 @@
+# Issue #931 — Phase 4 implementation plan: opt-in overload selectors
+
+**Design input:** `internal/specs/2026-08-08-issue-931-phase-4-overload-selectors.md` (CLEAN)
+
+**Baseline:** `develop` at `96c7e4b4` (#941, #942, and #943 merged)
+
+**Scope:** Phase 4 only. Add an opt-in source annotation that selects a target overload name while
+the Phase 3 lookup return/parameter types continue to form an exact `MethodType`. Preserve all
+Phase 1-3 loader, cache, error, and public-lookup boundaries. Do not implement general aliases,
+coercion, candidate search, fields, constructors, private access, or later phases.
+
+## Preconditions and hard gates
+
+1. Work only in `/private/tmp/btrace-issue-931-phase4`. Preserve the untracked clean design and
+   unrelated working-tree state. Before edits, read `AGENTS.md`, the clean design,
+   `docs/architecture/MaskedJarArchitecture.md`, the Phase 3 plan, `ExternalType`,
+   `ExternalTypeProcessor`, `MethodSpec`, `AdapterEmitter`, `CompileTestHarness`, the staged
+   extension/integration fixtures, and the external processor smoke resources.
+
+   **Stop:** A requirement that changes Phase 1-3 loader/cache/security policy, requires target
+   method enumeration, or asks for target-type descriptors in public generated methods is outside
+   this phase; return to design rather than adding a workaround.
+
+2. Establish the current test contracts before changing diagnostics. The authoritative existing
+   duplicate Java-name diagnostic is `@ExternalType does not support overloaded methods`; retain
+   it whenever any member of that Java-name duplicate group has no selector. Capture existing
+   processor/generator test shapes so compatibility assertions compare generated source and
+   failure text deliberately rather than incidentally.
+
+   **Stop:** Do not silently update a legacy test to accept an opt-in selector. A formerly invalid
+   duplicate source must remain invalid unless every member in the duplicate group opts in.
+
+## Implementation steps
+
+3. Add the narrow public source API in
+   `btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java`:
+
+   - Add nested public `@ExternalType.Overload`, `@Retention(SOURCE)`, `@Target(METHOD)`, with
+     only `String value()`.
+   - Keep `ExternalType.Type`, `ExternalType.Static`, existing retention/targets, and all binary
+     surfaces unchanged. Do not add class-array, descriptor, return-type, runtime helper, or
+     reflection-based selector attributes.
+   - Extend `ExternalTypeAnnotationTest` to pin method-only source retention and the absence of
+     unintended public annotation members.
+
+   **Gate:** The annotation is compile-time input only; later artifact inspection must nevertheless
+   find `ExternalType$Overload.class` in the published masked JAR.
+
+4. Refactor the model boundary in
+   `btrace-core/src/main/java/io/btrace/extension/processor/MethodSpec.java` and its users.
+
+   - Store `adapterName` and `targetName` independently; initialize both to the local Java name
+     for no-selector members. Retain `returnType`, `returnTargetFqn`, `paramTypes`,
+     `paramTargetFqns`, and static metadata exactly as Phase 3 represents them.
+   - Update `AdapterEmitter` so Java declarations and dispatcher calls use `adapterName`, while
+     `findVirtual`/`findStatic` and `ExternalTypeResolutionException` member text use
+     `targetName`.
+   - Preserve exact Phase 3 `MethodType` construction: ordinary erased declarations yield class
+     literals; each marked position loads its recorded target FQN with
+     `Class.forName(fqn, false, owner.getClassLoader())`. Return type remains part of the exact
+     lookup type even if the emitted signature is `Object`.
+
+   **Stop:** No emitted `ChildApi.class`, target-library `.class`, candidate enumeration,
+   `isAssignableFrom`, varargs packing, boxing/coercion, fallback target name, or retry using a
+   second signature is permitted.
+
+5. Rework `btrace-core/src/main/java/io/btrace/extension/processor/ExternalTypeProcessor.java`
+   so it validates a complete outer-interface model before emitting any adapter.
+
+   - Add `io.btrace.core.extensions.ExternalType.Overload` to supported annotation types and
+     read selector values with `AnnotationMirror`/`AnnotationValue`, never reflective annotation
+     access. Collect all adapted methods (non-default and non-Java-static) first.
+   - Consume/validate a selector only on an abstract adapted method of an `@ExternalType`
+     interface. A selector elsewhere, including a skipped default or actual Java-static method,
+     receives one source-positioned unconsumed-annotation diagnostic. Let javac retain native
+     applicability/non-repeatable errors for parameter/type placement and repeats.
+   - Implement frozen JVM member-name validation: value is nonblank; contains none of `.`, `;`,
+     `[`, or `/`; is neither `<init>` nor `<clinit>`; and is preserved byte-for-byte (do not trim a
+     nonblank name). Do not call host `SourceVersion.isIdentifier` or `isKeyword`: `_` must remain
+     valid under a newer host JDK when the extension is compiled as Java 8. Local adapter names
+     remain normal javac-validated Java declarations.
+   - First group by local Java method name. If a duplicate has any unselected member, issue the
+     established legacy duplicate diagnostic. Only an all-selected duplicate group continues.
+     Then group by target name (selector value, otherwise legacy local name): target groups larger
+     than one require selectors on every member, while a one-member selector group is rejected as
+     an unsupported general alias.
+   - Compute exact target keys as `(targetName, static/virtual, lookup return, lookup params)`.
+     The lookup positions use Phase 3 target FQNs rather than emitted `Object` types. Reject
+     duplicate exact keys. Separately compute generated descriptors: virtual
+     `(Object self, emitted args...)`, legacy static `(emitted args...)`, and explicit static
+     `(ClassLoader, emitted args...)`; reject any same-local-name collision, including selected
+     `read()` and `read(ClassLoader)` where Phase 2 forms overlap.
+   - Retain all Phase 3 `Type` marker validation, consumption, target-FQN metadata, and error
+     aggregation. Any invalid method/group prevents adapter emission for its outer interface.
+     Diagnostics name the member/group/collision and prescribe selecting every group member,
+     using distinct exact types, or renaming the local method.
+
+   **Gate:** Keep legacy unique no-selector source and generated lookup byte-for-byte equivalent
+   where practical. Do not add selector-name global maps, negative caches, or strong loader maps.
+
+6. Preserve emitter runtime semantics while adding selector coverage in
+   `AdapterEmitter` and focused `ExternalTypeProcessorTest` runtime fixtures.
+
+   - Each selected member retains its own existing `ClassValue<ResolvedCall>`, static monitor,
+     weak identity loader index, success-only publication, and resolution counter. Exact selected
+     keys mean independent handles; selector name is not a shared cache key.
+   - Virtual calls resolve owner from the receiver defining loader. Legacy static calls keep TCCL
+     with null-to-system fallback; explicit static calls require a non-null leading loader before
+     lookup/cache mutation. After either owner resolves, marked types load only from the owner
+     defining loader.
+   - Missing selected member, inaccessible selected member, owner failure, and missing marked type
+     remain cause-preserving, retryable `ExternalTypeResolutionException`s naming the selected
+     target name. Target exceptions, wrong-argument invocation errors, linkage/security failures,
+     and target-thrown resolution errors stay transparent. Keep `publicLookup()` and existing
+     module/access policy unchanged.
+
+   **Stop:** A wrong-loader child or incompatible argument must fail; it must never choose another
+   overload. Do not initialize target classes, mutate TCCL/classpaths, bypass module exports, or
+   use private lookup.
+
+## Focused test gates
+
+7. Extend `ExternalTypeProcessorTest` and any local compile harness needed for these source,
+   generated-source, and diagnostic cases. Keep a positive and an intended-failure assertion for
+   each new boundary.
+
+   - A valid same-local-name overload group and distinct local aliases both select target
+     `describe(String)` and `describe(vendor.Child)`; aliases use a Phase 3
+     `@ExternalType.Type(ChildApi.class) Object` declaration. Assert generated local descriptors
+     remain `Object`, lookup strings use `describe`, and the marked FQN—not `ChildApi`—enters the
+     `MethodType`. Include differing return types to prove return type participates in exact-key
+     validation.
+   - Preserve a unique no-selector generated source fixture. Assert duplicate Java names with a
+     legacy member retain the exact old duplicate diagnostic; assert all-selected duplicates no
+     longer receive that diagnostic.
+   - Assert malformed blank, `<init>`, `<clinit>`, and slash-containing selector values; a selector
+     outside an adapted interface; selector on default/actual Java-static skipped methods; a
+     one-member selector group; a target group mixed with legacy members; duplicate exact target
+     keys; invalid/repeated Phase 3 markers; and static legacy/explicit generated-descriptor
+     collision. Retain javac-native diagnostics for inapplicable/repeated annotation syntax.
+   - Add a Java-8 compilation fixture (or optional `CompileTestHarness` release flag) that uses
+     selector value `_` and a target member named `_`; compile the target with `javac --release 8`.
+     This proves host JDK keywords are not used for selector validation. The same fixture family
+     rejects `<init>`, `<clinit>`, blank, and `x/y`.
+   - Runtime tests use two hostile isolated loaders with same-FQN overloaded owner/child types;
+     prove loader-specific text and child paths select independent exact handles, a loader-A child
+     cannot call loader-B’s selected child overload, and hostile `equals`/`hashCode` are untouched.
+     Cover missing selected overload, missing marked type, inaccessible selection, retry after
+     availability, target-error transparency, wrong arguments/no fallback, and per-member cache
+     counters. Cover legacy-TCCL and explicit-loader static selected overloads, explicit null
+     before cache mutation, and null-TCCL system fallback.
+
+   **Gate:** Every new failure checks the intended diagnostic/cause rather than merely any failed
+   compilation or invocation.
+
+8. Add staged, real cross-process proof. Update
+   `integration-tests/src/test/java/resources/ExternalData.java`,
+   `btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalDataType.java`,
+   `btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestService.java`,
+   `btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestServiceImpl.java`,
+   `integration-tests/src/test/btrace/ExternalTypeAdapterTest.java`, and
+   `integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java`.
+
+   - Give `ExternalData` target-owned `describe(String)` and `describe(ExternalChild)` overloads
+     with unambiguous text and child markers. The extension contract exposes local aliases such as
+     `describeText` and `describeChild`, both annotated `@ExternalType.Overload("describe")`; the
+     child alias keeps its Phase 3 `@ExternalType.Type(ExternalChildType.class) Object` boundary.
+   - Stage a regenerated extension that calls both aliases through the normal client-agent-target
+     protocol and emits two distinct target-owned markers. The integration assertion waits for
+     both markers and keeps the Phase 2 explicit-loader/release-extension-isolation scenario
+     separate and passing.
+
+   **Stop:** Do not substitute direct unit invocation for this gate. The proof must exercise the
+   real client, agent, target JVM, protocol, staged extension, and application overloads.
+
+9. Extend the packaged external smoke resources under
+   `btrace-dist/src/test/resources/external-type-processor-smoke/` into a deliberately two-stage
+   Java-8 test.
+
+   - In `target-src`, provide `ExternalParent.describe(String)`,
+     `ExternalParent.describe(ExternalChild)`, and a legal Java-8 target member named `_`.
+   - In `extension-src`, add contract aliases with `Overload("describe")`, use Phase 3 marked
+     child type metadata, and a selector `Overload("_")`; keep contract/driver sources independent
+     of target imports/classes. Have the driver invoke text, child, and underscore paths and print
+     precise success markers.
+   - After a clean masked-JAR build, inspect the one jar for
+     `ExternalType$Overload.class`, `ExternalType$Type.class`, processor implementation/support,
+     and `META-INF/services/javax.annotation.processing.Processor`. Compile target sources first
+     with `javac --release 8`; compile contracts and driver with `javac --release 8`, with only
+     that masked JAR on `-cp` and `-processorpath`, never target output/sources. Inspect generated
+     source for local `Object` signatures, selected `describe`/`_` lookup names, and no target or
+     contract `.class` leakage. Require generated `ParentApi$Ext.java` and `ChildApi$Ext.java`,
+     plus both compiled adapter classes, and inspect both sources for their applicable `Object`
+     boundaries. Negatively scan all generated sources for `ChildApi.class`, `ParentApi.class`,
+     `ExternalChild.class`, and `ExternalParent.class`; target source availability cannot mask a
+     leak because the contract compilation classpath/processorpath contains only the masked JAR,
+     not target source or output. Run the driver only with extension output, target output, and the
+     masked JAR.
+
+   **Gate:** A missing annotation class, processor service, processor implementation, accidental
+   compile-path target dependency, failure to compile `_` under release 8, or missing marker stops
+   release validation. Make no unrelated Gradle packaging change unless inspection proves it is
+   needed.
+
+10. Update the canonical extension documentation in
+    `docs/BTraceExtensionDevelopmentGuide.md` and the manual-path pointer in
+    `docs/architecture/provided-style-extensions.md`.
+
+    - Explain that `Overload("targetName")` is source-only, only applies to complete selected
+      groups, maps a local method name to a target name, and combines with declared erased types
+      plus Phase 3 type markers for exact lookup.
+    - Document aliases for opaque `Object` target types and the retained static loader forms.
+      State explicitly that selectors do not offer single-method aliases, runtime overload choice,
+      coercion/boxing/varargs adaptation, generic/array target type support, fields/constructors,
+      private lookup, or JPMS bypass. Keep existing access/security warnings accurate.
+
+   **Gate:** Do not add Gradle plugin DSL, generated-adapter TCCL workarounds, or promises beyond
+   the verified public behavior.
+
+## Verification and publication readiness
+
+11. From `/private/tmp/btrace-issue-931-phase4`, redirect every Gradle command to `/tmp` and
+    inspect only filtered logs. A nonzero status, `BUILD FAILED`, test/format failure, artifact
+    mismatch, compiler diagnostic mismatch, or missing integration marker stops at the owning
+    step. Build the distribution before integration. Only if the documented restricted-environment
+    address-selection failure occurs, rerun the affected command with
+    `JAVA_TOOL_OPTIONS="-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false"`.
+
+    ```text
+    GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-core:test > /tmp/btrace-issue-931-phase4-core-test.log 2>&1
+    rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|ExternalType" /tmp/btrace-issue-931-phase4-core-test.log
+
+    GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-core:spotlessCheck > /tmp/btrace-issue-931-phase4-core-spotless.log 2>&1
+    rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase4-core-spotless.log
+
+    GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew clean :btrace-dist:btraceJar > /tmp/btrace-issue-931-phase4-masked-jar.log 2>&1
+    rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|btraceJar" /tmp/btrace-issue-931-phase4-masked-jar.log
+
+    rg --files btrace-dist/build/resources/main | rg '^btrace-dist/build/resources/main/v[^/]+/libs/btrace\.jar$' > /tmp/btrace-issue-931-phase4-jar-path.log
+    test "$(rg -c '^' /tmp/btrace-issue-931-phase4-jar-path.log)" = 1
+    BTRACE_931_PHASE4_JAR="$(rg -x 'btrace-dist/build/resources/main/v[^/]+/libs/btrace\.jar' /tmp/btrace-issue-931-phase4-jar-path.log)"
+    jar tf "$BTRACE_931_PHASE4_JAR" > /tmp/btrace-issue-931-phase4-jar-entries.log
+    rg -n 'io/btrace/core/extensions/ExternalType(\$Overload|\$Type|ResolutionException)?\.class|io/btrace/extension/processor/ExternalTypeProcessor\.class|META-INF/services/javax.annotation.processing.Processor' /tmp/btrace-issue-931-phase4-jar-entries.log
+    unzip -p "$BTRACE_931_PHASE4_JAR" META-INF/services/javax.annotation.processing.Processor > /tmp/btrace-issue-931-phase4-processor-service.log
+    rg -n '^io\.btrace\.extension\.processor\.ExternalTypeProcessor$' /tmp/btrace-issue-931-phase4-processor-service.log
+
+    BTRACE_931_PHASE4_SMOKE=$(mktemp -d /tmp/btrace-issue-931-phase4-smoke.XXXXXX)
+    javac --release 8 -d "$BTRACE_931_PHASE4_SMOKE/target-classes" btrace-dist/src/test/resources/external-type-processor-smoke/target-src/example/target/*.java > /tmp/btrace-issue-931-phase4-target-javac.log 2>&1
+    rg -n "error:|warning:|External" /tmp/btrace-issue-931-phase4-target-javac.log || true
+    javac --release 8 -cp "$BTRACE_931_PHASE4_JAR" -processorpath "$BTRACE_931_PHASE4_JAR" -d "$BTRACE_931_PHASE4_SMOKE/extension-classes" -s "$BTRACE_931_PHASE4_SMOKE/generated" btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/*.java > /tmp/btrace-issue-931-phase4-extension-javac.log 2>&1
+    rg -n "error:|warning:|ExternalType|ParentApi|ChildApi" /tmp/btrace-issue-931-phase4-extension-javac.log || true
+    test -f "$BTRACE_931_PHASE4_SMOKE/generated/example/ParentApi\$Ext.java"
+    test -f "$BTRACE_931_PHASE4_SMOKE/generated/example/ChildApi\$Ext.java"
+    test -f "$BTRACE_931_PHASE4_SMOKE/extension-classes/example/ParentApi\$Ext.class"
+    test -f "$BTRACE_931_PHASE4_SMOKE/extension-classes/example/ChildApi\$Ext.class"
+    rg -n 'Object|findVirtual|"describe"|"_"' "$BTRACE_931_PHASE4_SMOKE/generated/example/ParentApi\$Ext.java"
+    rg -n 'Object|findVirtual' "$BTRACE_931_PHASE4_SMOKE/generated/example/ChildApi\$Ext.java"
+    ! rg -n 'ChildApi\.class|ParentApi\.class|ExternalChild\.class|ExternalParent\.class' "$BTRACE_931_PHASE4_SMOKE/generated"/example/*.java
+    java -cp "$BTRACE_931_PHASE4_SMOKE/extension-classes:$BTRACE_931_PHASE4_SMOKE/target-classes:$BTRACE_931_PHASE4_JAR" example.ExternalTypeSmoke > /tmp/btrace-issue-931-phase4-external-run.log 2>&1
+    rg -n '^external-type-overload-text-ok$' /tmp/btrace-issue-931-phase4-external-run.log
+    rg -n '^external-type-overload-child-ok$' /tmp/btrace-issue-931-phase4-external-run.log
+    rg -n '^external-type-overload-underscore-ok$' /tmp/btrace-issue-931-phase4-external-run.log
+
+    GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-dist:build > /tmp/btrace-issue-931-phase4-dist-build.log 2>&1
+    rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Test" /tmp/btrace-issue-931-phase4-dist-build.log
+
+    GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-extensions:btrace-ext-test:spotlessCheck > /tmp/btrace-issue-931-phase4-ext-spotless.log 2>&1
+    rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase4-ext-spotless.log
+
+    GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:spotlessCheck > /tmp/btrace-issue-931-phase4-integration-spotless.log 2>&1
+    rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase4-integration-spotless.log
+
+    GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:test -Pintegration --tests tests.ExternalTypeAdapterIntegrationTest > /tmp/btrace-issue-931-phase4-integration.log 2>&1
+    rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|ExternalTypeAdapterIntegrationTest|timed out" /tmp/btrace-issue-931-phase4-integration.log
+    ```
+
+12. Before any user-authorized commit/push, run root formatting in the dedicated worktree, inspect
+    its intentional adjustments, then repeat its check and the affected tests if it changes source.
+    Finish with whitespace/status/release-surface review. This plan does not authorize committing
+    or pushing.
+
+    ```text
+    GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew spotlessApply > /tmp/btrace-issue-931-phase4-root-spotless-apply.log 2>&1
+    rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase4-root-spotless-apply.log
+    git diff --check
+    git status --short
+    GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew spotlessCheck > /tmp/btrace-issue-931-phase4-root-spotless-check.log 2>&1
+    rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase4-root-spotless-check.log
+    ```
+
+## Completion criteria
+
+Phase 4 is complete only when all-selected groups map local aliases and Phase 3 FQN metadata to
+exact public target handles; legacy duplicate protection is unchanged; frozen JVM-name validation
+accepts `_` under `javac --release 8`; selector diagnostics are source-positioned and specific;
+cache, loader, retry, error, access, and invocation boundaries hold; both application overloads
+work across the real client-agent-target path; the masked jar alone supports separated Java-8
+external compilation and execution; documentation is scope-accurate; all gates above pass; and
+the final diff is clean. This does not authorize Phase 5 or later work.

--- a/internal/specs/2026-08-08-issue-931-phase-4-overload-selectors.md
+++ b/internal/specs/2026-08-08-issue-931-phase-4-overload-selectors.md
@@ -1,0 +1,232 @@
+# Issue #931, Phase 4: opt-in `@ExternalType` overload selectors
+
+Date: 2026-08-08
+Status: design proposal; implementation and planning must wait for a CLEAN design review
+Baseline: `develop` at `96c7e4b4` (#941, #942, and #943 merged)
+
+## Problem and goal
+
+Phase 1 deliberately rejects duplicate adapted method names, preventing accidental overload
+selection. Phase 3 makes target-library signatures expressible, but two target types can both have
+an opaque `Object` Java boundary and therefore need distinct local adapter method names. Phase 4
+adds an explicit compile-time target-overload selector. It maps only to a target name; the existing
+declared erased return/parameter types, including Phase 3 marked types, form the exact signature.
+There is no runtime compatible-method search, coercion, or argument-driven overload selection.
+
+## Decision: `@ExternalType.Overload("targetName")`
+
+Add a nested public source-only annotation:
+
+```java
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.METHOD)
+public @interface Overload {
+  String value();
+}
+```
+
+`Overload` supplies the target method name. It is allowed only on an abstract adapted method in an
+`@ExternalType` interface, and only in a group of at least two adapted methods selecting that same
+target name. Every member of that target-name group must carry the annotation; a one-member target
+selection remains the existing unannotated method-name binding.
+
+```java
+@ExternalType("vendor.Parent")
+public interface ParentApi {
+  @ExternalType.Overload("describe")
+  String describeText(String text);
+
+  @ExternalType.Overload("describe")
+  String describeChild(@ExternalType.Type(ChildApi.class) Object child);
+}
+```
+
+The target keys are `(describe, virtual, (String)String)` and
+`(describe, virtual, (vendor.Child)String)`. Generated Java methods remain
+`describeText(Object self, String)` and `describeChild(Object self, Object)`: neither `ChildApi`
+nor `vendor.Child` enters the public adapter API.
+
+The annotation has no descriptor, `Class<?>[]`, or return-type attributes. The full selector is
+target name plus static/virtual kind plus the existing exact erased return and parameter types.
+
+| Option | Decision | Reason |
+| --- | --- | --- |
+| `@ExternalType.Overload("name")` plus declared types | Chosen | Minimal Java-8 opt-in; supports aliases for multiple `Object`-erased target types and reuses Phase 3 lookup types. |
+| Descriptor or `Class<?>[]` attributes | Rejected | Duplicates source signatures and drifts from Phase 3 metadata. |
+| Runtime assignability/first-match selection | Rejected | Loader-sensitive, ambiguous, and violates exact `MethodHandle` semantics. |
+| Implicitly permit duplicate names | Rejected | Changes legacy invalid-source behaviour and cannot handle distinct aliases. |
+| One-method target-name aliases | Rejected | Broadens scope; a unique legacy declaration is already exact. |
+
+`SOURCE` retention is intentional. The masked published JAR must expose
+`ExternalType$Overload.class` for external compilation, but generated adapters do not retain or
+inspect the annotation at runtime.
+
+## Validation and processor contract
+
+`ExternalTypeProcessor` adds `io.btrace.core.extensions.ExternalType.Overload` to supported
+annotation types and reads its value through `AnnotationMirror`/`AnnotationValue`. Before emitting
+an outer interface, it collects all non-default, non-Java-static methods and validates selectors as
+one model.
+
+1. A selector uses frozen JVM member-name semantics, not host-JDK
+   `SourceVersion.isIdentifier`/`isKeyword` behaviour. It is nonblank and an unqualified JVM
+   method name: it contains none of `.`, `;`, `[`, or `/`, and is not `<init>` or `<clinit>`.
+   Preserve the value exactly for lookup; do not trim a nonblank value. This intentionally accepts
+   `_` and other legal JVM aliases even when a newer host JDK treats them differently from Java 8.
+   Local adapter method names remain ordinary Java source declarations and are consequently
+   validated by javac as Java identifiers. Staticness comes solely from `ExternalType.Static`.
+2. A selector outside an adapted interface or on a default/Java-static skipped method is an
+   unconsumed, source-positioned processor error. Parameter/type uses and repeated annotations
+   retain normal javac applicability/non-repeatable diagnostics.
+3. For each **Java method-name** duplicate group, if any member lacks a selector, preserve the
+   current `@ExternalType does not support overloaded methods` error. Such a group can proceed
+   only when every member has a valid selector.
+4. Group candidates by **target name** (selector value or legacy Java name). A group with more than
+   one member is valid only when every member selects explicitly. A selector group of one is an
+   error: this phase is not general aliasing.
+
+5. Selected members must have distinct exact target keys: target name, static/virtual kind, erased
+   lookup return type, and erased lookup parameter types. Phase 3 positions compare referenced
+   target FQNs, not emitted `Object`. Reject duplicate keys rather than redundant aliases/caches.
+6. Independently calculate generated Java descriptors: virtual `(Object self, emitted args...)`,
+   static legacy `(emitted args...)`, and static explicit `(ClassLoader, emitted args...)`. For one
+   generated Java name, reject collisions, including selected `read()` and `read(ClassLoader)`,
+   whose Phase 2 explicit/legacy forms collide.
+7. Retain Phase 3 `Type` validation, marker consumption, and owner-loader lookup metadata. Any
+   invalid selected method prevents emitting that interface’s adapter.
+
+Diagnostics identify the method/group/collision and prescribe marking the whole selected group,
+using distinct exact signatures, or renaming a local method. Existing no-selector unique methods
+retain their source behaviour and emitted lookup.
+
+## Generated lookup, loaders, and invocation
+
+Extend `MethodSpec` with separate `adapterName` and `targetName`. They are equal for legacy
+members. `AdapterEmitter` uses `adapterName` for generated Java declarations and `targetName` in
+`findVirtual`, `findStatic`, and `ExternalTypeResolutionException` member text.
+
+For every member, retain Phases 1-3 resolution: ordinary types become erased class literals;
+Phase 3 marked types use `Class.forName(fqn, false, owner.getClassLoader())`; and
+`MethodHandles.publicLookup().findVirtual/findStatic(owner, targetName, exactMethodType)` is the
+only lookup. Return types participate in the exact `MethodType`.
+
+The handle sees only the adapter method’s declared values. There is no candidate enumeration,
+`isAssignableFrom`, varargs packing, boxing policy, fallback selector, or second-signature retry.
+Wrong-loader opaque objects and incompatible arguments fail transparently; they never change the
+selected overload.
+
+Static members retain both Phase 2 forms: legacy TCCL with null-to-system fallback, and explicit
+non-null leading loader. After either obtains the owner, Phase 3 marked types resolve from
+`owner.getClassLoader()`, never TCCL, selected loader, or extension loader. Virtual dispatch keeps
+its receiver defining-loader policy.
+
+## Cache, failure, and security boundaries
+
+Each selected member has its existing independent `ClassValue<ResolvedCall>`, static monitor, weak
+identity loader index, and resolution counter. Different exact target keys require different
+handles; no selector/name global map, second target cache, negative cache, or strong loader map is
+allowed. Success-only publication and unloadability remain unchanged.
+
+Owner/marked-type/missing-selected-member/access failures remain retryable
+`ExternalTypeResolutionException`s. The member in the message is the selected target name. Target
+exceptions, wrong-argument invocation errors, security/linkage errors, and target-thrown resolution
+exceptions remain transparent.
+
+`publicLookup()` remains the public/exported-module boundary. Phase 4 does not initialize classes,
+mutate TCCL/classpaths, use implementation loaders, bypass SecurityManager checks, open modules,
+use private lookup, or access non-public members.
+
+## Compatibility and published surface
+
+- Existing unique no-selector contracts retain source, binary, runtime, static-form, failure, and
+  cache behaviour.
+- Existing duplicate Java-name contracts keep the current duplicate-name error until every member
+  opts in; no previously-invalid source becomes silently valid.
+- A new selected group needs an extension rebuild. Its local generated methods are new opt-in
+  surface and its target aliases make no compatibility claim for a previously nonexistent adapter.
+- `ExternalType.Overload` is the only new public source API. It is source-retained and needs no
+  runtime helper or target-class reference. External builds require its narrow class plus current
+  processor service/support in published `io.btrace:btrace`.
+- Phase 3 opaque `Object` descriptors remain intact; selectors do not leak contract or target types
+  into generated public APIs.
+
+## Affected components
+
+- `btrace-core`: `ExternalType`, `ExternalTypeProcessor`, `MethodSpec`, possibly `AdapterSpec`,
+  `AdapterEmitter`, `ExternalTypeAnnotationTest`, and `ExternalTypeProcessorTest`.
+- `btrace-dist`: separated smoke inputs/assertions and masked-JAR inspection only unless a specific
+  missing annotation/processor entry proves a narrow packaging change necessary.
+- `btrace-extensions:btrace-ext-test` and `integration-tests`: application-only overloads,
+  regenerated test extension, dedicated marker, and real client-agent-target coverage.
+- `docs/BTraceExtensionDevelopmentGuide.md` (canonical) and
+  `docs/architecture/provided-style-extensions.md` (manual-path pointer). No Gradle plugin DSL.
+
+## Acceptance criteria
+
+1. `ExternalType.Overload` is source-retained, method-targeted, and externally compilable from the
+   masked JAR. A valid two-member group uses selector target names in generated lookup.
+2. A unique no-selector method is generated/resolved as before. A duplicate Java-name group with a
+   legacy member has the established duplicate-name error.
+3. Valid source overloads and distinct-name aliases select target `describe(String)` and
+   `describe(vendor.Child)` exactly. The latter uses the Phase 3 FQN in `MethodType` while keeping
+   `Object` public descriptors. Return type participates in the exact target key.
+4. Diagnostics reject blank, JVM-illegal, and special selector values; selector outside/skip
+   contexts; one-member selector groups; target groups with legacy members; duplicate exact keys;
+   failed Phase 3 markers; and static legacy/explicit generated descriptor collisions. Valid groups
+   have no duplicate diagnostics; repeated/inapplicable annotations retain javac native diagnostics.
+   A `javac --release 8` fixture must successfully select an application method named `_`, proving
+   selector validation is not host-JDK keyword dependent; fixtures reject `<init>`, `<clinit>`,
+   blank, and a name containing `/`.
+5. Two hostile isolated loaders with same-FQN overloaded owner/child types resolve independent
+   selected handles and values. A loader-A child cannot invoke loader-B’s child overload, and
+   hostile loader equality/hash code is unused.
+6. Legacy-TCCL and explicit-loader static overloads retain Phase 2/3 selection and type-loader
+   rules. Explicit null fails before lookup/cache; null TCCL retains system fallback.
+7. Missing selected overload, inaccessible selected overload, and missing marked type are
+   cause-preserving/retryable `ExternalTypeResolutionException`s using target selector name.
+   Target failures and wrong-argument invocation failures are transparent; no fallback overload.
+8. The staged test extension, real client, agent, target JVM, and protocol invoke ordinary and
+   marked-target application overloads through local aliases, emit target-owned markers, and retain
+   Phase 2 explicit-loader coverage/release-extension isolation.
+9. A clean masked JAR contains `ExternalType$Overload.class`, processor service/implementation,
+   and support. `javac --release 8` separately compiles target classes and contract/driver sources;
+   contracts use only the masked JAR on classpath/processorpath, and the driver runs both selected
+   paths with only target output, extension output, and that JAR.
+10. Docs state exact selector semantics and retain all Phase 2/3 and access boundaries; they do not
+    promise coercion, target-type generic/array support, fields, constructors, private/JPMS access,
+    or a general alias mechanism.
+
+## Verification gates
+
+Use a workspace-local Gradle cache, redirect every Gradle command to `/tmp`, and filter before
+reading. The implementation plan must run:
+
+```text
+:btrace-core:test
+:btrace-core:spotlessCheck
+clean :btrace-dist:btraceJar
+:btrace-dist:build
+:btrace-extensions:btrace-ext-test:spotlessCheck
+:integration-tests:spotlessCheck
+:integration-tests:test -Pintegration --tests tests.ExternalTypeAdapterIntegrationTest
+```
+
+It must inspect exactly one masked `btrace.jar`, its processor service, `ExternalType$Overload`,
+and processor implementation; compile target sources separately with `javac --release 8`; compile
+contracts/driver using `javac --release 8 -cp/-processorpath <masked-jar>` without target
+source/class paths; inspect generated local `Object` signatures and exact target names/no target or
+contract `.class` leakage; run the driver with only separated outputs/JAR; and finish with
+`git diff --check`. Each positive test needs a malformed, wrong-loader, missing-overload, or
+unfixed-behaviour case that demonstrably fails for the intended reason. Use IPv4
+`JAVA_TOOL_OPTIONS` only for the known restricted-environment address-selection issue.
+
+## Non-goals and completion boundary
+
+Phase 4 excludes one-method aliases, overload-by-value heuristics, varargs adaptation, boxing or
+coercion policy, generic/array target types, fields, constructors, casts/predicates,
+`MethodHandleCache` redesign, loader fallback, TCCL mutation, private lookup, and JPMS bypasses.
+
+It is complete only when explicit groups map local declarations plus Phase 3 lookup types to exact
+public target handles, legacy duplicate protection remains, cache/security boundaries hold, masked
+external compilation works, and real integration proves both selected overloads. It does not
+authorize Phase 5 or later work.


### PR DESCRIPTION
Closes #931.

## Summary

- Add source-only `@ExternalType.Overload("targetName")` for complete, opt-in overload selector groups.
- Preserve legacy duplicate-name rejection and exact `MethodType` lookup, including Phase 3 opaque target types.
- Reject ambiguous selector groups, duplicate target signatures, and generated dispatcher collisions before adapter emission.
- Cover selected overloads in staged integration fixtures and the separated external smoke resources; document the supported boundary.

## Compatibility

Existing unique declarations are unchanged. Existing duplicate local names remain invalid unless every member explicitly selects the same target name. Selectors never perform coercion or runtime candidate selection.

## Verification

- Root `spotlessApply` (`BUILD SUCCESSFUL`)
- `git diff --check`

Focused core, masked-artifact, and real integration execution remain pending local validation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/944)
<!-- Reviewable:end -->
