### PR TITLE
feat(extensions): add external type operations

### DIFF
--- a/btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java
+++ b/btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java
@@ -75,4 +75,59 @@ public @interface ExternalType {
   @interface Overload {
     String value();
   }
+
+  /**
+   * Selects a public target field read. The annotated method must have no target arguments and a
+   * non-{@code void} exact field type; {@link Static} selects a static field.
+   *
+   * <p>The processor consumes this source-only marker. Generated adapters do not inspect it at
+   * runtime.
+   */
+  @Retention(RetentionPolicy.SOURCE)
+  @Target(ElementType.METHOD)
+  @interface Getter {
+    String value();
+  }
+
+  /**
+   * Selects a public target field write. The annotated method must return {@code void} and have one
+   * exact field-type argument; {@link Static} selects a static field.
+   *
+   * <p>The processor consumes this source-only marker. Generated adapters do not inspect it at
+   * runtime.
+   */
+  @Retention(RetentionPolicy.SOURCE)
+  @Target(ElementType.METHOD)
+  @interface Setter {
+    String value();
+  }
+
+  /**
+   * Selects a public constructor on the adapted type. The annotated method must return direct
+   * {@code Object}; its parameters describe the exact constructor signature.
+   *
+   * <p>The processor consumes this source-only marker. Generated adapters do not inspect it at
+   * runtime.
+   */
+  @Retention(RetentionPolicy.SOURCE)
+  @Target(ElementType.METHOD)
+  @interface Constructor {}
+
+  /**
+   * Selects {@link Class#isInstance(Object)} for the adapted type. The annotated method must return
+   * {@code boolean} and accept one direct {@code Object}; resolution uses the non-null value's
+   * defining loader.
+   */
+  @Retention(RetentionPolicy.SOURCE)
+  @Target(ElementType.METHOD)
+  @interface InstanceOf {}
+
+  /**
+   * Selects {@link Class#cast(Object)} for the adapted type. The annotated method must return
+   * direct {@code Object} and accept one direct {@code Object}; resolution uses the non-null
+   * value's defining loader.
+   */
+  @Retention(RetentionPolicy.SOURCE)
+  @Target(ElementType.METHOD)
+  @interface Cast {}
 }

--- a/btrace-core/src/main/java/io/btrace/core/extensions/ExternalTypeResolutionException.java
+++ b/btrace-core/src/main/java/io/btrace/core/extensions/ExternalTypeResolutionException.java
@@ -20,8 +20,10 @@ package io.btrace.core.extensions;
  * Signals that an {@link ExternalType} adapter could not resolve its configured public target
  * member.
  *
- * <p>The cause is the original {@link ClassNotFoundException}, {@link NoSuchMethodException}, or
- * {@link IllegalAccessException}. Target-method failures are not translated to this exception.
+ * <p>The cause is the original {@link ClassNotFoundException}, {@link NoSuchMethodException},
+ * {@link NoSuchFieldException}, or {@link IllegalAccessException}, including an access probe for an
+ * {@link ExternalType.InstanceOf} or {@link ExternalType.Cast} operation. Target invocation
+ * failures are not translated to this exception.
  */
 public final class ExternalTypeResolutionException extends IllegalStateException {
   public ExternalTypeResolutionException(String owner, String member, Throwable cause) {

--- a/btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * Copyright (c) 2008, 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,7 @@ final class AdapterEmitter {
     w.println("import io.btrace.core.extensions.ExternalTypeResolutionException;");
     w.println();
     w.println("public final class " + spec.adapterSimpleName() + " {");
-    w.println("  private static final String OWNER = \"" + spec.externalFqn + "\";");
+    w.println("  private static final String OWNER = \"" + javaString(spec.externalFqn) + "\";");
     w.println("  private " + spec.adapterSimpleName() + "() {}");
     renderResolvedCall(w);
     renderLoaderKey(w);
@@ -108,13 +108,15 @@ final class AdapterEmitter {
     w.println("  }");
   }
 
-  private void renderMethod(PrintWriter w, MethodSpec m, int ordinal) {
+  private void renderMethod(PrintWriter w, MethodSpec method, int ordinal) {
+    if (method.operation == MethodSpec.OperationKind.INSTANCE_OF
+        || method.operation == MethodSpec.OperationKind.CAST) {
+      renderPredicate(w, method, ordinal);
+      return;
+    }
     String cache = "$" + ordinal + "$calls";
     String attempts = "__btraceExternalTypeResolutionAttempts$" + ordinal;
-    String[] lists = paramAndArgLists(m);
-    String paramList = lists[0];
-    String argList = lists[1];
-
+    String[] lists = paramAndArgLists(method);
     w.println();
     w.println("  private static int " + attempts + ";");
     w.println("  private static final ClassValue<ResolvedCall> " + cache + " =");
@@ -122,43 +124,31 @@ final class AdapterEmitter {
     w.println("        @Override");
     w.println(
         "        protected ResolvedCall computeValue(Class<?> "
-            + (m.isStatic ? "owner" : "receiver")
+            + (loaderOperation(method) ? "owner" : "receiver")
             + ") {");
     w.println("          try {");
-    if (!m.isStatic) {
+    if (!loaderOperation(method)) {
       w.println(
           "            Class<?> owner = Class.forName(OWNER, false, receiver.getClassLoader());");
     }
-    renderMarkedTypes(w, m, ordinal);
+    renderMarkedTypes(w, method, ordinal);
     w.println("            " + attempts + "++;");
-    if (m.isStatic) {
-      w.println(
-          "            return new ResolvedCall(owner, MethodHandles.publicLookup().findStatic(owner, \""
-              + m.targetName
-              + "\", "
-              + methodTypeLiteral(m, ordinal)
-              + ")); ");
-    } else {
-      w.println(
-          "            return new ResolvedCall(owner, MethodHandles.publicLookup().findVirtual(owner, \""
-              + m.targetName
-              + "\", "
-              + methodTypeLiteral(m, ordinal)
-              + ")); ");
-    }
-    w.println("          } catch (" + resolutionExceptions(m) + " e) {");
+    w.println(
+        "            return new ResolvedCall(owner, " + lookupExpression(method, ordinal) + ");");
+    w.println("          } catch (" + resolutionExceptions(method) + " e) {");
     w.println(
         "            throw new ExternalTypeResolutionException(OWNER, \""
-            + m.targetName
+            + javaString(method.targetName)
             + "\", e);");
     w.println("          }");
     w.println("        }");
     w.println("      };");
-    if (m.isStatic) renderStaticSupport(w, m, ordinal, cache);
+    if (loaderOperation(method)) renderStaticSupport(w, method, ordinal, cache);
     w.println();
-    w.println("  public static " + m.returnType + " " + m.adapterName + "(" + paramList + ") {");
+    w.println(
+        "  public static " + method.returnType + " " + method.adapterName + "(" + lists[0] + ") {");
     w.println("    try {");
-    if (m.isStatic) {
+    if (loaderOperation(method)) {
       w.println(
           "      ResolvedCall call = $"
               + ordinal
@@ -169,35 +159,115 @@ final class AdapterEmitter {
       w.println("      ResolvedCall call = " + cache + ".get(self.getClass());");
     }
     w.print("      ");
-    if (!"void".equals(m.returnType)) w.print("return (" + m.returnType + ") ");
-    w.println("call.handle.invoke(" + argList + ");");
+    if (!"void".equals(method.returnType)) w.print("return (" + method.returnType + ") ");
+    w.println("call.handle.invoke(" + lists[1] + ");");
     w.println("    } catch (Throwable t) { throw sneak(t); }");
     w.println("  }");
-    if (m.isStatic) {
-      String explicitParamList = "ClassLoader applicationLoader";
-      if (!paramList.isEmpty()) explicitParamList += ", " + paramList;
+    if (loaderOperation(method)) {
+      String explicitParameters = "ClassLoader applicationLoader";
+      if (!lists[0].isEmpty()) explicitParameters += ", " + lists[0];
       w.println();
       w.println(
           "  public static "
-              + m.returnType
+              + method.returnType
               + " "
-              + m.adapterName
+              + method.adapterName
               + "("
-              + explicitParamList
+              + explicitParameters
               + ") {");
       w.println(
           "    if (applicationLoader == null) throw new NullPointerException(\"applicationLoader\");");
       w.println("    try {");
       w.println("      ResolvedCall call = $" + ordinal + "$resolveStatic(applicationLoader);");
       w.print("      ");
-      if (!"void".equals(m.returnType)) w.print("return (" + m.returnType + ") ");
-      w.println("call.handle.invoke(" + argList + ");");
+      if (!"void".equals(method.returnType)) w.print("return (" + method.returnType + ") ");
+      w.println("call.handle.invoke(" + lists[1] + ");");
       w.println("    } catch (Throwable t) { throw sneak(t); }");
       w.println("  }");
     }
   }
 
-  private void renderStaticSupport(PrintWriter w, MethodSpec m, int ordinal, String cache) {
+  private void renderPredicate(PrintWriter w, MethodSpec method, int ordinal) {
+    String cache = "$" + ordinal + "$owners";
+    String attempts = "__btraceExternalTypeResolutionAttempts$" + ordinal;
+    w.println();
+    w.println("  private static int " + attempts + ";");
+    w.println("  private static final ClassValue<Class<?>> " + cache + " =");
+    w.println("      new ClassValue<Class<?>>() {");
+    w.println("        @Override");
+    w.println("        protected Class<?> computeValue(Class<?> valueType) {");
+    w.println("          try {");
+    w.println("            " + attempts + "++;");
+    w.println(
+        "            Class<?> owner = Class.forName(OWNER, false, valueType.getClassLoader());");
+    w.println(
+        "            MethodHandles.publicLookup().findVirtual(owner, \"getClass\", MethodType.methodType(Class.class));");
+    w.println("            return owner;");
+    w.println(
+        "          } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {");
+    w.println(
+        "            throw new ExternalTypeResolutionException(OWNER, \""
+            + javaString(method.targetName)
+            + "\", e);");
+    w.println("          }");
+    w.println("        }");
+    w.println("      };");
+    w.println();
+    w.println(
+        "  public static "
+            + method.returnType
+            + " "
+            + method.adapterName
+            + "(java.lang.Object p0) {");
+    if (method.operation == MethodSpec.OperationKind.INSTANCE_OF) {
+      w.println("    if (p0 == null) return false;");
+      w.println("    return " + cache + ".get(p0.getClass()).isInstance(p0);");
+    } else {
+      w.println("    if (p0 == null) return null;");
+      w.println("    return " + cache + ".get(p0.getClass()).cast(p0);");
+    }
+    w.println("  }");
+  }
+
+  private String lookupExpression(MethodSpec method, int ordinal) {
+    String name = "\"" + javaString(method.targetName) + "\"";
+    if (method.operation == MethodSpec.OperationKind.GETTER) {
+      return "MethodHandles.publicLookup()."
+          + (method.isStatic ? "findStaticGetter" : "findGetter")
+          + "(owner, "
+          + name
+          + ", "
+          + fieldTypeLiteral(method, ordinal)
+          + ")";
+    }
+    if (method.operation == MethodSpec.OperationKind.SETTER) {
+      return "MethodHandles.publicLookup()."
+          + (method.isStatic ? "findStaticSetter" : "findSetter")
+          + "(owner, "
+          + name
+          + ", "
+          + fieldTypeLiteral(method, ordinal)
+          + ")";
+    }
+    if (method.operation == MethodSpec.OperationKind.CONSTRUCTOR) {
+      return "MethodHandles.publicLookup().findConstructor(owner, "
+          + constructorTypeLiteral(method, ordinal)
+          + ")";
+    }
+    return "MethodHandles.publicLookup()."
+        + (method.isStatic ? "findStatic" : "findVirtual")
+        + "(owner, "
+        + name
+        + ", "
+        + methodTypeLiteral(method, ordinal)
+        + ")";
+  }
+
+  private boolean loaderOperation(MethodSpec method) {
+    return method.isStatic || method.operation == MethodSpec.OperationKind.CONSTRUCTOR;
+  }
+
+  private void renderStaticSupport(PrintWriter w, MethodSpec method, int ordinal, String cache) {
     String prefix = "$" + ordinal + "$";
     w.println();
     w.println("  private static final Object " + prefix + "monitor = new Object();");
@@ -235,7 +305,9 @@ final class AdapterEmitter {
     w.println("        owner = Class.forName(OWNER, false, loader);");
     w.println("      } catch (ClassNotFoundException e) {");
     w.println(
-        "        throw new ExternalTypeResolutionException(OWNER, \"" + m.targetName + "\", e);");
+        "        throw new ExternalTypeResolutionException(OWNER, \""
+            + javaString(method.targetName)
+            + "\", e);");
     w.println("      }");
     w.println("      ResolvedCall call = " + cache + ".get(owner);");
     w.println(
@@ -280,55 +352,98 @@ final class AdapterEmitter {
     w.println("  }");
   }
 
-  private void renderMarkedTypes(PrintWriter w, MethodSpec m, int ordinal) {
-    if (m.returnTargetFqn != null) {
+  private void renderMarkedTypes(PrintWriter w, MethodSpec method, int ordinal) {
+    if (method.returnTargetFqn != null) {
       w.println(
           "            Class<?> $"
               + ordinal
               + "$returnType = Class.forName(\""
-              + m.returnTargetFqn
+              + javaString(method.returnTargetFqn)
               + "\", false, owner.getClassLoader());");
     }
-    for (int i = 0; i < m.paramTargetFqns.size(); i++) {
-      String fqn = m.paramTargetFqns.get(i);
-      if (fqn == null) continue;
-      w.println(
-          "            Class<?> $"
-              + ordinal
-              + "$parameterType"
-              + i
-              + " = Class.forName(\""
-              + fqn
-              + "\", false, owner.getClassLoader());");
+    for (int i = 0; i < method.paramTargetFqns.size(); i++) {
+      String fqn = method.paramTargetFqns.get(i);
+      if (fqn != null)
+        w.println(
+            "            Class<?> $"
+                + ordinal
+                + "$parameterType"
+                + i
+                + " = Class.forName(\""
+                + javaString(fqn)
+                + "\", false, owner.getClassLoader());");
     }
   }
 
-  private String resolutionExceptions(MethodSpec m) {
-    if (!m.isStatic || m.returnTargetFqn != null || hasMarkedParameter(m)) {
+  private String resolutionExceptions(MethodSpec method) {
+    if (method.operation == MethodSpec.OperationKind.GETTER
+        || method.operation == MethodSpec.OperationKind.SETTER) {
+      if (!loaderOperation(method)
+          || method.returnTargetFqn != null
+          || hasMarkedParameter(method)) {
+        return "ClassNotFoundException | NoSuchFieldException | IllegalAccessException";
+      }
+      return "NoSuchFieldException | IllegalAccessException";
+    }
+    if (!loaderOperation(method) || method.returnTargetFqn != null || hasMarkedParameter(method)) {
       return "ClassNotFoundException | NoSuchMethodException | IllegalAccessException";
     }
     return "NoSuchMethodException | IllegalAccessException";
   }
 
-  private boolean hasMarkedParameter(MethodSpec m) {
-    for (String targetFqn : m.paramTargetFqns) {
-      if (targetFqn != null) return true;
-    }
+  private boolean hasMarkedParameter(MethodSpec method) {
+    for (String fqn : method.paramTargetFqns) if (fqn != null) return true;
     return false;
   }
 
-  private String methodTypeLiteral(MethodSpec m, int ordinal) {
+  private String fieldTypeLiteral(MethodSpec method, int ordinal) {
+    if (method.operation == MethodSpec.OperationKind.GETTER)
+      return method.returnTargetFqn == null
+          ? method.returnType + ".class"
+          : "$" + ordinal + "$returnType";
+    return method.paramTargetFqns.get(0) == null
+        ? method.paramTypes.get(0) + ".class"
+        : "$" + ordinal + "$parameterType0";
+  }
+
+  private String constructorTypeLiteral(MethodSpec method, int ordinal) {
+    StringBuilder result = new StringBuilder("MethodType.methodType(void.class");
+    for (int i = 0; i < method.paramTypes.size(); i++)
+      result.append(", ").append(typeLiteral(method, ordinal, i));
+    return result.append(")").toString();
+  }
+
+  private String methodTypeLiteral(MethodSpec method, int ordinal) {
     StringBuilder result = new StringBuilder("MethodType.methodType(");
     result.append(
-        m.returnTargetFqn == null ? m.returnType + ".class" : "$" + ordinal + "$returnType");
-    for (int i = 0; i < m.paramTypes.size(); i++) {
-      result.append(", ");
-      result.append(
-          m.paramTargetFqns.get(i) == null
-              ? m.paramTypes.get(i) + ".class"
-              : "$" + ordinal + "$parameterType" + i);
-    }
+        method.returnTargetFqn == null
+            ? method.returnType + ".class"
+            : "$" + ordinal + "$returnType");
+    for (int i = 0; i < method.paramTypes.size(); i++)
+      result.append(", ").append(typeLiteral(method, ordinal, i));
     return result.append(")").toString();
+  }
+
+  private String typeLiteral(MethodSpec method, int ordinal, int parameter) {
+    return method.paramTargetFqns.get(parameter) == null
+        ? method.paramTypes.get(parameter) + ".class"
+        : "$" + ordinal + "$parameterType" + parameter;
+  }
+
+  private String[] paramAndArgLists(MethodSpec method) {
+    StringBuilder parameters = new StringBuilder();
+    StringBuilder arguments = new StringBuilder();
+    if (!loaderOperation(method)) {
+      parameters.append("java.lang.Object self");
+      arguments.append("self");
+    }
+    for (int i = 0; i < method.paramTypes.size(); i++) {
+      if (parameters.length() > 0) parameters.append(", ");
+      if (arguments.length() > 0) arguments.append(", ");
+      parameters.append(method.paramTypes.get(i)).append(" p").append(i);
+      arguments.append("p").append(i);
+    }
+    return new String[] {parameters.toString(), arguments.toString()};
   }
 
   private void renderSneak(PrintWriter w) {
@@ -340,19 +455,18 @@ final class AdapterEmitter {
     w.println("  }");
   }
 
-  private String[] paramAndArgLists(MethodSpec m) {
-    StringBuilder params = new StringBuilder();
-    StringBuilder args = new StringBuilder();
-    if (!m.isStatic) {
-      params.append("java.lang.Object self");
-      args.append("self");
+  private String javaString(String text) {
+    StringBuilder escaped = new StringBuilder();
+    for (int i = 0; i < text.length(); i++) {
+      char c = text.charAt(i);
+      if (c == '\\') escaped.append("\\\\");
+      else if (c == '\"') escaped.append("\\\"");
+      else if (c == '\n') escaped.append("\\n");
+      else if (c == '\r') escaped.append("\\r");
+      else if (c == '\t') escaped.append("\\t");
+      else if (c < 0x20 || c == 0x7f) escaped.append(String.format("\\u%04x", (int) c));
+      else escaped.append(c);
     }
-    for (int i = 0; i < m.paramTypes.size(); i++) {
-      if (params.length() > 0) params.append(", ");
-      if (args.length() > 0) args.append(", ");
-      params.append(m.paramTypes.get(i)).append(" p").append(i);
-      args.append("p").append(i);
-    }
-    return new String[] {params.toString(), args.toString()};
+    return escaped.toString();
   }
 }

--- a/btrace-core/src/main/java/io/btrace/extension/processor/ExternalTypeProcessor.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/ExternalTypeProcessor.java
@@ -228,13 +228,7 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
 
       invalid |=
           validateSignature(
-              method,
-              operation,
-              isStatic,
-              returnType,
-              returnTargetFqn,
-              parameterTypes,
-              parameterTargetFqns);
+              method, operation, returnType, returnTargetFqn, parameterTypes, parameterTargetFqns);
       String adapterName = method.getSimpleName().toString();
       String targetName =
           operation == OperationKind.METHOD
@@ -335,7 +329,6 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
   private boolean validateSignature(
       ExecutableElement method,
       OperationKind operation,
-      boolean isStatic,
       String returnType,
       String returnTargetFqn,
       List<String> parameterTypes,

--- a/btrace-core/src/main/java/io/btrace/extension/processor/ExternalTypeProcessor.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/ExternalTypeProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Jaroslav Bachorik <j.bachorik@btrace.io>.
+ * Copyright (c) 2008, 2026, Jaroslav Bachorik <j.bachorik@btrace.io>.
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,8 +17,10 @@
 package io.btrace.extension.processor;
 
 import io.btrace.core.extensions.ExternalType;
+import io.btrace.extension.processor.MethodSpec.OperationKind;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,9 +44,21 @@ import javax.tools.JavaFileObject;
 @SupportedAnnotationTypes({
   "io.btrace.core.extensions.ExternalType",
   "io.btrace.core.extensions.ExternalType.Type",
-  "io.btrace.core.extensions.ExternalType.Overload"
+  "io.btrace.core.extensions.ExternalType.Overload",
+  "io.btrace.core.extensions.ExternalType.Getter",
+  "io.btrace.core.extensions.ExternalType.Setter",
+  "io.btrace.core.extensions.ExternalType.Constructor",
+  "io.btrace.core.extensions.ExternalType.InstanceOf",
+  "io.btrace.core.extensions.ExternalType.Cast"
 })
 public final class ExternalTypeProcessor extends AbstractProcessor {
+  private static final String TYPE = "io.btrace.core.extensions.ExternalType.Type";
+  private static final String OVERLOAD = "io.btrace.core.extensions.ExternalType.Overload";
+  private static final String GETTER = "io.btrace.core.extensions.ExternalType.Getter";
+  private static final String SETTER = "io.btrace.core.extensions.ExternalType.Setter";
+  private static final String CONSTRUCTOR = "io.btrace.core.extensions.ExternalType.Constructor";
+  private static final String INSTANCE_OF = "io.btrace.core.extensions.ExternalType.InstanceOf";
+  private static final String CAST = "io.btrace.core.extensions.ExternalType.Cast";
 
   @Override
   public SourceVersion getSupportedSourceVersion() {
@@ -53,266 +67,475 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
 
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-    Set<Element> markers =
-        new HashSet<>(roundEnv.getElementsAnnotatedWith(ExternalType.Type.class));
-    Set<Element> consumedMarkers = new HashSet<>();
-    Set<Element> selectors =
-        new HashSet<>(roundEnv.getElementsAnnotatedWith(ExternalType.Overload.class));
-    Set<Element> consumedSelectors = new HashSet<>();
+    Set<Element> typeMarkers = elements(roundEnv, ExternalType.Type.class);
+    Set<Element> overloadMarkers = elements(roundEnv, ExternalType.Overload.class);
+    Set<Element> getterMarkers = elements(roundEnv, ExternalType.Getter.class);
+    Set<Element> setterMarkers = elements(roundEnv, ExternalType.Setter.class);
+    Set<Element> constructorMarkers = elements(roundEnv, ExternalType.Constructor.class);
+    Set<Element> instanceOfMarkers = elements(roundEnv, ExternalType.InstanceOf.class);
+    Set<Element> castMarkers = elements(roundEnv, ExternalType.Cast.class);
+    Set<Element> consumed = new HashSet<>();
+
     for (Element e : roundEnv.getElementsAnnotatedWith(ExternalType.class)) {
       if (e.getKind() != ElementKind.INTERFACE) {
-        processingEnv
-            .getMessager()
-            .printMessage(
-                Diagnostic.Kind.ERROR,
-                "@ExternalType can only be applied to interfaces; found " + e.getKind() + " " + e,
-                e);
+        error("@ExternalType can only be applied to interfaces; found " + e.getKind() + " " + e, e);
         continue;
       }
       TypeElement iface = (TypeElement) e;
       String externalFqn = iface.getAnnotation(ExternalType.class).value();
       if (externalFqn == null || externalFqn.isEmpty()) {
-        processingEnv
-            .getMessager()
-            .printMessage(
-                Diagnostic.Kind.ERROR,
-                "@ExternalType.value() must be a non-empty class name on "
-                    + iface.getQualifiedName(),
-                iface);
+        error(
+            "@ExternalType.value() must be a non-empty class name on " + iface.getQualifiedName(),
+            e);
         continue;
       }
       try {
         AdapterSpec spec =
-            buildSpec(iface, externalFqn, markers, consumedMarkers, selectors, consumedSelectors);
+            buildSpec(
+                iface,
+                externalFqn,
+                typeMarkers,
+                overloadMarkers,
+                getterMarkers,
+                setterMarkers,
+                constructorMarkers,
+                instanceOfMarkers,
+                castMarkers,
+                consumed);
         if (spec != null) emit(spec, iface);
       } catch (Exception ex) {
-        processingEnv
-            .getMessager()
-            .printMessage(
-                Diagnostic.Kind.ERROR,
-                "Failed to emit adapter for " + iface.getQualifiedName() + ": " + ex,
-                iface);
+        error("Failed to emit adapter for " + iface.getQualifiedName() + ": " + ex, iface);
       }
     }
     reportUnconsumed(
-        selectors,
-        consumedSelectors,
+        typeMarkers,
+        consumed,
+        "@ExternalType.Type is only valid as @ExternalType.Type(OtherContract.class) Object on a non-static, non-default method of an @ExternalType interface.");
+    reportUnconsumed(
+        overloadMarkers,
+        consumed,
         "@ExternalType.Overload is only valid on an abstract method of an @ExternalType interface.");
-    for (Element marker : markers) {
-      if (consumedMarkers.contains(marker)) continue;
-      processingEnv
-          .getMessager()
-          .printMessage(
-              Diagnostic.Kind.ERROR,
-              "@ExternalType.Type is only valid as @ExternalType.Type(OtherContract.class) Object "
-                  + "on a non-static, non-default method of an @ExternalType interface.",
-              marker);
-    }
+    reportUnconsumed(
+        getterMarkers,
+        consumed,
+        "@ExternalType.Getter is only valid on an abstract method of an @ExternalType interface.");
+    reportUnconsumed(
+        setterMarkers,
+        consumed,
+        "@ExternalType.Setter is only valid on an abstract method of an @ExternalType interface.");
+    reportUnconsumed(
+        constructorMarkers,
+        consumed,
+        "@ExternalType.Constructor is only valid on an abstract method of an @ExternalType interface.");
+    reportUnconsumed(
+        instanceOfMarkers,
+        consumed,
+        "@ExternalType.InstanceOf is only valid on an abstract method of an @ExternalType interface.");
+    reportUnconsumed(
+        castMarkers,
+        consumed,
+        "@ExternalType.Cast is only valid on an abstract method of an @ExternalType interface.");
     return true;
+  }
+
+  private Set<Element> elements(RoundEnvironment roundEnv, Class<? extends Annotation> annotation) {
+    return new HashSet<>(roundEnv.getElementsAnnotatedWith(annotation));
   }
 
   private AdapterSpec buildSpec(
       TypeElement iface,
       String externalFqn,
-      Set<Element> markers,
-      Set<Element> consumedMarkers,
-      Set<Element> selectors,
-      Set<Element> consumedSelectors) {
+      Set<Element> typeMarkers,
+      Set<Element> overloadMarkers,
+      Set<Element> getterMarkers,
+      Set<Element> setterMarkers,
+      Set<Element> constructorMarkers,
+      Set<Element> instanceOfMarkers,
+      Set<Element> castMarkers,
+      Set<Element> consumed) {
     String pkg = processingEnv.getElementUtils().getPackageOf(iface).getQualifiedName().toString();
-    String simple = iface.getSimpleName().toString();
     List<MethodSpec> methods = new ArrayList<>();
-    Map<String, List<MethodSpec>> localGroups = new HashMap<>();
-    Map<String, List<MethodSpec>> targetGroups = new HashMap<>();
-    Map<MethodSpec, Boolean> selected = new HashMap<>();
     Map<MethodSpec, ExecutableElement> origins = new HashMap<>();
+    Map<MethodSpec, Boolean> selected = new HashMap<>();
+    Map<String, List<MethodSpec>> localMethodGroups = new HashMap<>();
+    Map<String, List<MethodSpec>> targetMethodGroups = new HashMap<>();
+    Map<FieldKey, MethodSpec> getters = new HashMap<>();
+    Map<FieldKey, MethodSpec> setters = new HashMap<>();
+    Map<String, Boolean> fieldStatic = new HashMap<>();
     boolean invalid = false;
-    for (Element m : iface.getEnclosedElements()) {
-      if (m.getKind() != ElementKind.METHOD) continue;
-      ExecutableElement em = (ExecutableElement) m;
-      if (em.isDefault() || em.getModifiers().contains(Modifier.STATIC)) continue;
-      String methodName = em.getSimpleName().toString();
-      String selector = null;
-      if (selectors.contains(em)) {
-        consumedSelectors.add(em);
-        selector = selectorValue(em);
-        if (!validTargetName(selector)) {
-          processingEnv
-              .getMessager()
-              .printMessage(
-                  Diagnostic.Kind.ERROR, "Invalid @ExternalType.Overload target name.", em);
+
+    for (Element member : iface.getEnclosedElements()) {
+      if (member.getKind() != ElementKind.METHOD) continue;
+      ExecutableElement method = (ExecutableElement) member;
+      OperationKind operation =
+          operation(
+              method,
+              getterMarkers,
+              setterMarkers,
+              constructorMarkers,
+              instanceOfMarkers,
+              castMarkers);
+      boolean hasOverload = overloadMarkers.contains(method);
+      boolean isStatic = method.getAnnotation(ExternalType.Static.class) != null;
+      if (method.isDefault() || method.getModifiers().contains(Modifier.STATIC)) {
+        continue;
+      }
+      if (operation != OperationKind.METHOD) consumed.add(method);
+      if (hasOverload) consumed.add(method);
+
+      if (operation == null) {
+        error("An @ExternalType method may have at most one operation marker.", method);
+        invalid = true;
+        operation = OperationKind.METHOD;
+      }
+      String selector = hasOverload ? annotationStringValue(method, OVERLOAD) : null;
+      if (hasOverload && !validMemberName(selector)) {
+        error("Invalid @ExternalType.Overload target name.", method);
+        invalid = true;
+      }
+      if (operation != OperationKind.METHOD && hasOverload) {
+        error("@ExternalType.Overload is only valid on ordinary method operations.", method);
+        invalid = true;
+      }
+      if ((operation == OperationKind.CONSTRUCTOR
+              || operation == OperationKind.INSTANCE_OF
+              || operation == OperationKind.CAST)
+          && isStatic) {
+        error("@ExternalType.Static is not valid on this operation.", method);
+        invalid = true;
+      }
+
+      String returnType = erased(method.getReturnType());
+      String returnTargetFqn = null;
+      if (typeMarkers.contains(method)) {
+        consumed.add(method);
+        returnTargetFqn = targetFqn(method, returnType);
+        invalid |= returnTargetFqn == null;
+      }
+      List<String> parameterTypes = new ArrayList<>();
+      List<String> parameterTargetFqns = new ArrayList<>();
+      for (VariableElement parameter : method.getParameters()) {
+        String parameterType = erased(parameter.asType());
+        parameterTypes.add(parameterType);
+        String targetFqn = null;
+        if (typeMarkers.contains(parameter)) {
+          consumed.add(parameter);
+          targetFqn = targetFqn(parameter, parameterType);
+          invalid |= targetFqn == null;
+        }
+        parameterTargetFqns.add(targetFqn);
+      }
+
+      invalid |=
+          validateSignature(
+              method,
+              operation,
+              isStatic,
+              returnType,
+              returnTargetFqn,
+              parameterTypes,
+              parameterTargetFqns);
+      String adapterName = method.getSimpleName().toString();
+      String targetName =
+          operation == OperationKind.METHOD
+              ? (selector != null ? selector : adapterName)
+              : operationTargetName(method, operation);
+      if ((operation == OperationKind.GETTER || operation == OperationKind.SETTER)
+          && !validFieldName(targetName)) {
+        error("Invalid @ExternalType field name.", method);
+        invalid = true;
+      }
+      MethodSpec spec =
+          new MethodSpec(
+              adapterName,
+              targetName,
+              operation,
+              returnType,
+              returnTargetFqn,
+              parameterTypes,
+              parameterTargetFqns,
+              isStatic);
+      methods.add(spec);
+      origins.put(spec, method);
+      if (operation == OperationKind.METHOD) {
+        selected.put(spec, hasOverload);
+        localMethodGroups.computeIfAbsent(adapterName, ignored -> new ArrayList<>()).add(spec);
+        targetMethodGroups.computeIfAbsent(targetName, ignored -> new ArrayList<>()).add(spec);
+      }
+      if (operation == OperationKind.GETTER || operation == OperationKind.SETTER) {
+        Boolean previousStatic = fieldStatic.putIfAbsent(targetName, isStatic);
+        if (previousStatic != null && previousStatic.booleanValue() != isStatic) {
+          error(
+              "An @ExternalType field cannot be both static and instance in one contract.", method);
+          invalid = true;
+        }
+        FieldKey fieldKey = new FieldKey(targetName, isStatic);
+        Map<FieldKey, MethodSpec> kind = operation == OperationKind.GETTER ? getters : setters;
+        if (kind.put(fieldKey, spec) != null) {
+          error(
+              "An @ExternalType contract permits only one getter and one setter per target field.",
+              method);
           invalid = true;
         }
       }
-      boolean isStatic = em.getAnnotation(ExternalType.Static.class) != null;
-      String rt = processingEnv.getTypeUtils().erasure(em.getReturnType()).toString();
-      String returnTargetFqn = null;
-      if (markers.contains(em)) {
-        consumedMarkers.add(em);
-        returnTargetFqn = targetFqn(em, rt);
-        invalid |= returnTargetFqn == null;
-      }
-      List<String> params = new ArrayList<>();
-      List<String> paramTargetFqns = new ArrayList<>();
-      for (VariableElement p : em.getParameters()) {
-        String paramType = processingEnv.getTypeUtils().erasure(p.asType()).toString();
-        params.add(paramType);
-        String targetFqn = null;
-        if (markers.contains(p)) {
-          consumedMarkers.add(p);
-          targetFqn = targetFqn(p, paramType);
-          invalid |= targetFqn == null;
-        }
-        paramTargetFqns.add(targetFqn);
-      }
-      String targetName = selector != null ? selector : methodName;
-      MethodSpec spec =
-          new MethodSpec(
-              methodName, targetName, rt, returnTargetFqn, params, paramTargetFqns, isStatic);
-      methods.add(spec);
-      origins.put(spec, em);
-      selected.put(spec, selector != null);
-      localGroups.computeIfAbsent(methodName, ignored -> new ArrayList<>()).add(spec);
-      targetGroups.computeIfAbsent(targetName, ignored -> new ArrayList<>()).add(spec);
     }
+    invalid |=
+        validateMethodGroups(iface, localMethodGroups, targetMethodGroups, selected, origins);
+    for (FieldKey key : getters.keySet()) {
+      MethodSpec getter = getters.get(key);
+      MethodSpec setter = setters.get(key);
+      if (setter != null
+          && !"void".equals(getter.returnType)
+          && setter.paramTypes.size() == 1
+          && !lookupType(getter, true).equals(lookupType(setter, false))) {
+        error(
+            "@ExternalType getter and setter for a field must use the same exact field type.",
+            origins.get(setter));
+        invalid = true;
+      }
+    }
+    invalid |= validateKeys(methods, origins);
+    return invalid
+        ? null
+        : new AdapterSpec(pkg, iface.getSimpleName().toString(), externalFqn, methods);
+  }
+
+  private OperationKind operation(
+      ExecutableElement method,
+      Set<Element> getters,
+      Set<Element> setters,
+      Set<Element> constructors,
+      Set<Element> instanceOfs,
+      Set<Element> casts) {
+    int count = 0;
+    OperationKind result = OperationKind.METHOD;
+    if (getters.contains(method)) {
+      count++;
+      result = OperationKind.GETTER;
+    }
+    if (setters.contains(method)) {
+      count++;
+      result = OperationKind.SETTER;
+    }
+    if (constructors.contains(method)) {
+      count++;
+      result = OperationKind.CONSTRUCTOR;
+    }
+    if (instanceOfs.contains(method)) {
+      count++;
+      result = OperationKind.INSTANCE_OF;
+    }
+    if (casts.contains(method)) {
+      count++;
+      result = OperationKind.CAST;
+    }
+    return count > 1 ? null : result;
+  }
+
+  private boolean validateSignature(
+      ExecutableElement method,
+      OperationKind operation,
+      boolean isStatic,
+      String returnType,
+      String returnTargetFqn,
+      List<String> parameterTypes,
+      List<String> parameterTargetFqns) {
+    boolean invalid = false;
+    if (operation == OperationKind.GETTER) {
+      invalid |=
+          require(
+              !"void".equals(returnType) && parameterTypes.isEmpty(),
+              "@ExternalType.Getter requires a non-void return and no target arguments.",
+              method);
+      invalid |=
+          require(
+              allNull(parameterTargetFqns),
+              "@ExternalType.Getter does not permit parameter @ExternalType.Type markers.",
+              method);
+    } else if (operation == OperationKind.SETTER) {
+      invalid |=
+          require(
+              "void".equals(returnType) && parameterTypes.size() == 1,
+              "@ExternalType.Setter requires void return and exactly one target argument.",
+              method);
+      invalid |=
+          require(
+              returnTargetFqn == null,
+              "@ExternalType.Setter does not permit a return @ExternalType.Type marker.",
+              method);
+    } else if (operation == OperationKind.CONSTRUCTOR) {
+      invalid |=
+          require(
+              "java.lang.Object".equals(returnType) && returnTargetFqn == null,
+              "@ExternalType.Constructor requires direct Object return without @ExternalType.Type.",
+              method);
+    } else if (operation == OperationKind.INSTANCE_OF) {
+      invalid |=
+          require(
+              "boolean".equals(returnType)
+                  && parameterTypes.size() == 1
+                  && "java.lang.Object".equals(parameterTypes.get(0))
+                  && returnTargetFqn == null
+                  && allNull(parameterTargetFqns),
+              "@ExternalType.InstanceOf requires boolean return and one direct unmarked Object argument.",
+              method);
+    } else if (operation == OperationKind.CAST) {
+      invalid |=
+          require(
+              "java.lang.Object".equals(returnType)
+                  && parameterTypes.size() == 1
+                  && "java.lang.Object".equals(parameterTypes.get(0))
+                  && returnTargetFqn == null
+                  && allNull(parameterTargetFqns),
+              "@ExternalType.Cast requires direct Object return and one direct unmarked Object argument.",
+              method);
+    }
+    return invalid;
+  }
+
+  private boolean require(boolean condition, String message, Element element) {
+    if (!condition) error(message, element);
+    return !condition;
+  }
+
+  private boolean validateMethodGroups(
+      TypeElement iface,
+      Map<String, List<MethodSpec>> localGroups,
+      Map<String, List<MethodSpec>> targetGroups,
+      Map<MethodSpec, Boolean> selected,
+      Map<MethodSpec, ExecutableElement> origins) {
+    boolean invalid = false;
     for (Map.Entry<String, List<MethodSpec>> entry : localGroups.entrySet()) {
       if (entry.getValue().size() > 1
           && entry.getValue().stream().anyMatch(m -> !selected.get(m))) {
-        processingEnv
-            .getMessager()
-            .printMessage(
-                Diagnostic.Kind.ERROR,
-                "@ExternalType does not support overloaded methods: '"
-                    + entry.getKey()
-                    + "' is declared more than once in "
-                    + iface.getQualifiedName()
-                    + ". Rename the methods or select every member.",
-                origins.get(entry.getValue().get(0)));
+        error(
+            "@ExternalType does not support overloaded methods: '"
+                + entry.getKey()
+                + "' is declared more than once in "
+                + iface.getQualifiedName()
+                + ". Rename the methods or select every member.",
+            origins.get(entry.getValue().get(0)));
         invalid = true;
       }
     }
     for (Map.Entry<String, List<MethodSpec>> entry : targetGroups.entrySet()) {
-      if (entry.getValue().size() == 1 && selected.get(entry.getValue().get(0))) {
-        processingEnv
-            .getMessager()
-            .printMessage(
-                Diagnostic.Kind.ERROR,
-                "@ExternalType.Overload requires at least two methods selecting '"
-                    + entry.getKey()
-                    + "'.",
-                origins.get(entry.getValue().get(0)));
+      List<MethodSpec> group = entry.getValue();
+      if (group.size() == 1 && selected.get(group.get(0))) {
+        error(
+            "@ExternalType.Overload requires at least two methods selecting '"
+                + entry.getKey()
+                + "'.",
+            origins.get(group.get(0)));
         invalid = true;
       }
-      if (entry.getValue().size() > 1
-          && entry.getValue().stream().anyMatch(m -> !selected.get(m))) {
-        processingEnv
-            .getMessager()
-            .printMessage(
-                Diagnostic.Kind.ERROR,
-                "Every method selecting target '"
-                    + entry.getKey()
-                    + "' must use @ExternalType.Overload.",
-                origins.get(entry.getValue().get(0)));
+      if (group.size() > 1 && group.stream().anyMatch(m -> !selected.get(m))) {
+        error(
+            "Every method selecting target '"
+                + entry.getKey()
+                + "' must use @ExternalType.Overload.",
+            origins.get(group.get(0)));
         invalid = true;
       }
     }
+    return invalid;
+  }
+
+  private boolean validateKeys(
+      List<MethodSpec> methods, Map<MethodSpec, ExecutableElement> origins) {
+    boolean invalid = false;
     Map<TargetKey, MethodSpec> targetKeys = new HashMap<>();
-    Map<String, MethodSpec> generatedDescriptors = new HashMap<>();
+    Map<String, MethodSpec> descriptors = new HashMap<>();
+    Map<OperationKind, MethodSpec> predicates = new HashMap<>();
     for (MethodSpec method : methods) {
-      TargetKey targetKey = targetKey(method);
-      if (targetKeys.put(targetKey, method) != null) {
-        processingEnv
-            .getMessager()
-            .printMessage(
-                Diagnostic.Kind.ERROR,
-                "@ExternalType selected methods must have distinct exact target signatures.",
-                origins.get(method));
+      if ((method.operation == OperationKind.INSTANCE_OF || method.operation == OperationKind.CAST)
+          && predicates.put(method.operation, method) != null) {
+        error(
+            "An @ExternalType contract permits only one " + method.operation + " operation.",
+            origins.get(method));
+        invalid = true;
+      }
+      if (targetKeys.put(targetKey(method), method) != null) {
+        error(
+            "@ExternalType operations must have distinct exact target signatures.",
+            origins.get(method));
         invalid = true;
       }
       for (String descriptor : generatedDescriptors(method)) {
-        if (generatedDescriptors.put(descriptor, method) != null) {
-          processingEnv
-              .getMessager()
-              .printMessage(
-                  Diagnostic.Kind.ERROR,
-                  "@ExternalType selected methods collide in generated adapter descriptors; rename the local method.",
-                  origins.get(method));
+        if (descriptors.put(descriptor, method) != null) {
+          error(
+              "@ExternalType operations collide in generated adapter descriptors; rename the local method.",
+              origins.get(method));
           invalid = true;
         }
       }
     }
-    if (invalid) return null;
-    return new AdapterSpec(pkg, simple, externalFqn, methods);
+    return invalid;
   }
 
   private TargetKey targetKey(MethodSpec method) {
-    List<String> params = new ArrayList<>();
-    for (int i = 0; i < method.paramTypes.size(); i++)
-      params.add(
-          method.paramTargetFqns.get(i) != null
-              ? method.paramTargetFqns.get(i)
-              : method.paramTypes.get(i));
+    List<String> types = new ArrayList<>();
+    for (int i = 0; i < method.paramTypes.size(); i++) types.add(lookupType(method, i));
     return new TargetKey(
-        method.targetName,
-        method.isStatic,
-        method.returnTargetFqn != null ? method.returnTargetFqn : method.returnType,
-        params);
+        method.operation, method.targetName, method.isStatic, lookupType(method, true), types);
   }
 
-  private static final class TargetKey {
-    final String name;
-    final boolean statik;
-    final String result;
-    final List<String> params;
+  private String lookupType(MethodSpec method, boolean returnType) {
+    return returnType
+        ? method.returnTargetFqn != null ? method.returnTargetFqn : method.returnType
+        : lookupType(method, 0);
+  }
 
-    TargetKey(String name, boolean statik, String result, List<String> params) {
-      this.name = name;
-      this.statik = statik;
-      this.result = result;
-      this.params = params;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (!(o instanceof TargetKey)) return false;
-      TargetKey k = (TargetKey) o;
-      return statik == k.statik
-          && name.equals(k.name)
-          && result.equals(k.result)
-          && params.equals(k.params);
-    }
-
-    @Override
-    public int hashCode() {
-      return java.util.Objects.hash(name, statik, result, params);
-    }
+  private String lookupType(MethodSpec method, int index) {
+    return method.paramTargetFqns.get(index) != null
+        ? method.paramTargetFqns.get(index)
+        : method.paramTypes.get(index);
   }
 
   private List<String> generatedDescriptors(MethodSpec method) {
     List<String> descriptors = new ArrayList<>();
     StringBuilder legacy = new StringBuilder(method.adapterName).append('(');
-    if (!method.isStatic) legacy.append("java.lang.Object,");
-    for (String param : method.paramTypes) legacy.append(param).append(',');
+    if (hasGeneratedReceiver(method)) legacy.append("java.lang.Object,");
+    for (String parameter : method.paramTypes) legacy.append(parameter).append(',');
     descriptors.add(legacy.append(')').toString());
-    if (method.isStatic) {
+    if (method.isStatic || method.operation == OperationKind.CONSTRUCTOR) {
       StringBuilder explicit =
           new StringBuilder(method.adapterName).append("(java.lang.ClassLoader,");
-      for (String param : method.paramTypes) explicit.append(param).append(',');
+      for (String parameter : method.paramTypes) explicit.append(parameter).append(',');
       descriptors.add(explicit.append(')').toString());
     }
     return descriptors;
   }
 
-  private void reportUnconsumed(Set<Element> values, Set<Element> consumed, String message) {
-    for (Element value : values)
-      if (!consumed.contains(value))
-        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, value);
+  private boolean hasGeneratedReceiver(MethodSpec method) {
+    return !method.isStatic
+        && (method.operation == OperationKind.METHOD
+            || method.operation == OperationKind.GETTER
+            || method.operation == OperationKind.SETTER);
   }
 
-  private String selectorValue(Element element) {
-    return annotationStringValue(element, "io.btrace.core.extensions.ExternalType.Overload");
+  private String operationTargetName(ExecutableElement method, OperationKind operation) {
+    if (operation == OperationKind.GETTER) return annotationStringValue(method, GETTER);
+    if (operation == OperationKind.SETTER) return annotationStringValue(method, SETTER);
+    if (operation == OperationKind.CONSTRUCTOR) return "<init>";
+    if (operation == OperationKind.INSTANCE_OF) return "isInstance";
+    if (operation == OperationKind.CAST) return "cast";
+    return method.getSimpleName().toString();
   }
 
-  private boolean validTargetName(String name) {
+  private boolean allNull(List<String> values) {
+    for (String value : values) if (value != null) return false;
+    return true;
+  }
+
+  private String erased(TypeMirror type) {
+    return processingEnv.getTypeUtils().erasure(type).toString();
+  }
+
+  private boolean validFieldName(String name) {
+    return validMemberName(name);
+  }
+
+  private boolean validMemberName(String name) {
     return name != null
         && !name.trim().isEmpty()
         && !name.equals("<init>")
@@ -321,6 +544,10 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
         && name.indexOf(';') < 0
         && name.indexOf('[') < 0
         && name.indexOf('/') < 0;
+  }
+
+  private void reportUnconsumed(Set<Element> markers, Set<Element> consumed, String message) {
+    for (Element marker : markers) if (!consumed.contains(marker)) error(message, marker);
   }
 
   private String annotationStringValue(Element marker, String annotationName) {
@@ -337,45 +564,33 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
 
   private String targetFqn(Element marker, String erasedType) {
     if (!"java.lang.Object".equals(erasedType)) {
-      processingEnv
-          .getMessager()
-          .printMessage(
-              Diagnostic.Kind.ERROR,
-              "@ExternalType.Type is valid only as @ExternalType.Type(OtherContract.class) Object.",
-              marker);
+      error(
+          "@ExternalType.Type is valid only as @ExternalType.Type(OtherContract.class) Object.",
+          marker);
       return null;
     }
     TypeMirror contractType = annotationTypeValue(marker);
     if (contractType == null
-        || !(processingEnv.getTypeUtils().asElement(contractType) instanceof TypeElement)) {
+        || !(processingEnv.getTypeUtils().asElement(contractType) instanceof TypeElement))
       return invalidContract(marker);
-    }
     TypeElement contract = (TypeElement) processingEnv.getTypeUtils().asElement(contractType);
     ExternalType externalType = contract.getAnnotation(ExternalType.class);
     if (contract.getKind() != ElementKind.INTERFACE
         || externalType == null
-        || externalType.value().isEmpty()) {
-      return invalidContract(marker);
-    }
+        || externalType.value().isEmpty()) return invalidContract(marker);
     return externalType.value();
   }
 
   private String invalidContract(Element marker) {
-    processingEnv
-        .getMessager()
-        .printMessage(
-            Diagnostic.Kind.ERROR,
-            "@ExternalType.Type must reference an interface with a non-empty @ExternalType value.",
-            marker);
+    error(
+        "@ExternalType.Type must reference an interface with a non-empty @ExternalType value.",
+        marker);
     return null;
   }
 
   private TypeMirror annotationTypeValue(Element marker) {
     for (javax.lang.model.element.AnnotationMirror annotation : marker.getAnnotationMirrors()) {
-      if (!annotation
-          .getAnnotationType()
-          .toString()
-          .equals("io.btrace.core.extensions.ExternalType.Type")) continue;
+      if (!annotation.getAnnotationType().toString().equals(TYPE)) continue;
       for (javax.lang.model.element.AnnotationValue value :
           processingEnv.getElementUtils().getElementValuesWithDefaults(annotation).values()) {
         Object raw = value.getValue();
@@ -389,6 +604,69 @@ public final class ExternalTypeProcessor extends AbstractProcessor {
     JavaFileObject jfo = processingEnv.getFiler().createSourceFile(spec.adapterFqn(), origin);
     try (PrintWriter w = new PrintWriter(jfo.openWriter())) {
       new AdapterEmitter(spec).render(w);
+    }
+  }
+
+  private void error(String message, Element element) {
+    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, element);
+  }
+
+  private static final class FieldKey {
+    final String name;
+    final boolean statik;
+
+    FieldKey(String name, boolean statik) {
+      this.name = name;
+      this.statik = statik;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof FieldKey)) return false;
+      FieldKey that = (FieldKey) other;
+      return statik == that.statik && name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return java.util.Objects.hash(name, statik);
+    }
+  }
+
+  private static final class TargetKey {
+    final OperationKind operation;
+    final String name;
+    final boolean statik;
+    final String result;
+    final List<String> parameters;
+
+    TargetKey(
+        OperationKind operation,
+        String name,
+        boolean statik,
+        String result,
+        List<String> parameters) {
+      this.operation = operation;
+      this.name = name;
+      this.statik = statik;
+      this.result = result;
+      this.parameters = parameters;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof TargetKey)) return false;
+      TargetKey that = (TargetKey) other;
+      return operation == that.operation
+          && statik == that.statik
+          && name.equals(that.name)
+          && result.equals(that.result)
+          && parameters.equals(that.parameters);
+    }
+
+    @Override
+    public int hashCode() {
+      return java.util.Objects.hash(operation, name, statik, result, parameters);
     }
   }
 }

--- a/btrace-core/src/main/java/io/btrace/extension/processor/MethodSpec.java
+++ b/btrace-core/src/main/java/io/btrace/extension/processor/MethodSpec.java
@@ -20,8 +20,18 @@ import java.util.Collections;
 import java.util.List;
 
 final class MethodSpec {
+  enum OperationKind {
+    METHOD,
+    GETTER,
+    SETTER,
+    CONSTRUCTOR,
+    INSTANCE_OF,
+    CAST
+  }
+
   final String adapterName;
   final String targetName;
+  final OperationKind operation;
   final String returnType;
   final String returnTargetFqn;
   final List<String> paramTypes;
@@ -31,6 +41,7 @@ final class MethodSpec {
   MethodSpec(
       String adapterName,
       String targetName,
+      OperationKind operation,
       String returnType,
       String returnTargetFqn,
       List<String> paramTypes,
@@ -38,6 +49,7 @@ final class MethodSpec {
       boolean isStatic) {
     this.adapterName = adapterName;
     this.targetName = targetName;
+    this.operation = operation;
     this.returnType = returnType;
     this.returnTargetFqn = returnTargetFqn;
     this.paramTypes = Collections.unmodifiableList(new java.util.ArrayList<>(paramTypes));

--- a/btrace-core/src/test/java/io/btrace/core/extensions/ExternalTypeAnnotationTest.java
+++ b/btrace-core/src/test/java/io/btrace/core/extensions/ExternalTypeAnnotationTest.java
@@ -60,4 +60,24 @@ class ExternalTypeAnnotationTest {
     assertArrayEquals(
         new ElementType[] {ElementType.METHOD, ElementType.PARAMETER}, target.value());
   }
+
+  @Test
+  void phaseFiveOperationMarkersAreSourceOnlyMethodDeclarations() {
+    assertMarker(ExternalType.Getter.class, true);
+    assertMarker(ExternalType.Setter.class, true);
+    assertMarker(ExternalType.Constructor.class, false);
+    assertMarker(ExternalType.InstanceOf.class, false);
+    assertMarker(ExternalType.Cast.class, false);
+  }
+
+  private static void assertMarker(Class<? extends Annotation> marker, boolean hasValue) {
+    assertEquals(RetentionPolicy.SOURCE, marker.getAnnotation(Retention.class).value());
+    assertArrayEquals(
+        new ElementType[] {ElementType.METHOD}, marker.getAnnotation(Target.class).value());
+    assertEquals(hasValue ? 1 : 0, marker.getDeclaredMethods().length);
+    if (hasValue) {
+      assertEquals(String.class, marker.getDeclaredMethods()[0].getReturnType());
+      assertEquals("value", marker.getDeclaredMethods()[0].getName());
+    }
+  }
 }

--- a/btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java
+++ b/btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java
@@ -999,6 +999,226 @@ class ExternalTypeProcessorTest {
     assertInstanceOf(IllegalAccessException.class, access.getCause());
   }
 
+  @Test
+  void fieldsConstructorsAndTypePredicatesGenerateExactDispatchers() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.target.Widget",
+        "package com.example.target; public class Widget { public String name; public static int COUNT = 7; public Widget(String name) { this.name = name; } }");
+    sources.put(
+        "com.example.adapter.WidgetApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Widget\") public interface WidgetApi { "
+            + "@ExternalType.Getter(\"name\") String name(); "
+            + "@ExternalType.Setter(\"name\") void setName(String value); "
+            + "@ExternalType.Static @ExternalType.Getter(\"COUNT\") int count(); "
+            + "@ExternalType.Constructor Object create(String name); "
+            + "@ExternalType.InstanceOf boolean isWidget(Object value); "
+            + "@ExternalType.Cast Object castWidget(Object value); }");
+
+    CompileTestHarness.Result result = CompileTestHarness.compile(sources, 8);
+    assertTrue(result.success, result.errors());
+    String generated = result.generatedSources.get("com.example.adapter.WidgetApi$Ext");
+    assertNotNull(generated);
+    assertTrue(generated.contains("findGetter(owner, \"name\""), generated);
+    assertTrue(generated.contains("findSetter(owner, \"name\""), generated);
+    assertTrue(generated.contains("findStaticGetter(owner, \"COUNT\""), generated);
+    assertTrue(
+        generated.contains(
+            "findConstructor(owner, MethodType.methodType(void.class, java.lang.String.class))"),
+        generated);
+    assertTrue(generated.contains(".isInstance(p0)"), generated);
+    assertTrue(generated.contains(".cast(p0)"), generated);
+  }
+
+  @Test
+  void phaseFiveOperationsDispatchAndPreserveNullPredicateSemantics() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.target.Widget",
+        "package com.example.target; public class Widget { public String name; public Widget(String name) { this.name = name; } }");
+    sources.put("com.example.target.Other", "package com.example.target; public class Other {}");
+    sources.put(
+        "com.example.adapter.WidgetApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Widget\") public interface WidgetApi { "
+            + "@ExternalType.Getter(\"name\") String name(); "
+            + "@ExternalType.Setter(\"name\") void setName(String value); "
+            + "@ExternalType.Constructor Object create(String name); "
+            + "@ExternalType.InstanceOf boolean isWidget(Object value); "
+            + "@ExternalType.Cast Object castWidget(Object value); }");
+    CompileTestHarness.RunnableResult result = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(result.success, result.errors());
+    Class<?> adapter = result.loader.loadClass("com.example.adapter.WidgetApi$Ext");
+    Object widget =
+        adapter
+            .getMethod("create", ClassLoader.class, String.class)
+            .invoke(null, result.loader, "first");
+    assertEquals("first", adapter.getMethod("name", Object.class).invoke(null, widget));
+    adapter.getMethod("setName", Object.class, String.class).invoke(null, widget, "second");
+    assertEquals("second", adapter.getMethod("name", Object.class).invoke(null, widget));
+    assertEquals(Boolean.TRUE, adapter.getMethod("isWidget", Object.class).invoke(null, widget));
+    Object other =
+        result.loader.loadClass("com.example.target.Other").getConstructor().newInstance();
+    assertEquals(Boolean.FALSE, adapter.getMethod("isWidget", Object.class).invoke(null, other));
+    assertEquals(
+        Boolean.FALSE,
+        adapter.getMethod("isWidget", Object.class).invoke(null, new Object[] {null}));
+    assertNull(adapter.getMethod("castWidget", Object.class).invoke(null, new Object[] {null}));
+    assertSame(widget, adapter.getMethod("castWidget", Object.class).invoke(null, widget));
+  }
+
+  @Test
+  void rejectsInvalidFieldAndConstructorFormsWithoutGeneratingAnAdapter() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.adapter.BadApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Widget\") public interface BadApi { "
+            + "@ExternalType.Getter(\"a/b\") void badField(); "
+            + "@ExternalType.Constructor String badConstructor(); }");
+    CompileTestHarness.Result result = CompileTestHarness.compile(sources);
+    assertFalse(result.success);
+    assertTrue(result.errors().contains("Invalid @ExternalType field name"), result.errors());
+    assertTrue(result.errors().contains("requires direct Object return"), result.errors());
+    assertFalse(result.generatedSources.containsKey("com.example.adapter.BadApi$Ext"));
+  }
+
+  @Test
+  void malformedFieldPairsRetainTheirSpecificDiagnostics() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.adapter.BadApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Widget\") public interface BadApi { "
+            + "@ExternalType.Getter(\"value\") int getValue(); "
+            + "@ExternalType.Setter(\"value\") void setValue(); }");
+
+    CompileTestHarness.Result result = CompileTestHarness.compile(sources);
+    assertFalse(result.success);
+    assertTrue(
+        result.errors().contains("Setter requires void return and exactly one target argument"));
+    assertFalse(result.errors().contains("Failed to emit adapter"), result.errors());
+    assertFalse(result.generatedSources.containsKey("com.example.adapter.BadApi$Ext"));
+  }
+
+  @Test
+  void rejectsCrossKindGeneratedDescriptorCollisionWithPredicate() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.adapter.BadApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Widget\") public interface BadApi { "
+            + "@ExternalType.Getter(\"name\") String same(); "
+            + "@ExternalType.InstanceOf boolean same(Object value); }");
+
+    CompileTestHarness.Result result = CompileTestHarness.compile(sources);
+    assertFalse(result.success);
+    assertTrue(
+        result.errors().contains("collide in generated adapter descriptors"), result.errors());
+    assertFalse(result.generatedSources.containsKey("com.example.adapter.BadApi$Ext"));
+  }
+
+  @Test
+  void staticSetterUsesLegacyAndExplicitLoadersWithoutPassingControlArgument() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.target.Counter",
+        "package com.example.target; public class Counter { public static int count; }");
+    sources.put(
+        "com.example.adapter.CounterApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Counter\") public interface CounterApi { "
+            + "@ExternalType.Static @ExternalType.Setter(\"count\") void setCount(int value); }");
+    CompileTestHarness.RunnableResult result = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(result.success, result.errors());
+    Class<?> adapter = result.loader.loadClass("com.example.adapter.CounterApi$Ext");
+    java.lang.reflect.Method legacy = adapter.getMethod("setCount", int.class);
+    java.lang.reflect.Method explicit = adapter.getMethod("setCount", ClassLoader.class, int.class);
+    assertThrows(
+        InvocationTargetException.class,
+        () -> explicit.invoke(null, new Object[] {null, Integer.valueOf(1)}));
+    assertEquals(0, resolutionAttempts(adapter, 0));
+    assertEquals(0, staticLoaderIndexEntries(adapter, 0));
+
+    ClassLoader saved = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(result.loader);
+      legacy.invoke(null, Integer.valueOf(7));
+      assertSame(result.loader, Thread.currentThread().getContextClassLoader());
+    } finally {
+      Thread.currentThread().setContextClassLoader(saved);
+    }
+    Class<?> counter = result.loader.loadClass("com.example.target.Counter");
+    assertEquals(7, counter.getField("count").getInt(null));
+    ClassLoader explicitSaved = Thread.currentThread().getContextClassLoader();
+    explicit.invoke(null, result.loader, Integer.valueOf(9));
+    assertSame(explicitSaved, Thread.currentThread().getContextClassLoader());
+    assertEquals(9, counter.getField("count").getInt(null));
+    assertEquals(1, resolutionAttempts(adapter, 0));
+    assertEquals(1, staticLoaderIndexEntries(adapter, 0));
+  }
+
+  @Test
+  void quotesBackslashesAndControlsInFieldNamesAreEscapedForJavaEightSource() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.adapter.QuotedApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Quoted\") public interface QuotedApi { "
+            + "@ExternalType.Getter(\"a\\\"b\\\\c\\001\") String quoted(); }");
+
+    CompileTestHarness.Result result = CompileTestHarness.compile(sources, 8);
+    assertTrue(result.success, result.errors());
+    String generated = result.generatedSources.get("com.example.adapter.QuotedApi$Ext");
+    assertNotNull(generated);
+    String expected = "findGetter(owner, \"a\\\"b\\\\c" + "\\u0001" + "\", java.lang.String.class)";
+    assertTrue(generated.contains(expected), generated);
+  }
+
+  @Test
+  void markedTypesResolveFromTheOwnerLoaderForPhaseFiveFieldsAndConstructors() throws Exception {
+    Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(
+        "com.example.target.Child",
+        "package com.example.target; public class Child { "
+            + "private final String label; public Child(String label) { this.label = label; } "
+            + "public String label() { return label; } }");
+    sources.put(
+        "com.example.target.Parent",
+        "package com.example.target; public class Parent { public Child child; "
+            + "public Parent(Child child) { this.child = child; } }");
+    sources.put(
+        "com.example.adapter.ChildApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Child\") public interface ChildApi { "
+            + "@ExternalType.Constructor Object create(String label); String label(); }");
+    sources.put(
+        "com.example.adapter.ParentApi",
+        "package com.example.adapter; import io.btrace.core.extensions.ExternalType; "
+            + "@ExternalType(\"com.example.target.Parent\") public interface ParentApi { "
+            + "@ExternalType.Getter(\"child\") @ExternalType.Type(ChildApi.class) Object child(); "
+            + "@ExternalType.Setter(\"child\") void setChild(@ExternalType.Type(ChildApi.class) Object child); "
+            + "@ExternalType.Constructor Object create(@ExternalType.Type(ChildApi.class) Object child); }");
+
+    CompileTestHarness.RunnableResult result = CompileTestHarness.compileAndLoad(sources);
+    assertTrue(result.success, result.errors());
+    Class<?> childAdapter = result.loader.loadClass("com.example.adapter.ChildApi$Ext");
+    Class<?> parentAdapter = result.loader.loadClass("com.example.adapter.ParentApi$Ext");
+    Object child =
+        childAdapter
+            .getMethod("create", ClassLoader.class, String.class)
+            .invoke(null, result.loader, "marked-child");
+    Object parent =
+        parentAdapter
+            .getMethod("create", ClassLoader.class, Object.class)
+            .invoke(null, result.loader, child);
+    parentAdapter.getMethod("setChild", Object.class, Object.class).invoke(null, parent, child);
+    Object returnedChild = parentAdapter.getMethod("child", Object.class).invoke(null, parent);
+    assertEquals(
+        "marked-child", childAdapter.getMethod("label", Object.class).invoke(null, returnedChild));
+  }
+
   private static Map<String, String> externalTypeSources(String apiMethod, String implementation) {
     return externalTypeSources(apiMethod, implementation, "value");
   }

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/ExternalTypeSmoke.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/ExternalTypeSmoke.java
@@ -9,7 +9,30 @@ public final class ExternalTypeSmoke {
     Class<?> parentType = Class.forName("example.target.ExternalParent");
     Constructor<?> constructor = parentType.getConstructor();
     Object parent = constructor.newInstance();
+    if (!"external-type-field-initial".equals(ParentApi$Ext.name(parent))) {
+      throw new AssertionError();
+    }
+    ParentApi$Ext.setName(parent, "external-type-field-ok");
+    if (!"external-type-field-ok".equals(ParentApi$Ext.name(parent))) {
+      throw new AssertionError();
+    }
+    if (!"external-type-chain-ok".equals(ChildApi$Ext.marker(ParentApi$Ext.defaultChild()))) {
+      throw new AssertionError();
+    }
+    Object created = ParentApi$Ext.create("external-type-constructor-ok");
+    if (!ParentApi$Ext.isParent(created)
+        || !"external-type-constructor-ok".equals(ParentApi$Ext.name(ParentApi$Ext.castParent(created)))) {
+      throw new AssertionError();
+    }
     Object child = ParentApi$Ext.child(parent);
+    ParentApi$Ext.setChildField(parent, child);
+    if (!"external-type-chain-ok".equals(ChildApi$Ext.marker(ParentApi$Ext.childField(parent)))) {
+      throw new AssertionError();
+    }
+    Object childParent = ParentApi$Ext.createWithChild(child);
+    if (!"external-type-chain-ok".equals(ChildApi$Ext.marker(ParentApi$Ext.childField(childParent)))) {
+      throw new AssertionError();
+    }
     if (!"external-type-overload-text-ok".equals(ParentApi$Ext.describeText(parent, "text"))) {
       throw new AssertionError();
     }
@@ -21,5 +44,9 @@ public final class ExternalTypeSmoke {
     }
     System.out.println(ChildApi$Ext.marker(child));
     System.out.println("external-type-overload-text-ok");
+    System.out.println("external-type-field-ok");
+    System.out.println("external-type-constructor-ok");
+    System.out.println("external-type-predicate-ok");
+    System.out.println("external-type-marked-field-constructor-ok");
   }
 }

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/ParentApi.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/ParentApi.java
@@ -4,6 +4,36 @@ import io.btrace.core.extensions.ExternalType;
 
 @ExternalType("example.target.ExternalParent")
 public interface ParentApi {
+  @ExternalType.Getter("name")
+  String name();
+
+  @ExternalType.Setter("name")
+  void setName(String name);
+
+  @ExternalType.Static
+  @ExternalType.Getter("DEFAULT_CHILD")
+  @ExternalType.Type(ChildApi.class)
+  Object defaultChild();
+
+  @ExternalType.Constructor
+  Object create(String name);
+
+  @ExternalType.InstanceOf
+  boolean isParent(Object value);
+
+  @ExternalType.Cast
+  Object castParent(Object value);
+
+  @ExternalType.Getter("childField")
+  @ExternalType.Type(ChildApi.class)
+  Object childField();
+
+  @ExternalType.Setter("childField")
+  void setChildField(@ExternalType.Type(ChildApi.class) Object child);
+
+  @ExternalType.Constructor
+  Object createWithChild(@ExternalType.Type(ChildApi.class) Object child);
+
   @ExternalType.Type(ChildApi.class)
   Object child();
 

--- a/btrace-dist/src/test/resources/external-type-processor-smoke/target-src/example/target/ExternalParent.java
+++ b/btrace-dist/src/test/resources/external-type-processor-smoke/target-src/example/target/ExternalParent.java
@@ -1,6 +1,23 @@
 package example.target;
 
 public final class ExternalParent {
+  public String name;
+  public static ExternalChild DEFAULT_CHILD = new ExternalChild();
+
+  public ExternalParent() {
+    this("external-type-field-initial");
+  }
+
+  public ExternalParent(String name) {
+    this.name = name;
+  }
+
+  public ExternalChild childField;
+
+  public ExternalParent(ExternalChild child) {
+    this.childField = child;
+  }
+
   public ExternalChild child() {
     return new ExternalChild();
   }

--- a/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalDataType.java
+++ b/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalDataType.java
@@ -40,6 +40,44 @@ public interface ExternalDataType {
   @ExternalType.Overload("describe")
   String describeChild(@ExternalType.Type(ExternalChildType.class) Object child);
 
+  @ExternalType.Getter("fieldValue")
+  int fieldValue();
+
+  @ExternalType.Setter("fieldValue")
+  void setFieldValue(int value);
+
+  @ExternalType.Getter("childField")
+  @ExternalType.Type(ExternalChildType.class)
+  Object childField();
+
+  @ExternalType.Setter("childField")
+  void setChildField(@ExternalType.Type(ExternalChildType.class) Object child);
+
+  @ExternalType.Constructor
+  Object createWithChild(@ExternalType.Type(ExternalChildType.class) Object child);
+
+  @ExternalType.Static
+  @ExternalType.Getter("staticField")
+  int staticField();
+
+  @ExternalType.Static
+  @ExternalType.Setter("staticField")
+  void setStaticField(int value);
+
+  @ExternalType.Static
+  @ExternalType.Getter("DEFAULT_CHILD")
+  @ExternalType.Type(ExternalChildType.class)
+  Object defaultChild();
+
+  @ExternalType.Constructor
+  Object create(int value);
+
+  @ExternalType.InstanceOf
+  boolean isExternalData(Object value);
+
+  @ExternalType.Cast
+  Object castExternalData(Object value);
+
   /** Maps to ExternalData.tag() — static dispatch via TCCL. */
   @ExternalType.Static
   String tag();

--- a/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestService.java
+++ b/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestService.java
@@ -39,4 +39,7 @@ public interface ExternalTypeTestService {
    * Returns the instance value from an resources.ExternalData object via its @ExternalType adapter.
    */
   int value(Object externalData);
+
+  /** Exercises field access, construction, and type narrowing through generated adapters. */
+  String phaseFiveMarkers(Object externalData);
 }

--- a/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestServiceImpl.java
+++ b/btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalTypeTestServiceImpl.java
@@ -57,4 +57,32 @@ public final class ExternalTypeTestServiceImpl extends Extension
   public int value(Object externalData) {
     return ExternalDataType$Ext.value(externalData);
   }
+
+  @Override
+  public String phaseFiveMarkers(Object externalData) {
+    int initial = ExternalDataType$Ext.fieldValue(externalData);
+    ExternalDataType$Ext.setFieldValue(externalData, initial + 1);
+    ClassLoader applicationLoader = ClassLoadingUtil.definingLoader(externalData);
+    if (applicationLoader == null) applicationLoader = ClassLoader.getSystemClassLoader();
+    ExternalDataType$Ext.setStaticField(applicationLoader, initial + 3);
+    Object defaultChild = ExternalDataType$Ext.defaultChild();
+    Object created = ExternalDataType$Ext.create(initial + 2);
+    Object child = ExternalDataType$Ext.child(externalData);
+    ExternalDataType$Ext.setChildField(externalData, child);
+    Object childCreated = ExternalDataType$Ext.createWithChild(applicationLoader, child);
+    if (!ExternalDataType$Ext.isExternalData(created)) return "ext-predicate-failed";
+    Object narrowed = ExternalDataType$Ext.castExternalData(created);
+    return "ext-field-"
+        + ExternalDataType$Ext.fieldValue(externalData)
+        + ","
+        + ExternalChildType$Ext.marker(defaultChild)
+        + ","
+        + ExternalDataType$Ext.value(narrowed)
+        + ","
+        + ExternalDataType$Ext.staticField()
+        + ","
+        + ExternalChildType$Ext.marker(ExternalDataType$Ext.childField(externalData))
+        + ","
+        + ExternalChildType$Ext.marker(ExternalDataType$Ext.childField(childCreated));
+  }
 }

--- a/docs/BTraceExtensionDevelopmentGuide.md
+++ b/docs/BTraceExtensionDevelopmentGuide.md
@@ -305,9 +305,63 @@ An overload group has three required properties:
    signature.
 
 Do not use `@ExternalType.Overload` for a one-method rename. A uniquely named contract method
-already binds to the target method with the same name. It also cannot enable fields, constructors,
-private members, generic/array target types, coercion, or fallback lookup; use the manual
-`MethodHandleCache` path for those cases.
+already binds to the target method with the same name. It cannot enable private members,
+generic/array target types, coercion, or fallback lookup; use the manual path for those cases.
+
+### Fields, construction, and type narrowing
+
+Five narrow operation markers cover the common public application-state cases. They are all
+source-only processor input: generated adapters never inspect annotations at runtime.
+
+```java
+@ExternalType("vendor.Child")
+interface ChildApi { String label(); }
+
+@ExternalType("vendor.Widget")
+interface WidgetApi {
+    @ExternalType.Getter("name")
+    String name();                         // WidgetApi$Ext.name(Object self)
+
+    @ExternalType.Setter("name")
+    void setName(String value);             // WidgetApi$Ext.setName(Object self, String)
+
+    @ExternalType.Static
+    @ExternalType.Getter("DEFAULT_CHILD")
+    @ExternalType.Type(ChildApi.class)
+    Object defaultChild();                  // defaultChild(), defaultChild(ClassLoader)
+
+    @ExternalType.Constructor
+    Object create(String name);             // create(String), create(ClassLoader, String)
+
+    @ExternalType.InstanceOf
+    boolean isWidget(Object value);
+
+    @ExternalType.Cast
+    Object castWidget(Object value);
+}
+```
+
+Getters have a non-`void` return and no target arguments; setters return `void` and take exactly
+one target argument. Both use one exact public field type, so a getter/setter pair for the same
+field must agree on static state and type. Use `@Type(ChildApi.class) Object` only for a direct
+target-library field return or setter parameter. `@Static` is legal only for fields (and ordinary
+methods), producing the same legacy-TCCL and explicit non-null-loader forms as static methods.
+
+`@Constructor` returns direct `Object`; its declared parameters are the exact public constructor
+signature and may have direct `@Type` markers. It has no receiver and therefore also exposes the
+legacy and explicit-loader forms. The explicit `ClassLoader` is adapter control data, never a
+constructor argument or part of the constructor `MethodType`.
+
+`@InstanceOf` is exactly `boolean operation(Object)` and `@Cast` exactly `Object operation(Object)`.
+For a non-null candidate, both resolve the owner through the candidate value's defining loader,
+then follow `Class.isInstance`/`Class.cast`: `isInstance(null)` is `false`, `cast(null)` is `null`,
+and a wrong non-null cast throws normal `ClassCastException`. They do not use the TCCL.
+
+All field/constructor resolution uses public exact lookup and is retryable after an unavailable
+class or member appears. Resolution does not initialize the target; ordinary static-field access
+and constructor invocation may initialize it under normal JVM rules. Missing/inaccessible public
+members and the predicate/cast public-access probe throw `ExternalTypeResolutionException` with
+the original cause. Target initializer and constructor failures remain transparent.
 
 ### Rules
 
@@ -317,6 +371,8 @@ private members, generic/array target types, coercion, or fallback lookup; use t
 - **Access:** dispatch uses `MethodHandles.publicLookup()`. Only public members of public, accessible types are supported; do not add module-opening flags implicitly.
 - **Static methods:** add `@ExternalType.Static` on the interface method. `version()` preserves legacy TCCL-based class loading with the documented null-TCCL system-loader fallback. `version(ClassLoader applicationLoader)` resolves with that non-null loader exactly; it rejects null immediately with `NullPointerException("applicationLoader")`. The control argument is not a target argument. Neither form changes the target's observed TCCL.
 - **Overload groups:** follow [the overload-group pattern above](#overload-groups-map-local-aliases-to-one-target-name). The selector changes only the target name; declared exact types, including `Type` markers, select the overload. It is not a single-method alias or runtime coercion/search facility.
+- **Fields and constructors:** `Getter`, `Setter`, and `Constructor` use exact public lookup types; fields require a legal raw JVM field name and constructors have no overload selector. `Static` is legal only for ordinary methods and fields.
+- **Predicates and casts:** `InstanceOf` and `Cast` operate on the owner named by the contract, using the non-null candidate's defining loader. They do not initialize the owner during resolution or bypass public/exported access.
 - **Default methods and static interface methods:** skipped (they already have bodies).
 - **Failures:** class lookup, missing member, and inaccessible-member failures throw `ExternalTypeResolutionException` with the original cause. Exceptions thrown by the target method propagate unchanged.
 
@@ -330,7 +386,8 @@ Use generated adapters only for the supported row below. The manual path is the 
 | A direct target-library `Object` parameter or return type | Supported | Mark it with `@ExternalType.Type(OtherContract.class) Object`; chain opaque results into another generated adapter. |
 | Target types in generic elements or arrays | Unsupported | Use `ClassLoadingUtil` and `MethodHandleCache` directly. |
 | Explicit target overload groups | Supported | Mark every group member with `@ExternalType.Overload("targetName")`; local names may differ. |
-| Fields, constructors, `instanceof`, and casts | Unsupported | Use `ClassLoadingUtil` plus the appropriate direct `MethodHandles.publicLookup()` or `Class` operation. `MethodHandleCache` caches virtual and static method lookups only. |
+| Public exact field get/set, public construction, `isInstance`, and `cast` | Supported | Use the five operation markers above. Keep target-library values opaque with direct `@Type(... ) Object` positions. |
+| Generic/array target types, bulk/reflection-style operations, fluent setters, constructor selectors, runtime overload choice/coercion | Unsupported | Use `ClassLoadingUtil` plus direct `MethodHandles.publicLookup()` or `Class` operations. |
 | Non-public or non-exported named-module members | Unsupported | Use a public supported API or explicitly configure the target JVM outside BTrace. |
 
 For a generated static call under an author-controlled application loader, select it explicitly. Normalize a bootstrap-owned context object's null defining loader to the system loader, whose normal delegation reaches bootstrap:

--- a/docs/architecture/provided-style-extensions.md
+++ b/docs/architecture/provided-style-extensions.md
@@ -68,7 +68,12 @@ public final class SparkApiImpl implements SparkApi {
 
 ## External Type Adapters
 
-`@ExternalType` supports exact public methods, opaque target-type positions, and explicit complete overload groups declared with `@ExternalType.Overload("targetName")`. The canonical selector, owner-loader, failure, and static-loader rules are in the [Extension Development Guide](../BTraceExtensionDevelopmentGuide.md#app-type-adapters-with-externaltype). Keep the manual pattern here for target types in generic elements/arrays, fields, constructors, and type predicates.
+`@ExternalType` supports exact public methods, opaque target-type positions, complete overload
+groups, exact public field getters/setters, constructors, and `isInstance`/`cast` operations. The
+canonical signatures, owner-loader, failure, and static-loader rules are in the [Extension
+Development Guide](../BTraceExtensionDevelopmentGuide.md#app-type-adapters-with-externaltype).
+Keep the manual pattern here for generic/array target types, bulk reflection-style work, fluent
+setters, constructor selectors, runtime coercion, and non-public or JPMS-bypassing access.
 
 For a generated static target call where the application loader is known, pass it directly:
 

--- a/integration-tests/src/test/btrace/ExternalTypeAdapterTest.java
+++ b/integration-tests/src/test/btrace/ExternalTypeAdapterTest.java
@@ -28,6 +28,7 @@ public class ExternalTypeAdapterTest {
     println("child=" + extSvc.childMarker(data));
     println("accepted-child=" + extSvc.acceptedChildMarker(data));
     println("overloads=" + extSvc.overloadMarkers(data));
+    println("phase5=" + extSvc.phaseFiveMarkers(data));
     exit(0);
   }
 }

--- a/integration-tests/src/test/java/resources/ExternalData.java
+++ b/integration-tests/src/test/java/resources/ExternalData.java
@@ -24,9 +24,20 @@ package resources;
  */
 public final class ExternalData {
   private final int value;
+  public int fieldValue;
+  public static int staticField;
+  public static ExternalChild DEFAULT_CHILD = new ExternalChild();
+  public ExternalChild childField;
 
   public ExternalData(int value) {
     this.value = value;
+    this.fieldValue = value;
+  }
+
+  public ExternalData(ExternalChild child) {
+    this.value = 0;
+    this.fieldValue = 0;
+    this.childField = child;
   }
 
   public int value() {
@@ -47,6 +58,10 @@ public final class ExternalData {
 
   public String describe(ExternalChild child) {
     return "ext-overload-child-" + child.marker();
+  }
+
+  public String fieldMarker() {
+    return "ext-field-" + fieldValue;
   }
 
   public static String tag() {

--- a/integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java
+++ b/integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java
@@ -66,7 +66,8 @@ public class ExternalTypeAdapterIntegrationTest extends RuntimeTest {
             "value=42",
             "child=ext-child-chain-ok",
             "accepted-child=ext-child-chain-ok",
-            "overloads=ext-overload-text-ok,ext-overload-child-ext-child-chain-ok"),
+            "overloads=ext-overload-text-ok,ext-overload-child-ext-child-chain-ok",
+            "phase5=ext-field-43,ext-child-chain-ok,44,45,ext-child-chain-ok,ext-child-chain-ok"),
         new ResultValidator() {
           @Override
           public void validate(String stdout, String stderr, int retcode, String jfrFile) {
@@ -88,6 +89,10 @@ public class ExternalTypeAdapterIntegrationTest extends RuntimeTest {
                 stdout.contains(
                     "overloads=ext-overload-text-ok,ext-overload-child-ext-child-chain-ok"),
                 "@ExternalType overload dispatch failed. stdout: " + stdout);
+            assertTrue(
+                stdout.contains(
+                    "phase5=ext-field-43,ext-child-chain-ok,44,45,ext-child-chain-ok,ext-child-chain-ok"),
+                "@ExternalType field, construction, or type narrowing failed. stdout: " + stdout);
           }
         });
   }

--- a/internal/plans/2026-08-08-issue-931-phase-5-fields-constructors-type-predicates-plan.md
+++ b/internal/plans/2026-08-08-issue-931-phase-5-fields-constructors-type-predicates-plan.md
@@ -1,0 +1,385 @@
+# Issue #931 — Phase 5 implementation plan: fields, constructors, and type predicates
+
+**Design input:** `internal/specs/2026-08-08-issue-931-phase-5-fields-constructors-type-predicates.md`
+**Required design state:** CLEAN before implementation begins
+**Baseline:** `develop` after Phase 4 PR #944
+**Worktree:** `/private/tmp/btrace-issue-931-phase5`
+
+## Scope and invariants
+
+Implement exactly five source-only `ExternalType` operations: instance/static field getters,
+instance/static field setters, constructors, `isInstance`, and `cast`. A contract remains a
+compile-time declaration of exact erased target signatures; generated public APIs keep ordinary
+Java types and opaque `Object` boundaries. This phase neither adds a reflection language nor
+changes extension staging, protocol, loader policy, package access, or masked-JAR layout unless
+the artifact proof demonstrates a narrowly missing published class.
+
+Preserve every Phase 1--4 boundary:
+
+- virtual operations select the receiver/value defining loader; static fields and constructors
+  retain legacy TCCL-with-null-system-fallback and explicit non-null loader forms;
+- owners and marked target types load with `Class.forName(name, false, loader)`; resolution does
+  not initialize targets, has no alternate-loader/name/signature fallback, and publishes only
+  successful results;
+- public lookup and exported-access requirements remain mandatory; do not use reflection,
+  `setAccessible`, `privateLookupIn`, `Lookup.in`, TCCL mutation, classpath/module rewriting, or
+  privileged access;
+- Phase 3 `@Type` remains a direct `Object` return/parameter marker only where explicitly
+  permitted; Phase 4 overload grouping remains `METHOD`-only;
+- all invalid contracts receive source-positioned processor diagnostics and emit no partial
+  adapter.
+
+## Preconditions and stop conditions
+
+1. Before editing, read `AGENTS.md`, this clean design, the Phase 4 plan, `ExternalType`,
+   `ExternalTypeResolutionException`, `ExternalTypeProcessor`, `MethodSpec`, `AdapterSpec`,
+   `AdapterEmitter`, `CompileTestHarness`, the existing processor/annotation tests, staged
+   `ExternalData` fixtures, the external processor smoke resources, and both canonical
+   extension-documentation pages. Read `docs/architecture/MaskedJarArchitecture.md` before any
+   distribution assertion or packaging change.
+
+2. Keep the existing untracked design spec untouched. Preserve any unrelated tracked/untracked
+   worktree state; inspect `git status --short` before and after each implementation gate.
+
+3. Stop for design review rather than improvise if a requirement needs generic/array target
+   metadata, reflection/bulk field access, constructor selectors, one-member aliases, overload
+   candidate search/coercion, private/JPMS bypass, loader fallback, cache-lifecycle redesign, or
+   a protocol/staging change.
+
+4. Stop at the owning gate on a failed diagnostic assertion, missing generated class/marker,
+   failed artifact inspection, nonzero verification command, `BUILD FAILED`, failing test, or
+   unexpected formatter rewrite. Never commit or push from this plan without explicit user
+   authorization and all required gates passing.
+
+## Implementation plan
+
+### 1. Publish the five narrow source markers
+
+Update `btrace-core/src/main/java/io/btrace/core/extensions/ExternalType.java`.
+
+- Add public nested `@Getter(String value)`, `@Setter(String value)`,
+  `@Constructor`, `@InstanceOf`, and `@Cast` annotations. Each has
+  `RetentionPolicy.SOURCE` and `ElementType.METHOD`; getter/setter have exactly their
+  `String value()` member and the remaining three have no elements.
+- Keep `Static` runtime retention, `Type` source retention, and `Overload` source retention
+  unchanged. The markers are processor input, but their nested `.class` files must still be in
+  the published masked JAR so external users can compile a contract.
+- Extend `btrace-core/src/test/java/io/btrace/core/extensions/ExternalTypeAnnotationTest.java` to
+  lock source retention, method target, exact members, and lack of accidental runtime elements for
+  all five annotations.
+- Add concise JavaDoc that states exact legal signatures, `Static` scope, `Type` scope, and that
+  markers never drive runtime annotation inspection.
+
+**Gate:** no new runtime helper/public reflection API or annotation descriptor grammar is added.
+
+### 2. Make operation kind explicit in the processor model
+
+Update `btrace-core/src/main/java/io/btrace/extension/processor/MethodSpec.java` (and
+`AdapterSpec` only if it needs a model-level helper).
+
+- Introduce an explicit `OperationKind` with `METHOD`, `GETTER`, `SETTER`,
+  `CONSTRUCTOR`, `INSTANCE_OF`, and `CAST`; retain independent `adapterName`,
+  `targetName`, erased return type, marked return FQN, erased parameter types, marked parameter
+  FQNs, and static state.
+- Add operation metadata only as needed: field name for fields, and the defined diagnostic member
+  text (`field`, `<init>`, `isInstance`, or `cast`). Do not overload a method-selector field
+  to describe fields/predicates.
+- Treat selector/field text as raw JVM member text in the model. Rendering is a separate concern:
+  generated Java source must quote it through one shared Java-string-literal escaper, never by
+  restricting or normalizing the stored member text.
+- Keep target identity and generated Java descriptor calculations separate. Exact target identity
+  includes operation kind, static/virtual state, target name/field name, return lookup type, and
+  lookup parameter types. Generated-descriptor collision detection remains cross-kind because two
+  generated Java methods cannot share a descriptor.
+
+**Gate:** `METHOD` remains the sole participant in Phase 4 local-name and target-name group
+validation. A field, constructor, predicate, or cast must never accidentally form an overload
+group merely because its text matches a method name.
+
+### 3. Validate complete contracts before rendering
+
+Refactor `btrace-core/src/main/java/io/btrace/extension/processor/ExternalTypeProcessor.java` to
+collect all adapted abstract interface methods, consume all operation annotations through
+`AnnotationMirror`/`AnnotationValue` where values are needed, validate the complete contract, and
+only then build/emit an `AdapterSpec`.
+
+- Add all five annotation names to `@SupportedAnnotationTypes`, track their annotated elements,
+  and report each unconsumed marker exactly once at its source position. Default and real Java
+  static interface methods are skipped adapters; operation marker use there is an error.
+- Reject more than one Phase 5 operation marker on a method. `Static` is valid for ordinary
+  `METHOD`, `GETTER`, and `SETTER` only; reject it for constructor/predicate/cast. Reject
+  `Overload` on every non-`METHOD` operation. Continue the Phase 3 direct-position-only and
+  `Object`-erasure validation for `Type`, then additionally reject it in forbidden positions.
+- Preserve frozen JVM field-name validation: nonblank (without trimming a valid name), unqualified
+  and containing none of `.`, `;`, `[`, `/`, `<init>`, or `<clinit>`; do not use host-JDK
+  keyword APIs. Quote, backslash, and control characters are valid frozen JVM name text and must
+  not be rejected merely because generated Java needs escaping. Fields outside adapted methods or
+  on default/static interface methods remain errors.
+- Validate operation signatures exactly:
+  - getter: non-`void`, zero declared target arguments; return lookup type may carry a direct
+    `@Type` marker;
+  - setter: `void`, exactly one declared target argument; that parameter may carry direct
+    `@Type`;
+  - constructor: direct `Object` return, no return `Type`, any ordinary/marked exact parameters,
+    no `Static`/`Overload`;
+  - `InstanceOf`: `boolean` return and exactly one direct unmarked `Object` parameter;
+  - `Cast`: direct unmarked `Object` return and exactly one direct unmarked `Object` parameter.
+- For fields, group by field name and static state: permit at most one getter and one setter; a
+  pair must have identical exact lookup type (target FQN rather than emitted `Object` when
+  marked). Reject duplicate getter/setter aliases and static/instance reuse of the same field.
+- Preserve Phase 4 `METHOD` rules unchanged: duplicate local Java names need selectors on every
+  group member, target-name groups have the existing all-selected rule, and a one-member selector
+  remains rejected. Do not apply those maps to special operations.
+- Calculate exact target-operation keys and reject duplicate keys. Separately calculate every
+  generated form: virtual `(Object self, emitted args...)`, static legacy `(emitted args...)`,
+  static/constructor explicit `(ClassLoader, emitted args...)`. Reject collisions with the
+  established generated-descriptor diagnostic, including `create()` against
+  `create(ClassLoader)` and a collision across operation kinds. Anchor each diagnostic to the
+  declaration that caused it and retain no-partial-adapter behavior.
+
+**Gate:** diagnostics explain the offending declaration/group and the corrective rule (signature,
+marker, field pairing, or local rename). Do not weaken existing Phase 1--4 failure text merely to
+accommodate Phase 5.
+
+### 4. Render independent, exact public operations
+
+Extend `btrace-core/src/main/java/io/btrace/extension/processor/AdapterEmitter.java` using the
+operation kind rather than branching on method name.
+
+- Add one shared Java string-literal escaper and use it for every generated target member literal:
+  ordinary/selected method names, getter/setter field names, and resolution-exception member text.
+  It must preserve the raw model text used for identity/lookup while escaping `"`, `\\`, control
+  characters, and other source-sensitive code points into Java-8-valid source. Do not concatenate
+  raw annotation text into generated source or alter the lookup name to its escaped spelling.
+- Keep one independent successful-resolution cache per field operation/constructor. Reuse the
+  existing `ResolvedCall`, virtual `ClassValue`, and static weak-identity loader index,
+  per-operation monitor, bootstrap/system sentinels, expunging, and owner-keyed `ClassValue`.
+  Legacy and explicit static/constructor calls share their successful entry. Failures must not
+  create cache/index entries.
+- Render public lookup calls exactly:
+  `findGetter`, `findSetter`, `findStaticGetter`, `findStaticSetter`, and
+  `findConstructor` with `MethodType.methodType(void.class, exactParameterTypes)`. Resolve
+  marked field/constructor types with the successfully resolved owner's defining loader before
+  lookup. Never pass the adapter control `ClassLoader` into a constructor `MethodType` or
+  invocation list.
+- Preserve virtual field null-receiver behavior and static explicit-loader null rejection before
+  cache access. Use the Phase 2 legacy/static policy unchanged for static fields and constructors.
+  Keep ordinary `METHOD` and selected-method emitter output behavior intact.
+- Render predicate/cast operations with an independent `ClassValue<Class<?>>` keyed by
+  `value.getClass()`. On non-null compute, load `OWNER` with that defining loader and verify
+  public/exported access via `publicLookup().findVirtual(owner, "getClass",
+  MethodType.methodType(Class.class))`; discard the probe handle. Then use `owner.isInstance` or
+  `owner.cast`, not a member lookup/handle. Bypass the cache entirely for null: return `false` or
+  `null`. Let a wrong non-null cast throw ordinary `ClassCastException`.
+- Translate only resolution-phase `ClassNotFoundException`, `NoSuchFieldException`,
+  `NoSuchMethodException`, and `IllegalAccessException` into
+  `ExternalTypeResolutionException`, with owner plus the defined member text. Keep target
+  initializer/constructor errors, linkage/security errors, wrong invocation arguments,
+  `ClassCastException`, and target-thrown resolution exceptions transparent.
+
+Update `btrace-core/src/main/java/io/btrace/core/extensions/ExternalTypeResolutionException.java`
+JavaDoc to include field lookup and predicate/cast public-access probe failures while preserving
+the cause contract.
+
+**Gate:** resolution class loads use `initialize=false`; a successful lookup/probe cannot trigger
+target initialization. Static field access and constructor invocation may initialize normally.
+
+### 5. Build exhaustive focused processor and runtime tests
+
+Extend `btrace-core/src/test/java/io/btrace/extension/processor/ExternalTypeProcessorTest.java`
+and, only if necessary, `CompileTestHarness.java` with source-generation, diagnostics, isolated
+loader, mutable-loader/retry, and cache fixtures. Keep existing Phase 1--4 tests untouched except
+for strictly necessary shared test helpers.
+
+- Positive generation/runtime coverage: primitive and JDK instance fields; marked `Object` field
+  return/parameter; static field legacy TCCL and explicit loader forms; get/set pair sharing the
+  same exact field type; public construction with regular and marked arguments; coexistence with
+  an ordinary static method; predicate/cast behavior before another adapter call.
+- Isolated hostile loaders with same-FQN owners prove virtual field and predicate/cast selection
+  follows receiver/value definition, cache entries stay loader-isolated, wrong-loader marked
+  values fail without fallback, and user `equals`/`hashCode` are never called. Cover null
+  receiver, null predicate/cast semantics, null explicit loader before cache mutation, retry after
+  an owner/marked type/member appears, per-operation attempts, and no negative caching.
+- Failure/transparency coverage: missing/inaccessible/final field write, missing/inaccessible
+  constructor, inaccessible predicate owner access probe, missing marked type, source exception
+  cause/member text, target initializer/constructor failure, wrong handle argument, cast
+  `ClassCastException`, security/linkage transparency, and target-thrown resolution exception.
+  Each failure must assert the intended cause/message, not just any failure.
+- Initialization fixture: establish that a lookup-only successful path leaves a target uninitialized
+  and that invoking a static getter/setter or constructor initializes only at normal JVM execution.
+- Validation fixtures: malformed field names; operation markers outside an adapted contract or on
+  default/static methods; multiple operation markers; illegal `Static`, `Overload`, and `Type`;
+  malformed getter/setter/constructor/predicate/cast signatures; duplicate predicates/casts;
+  duplicate getter/setter aliases; incompatible read/write pairs; static/instance same-field reuse;
+  exact-key duplicates; constructor generated-form collision; cross-kind descriptor collision;
+  and no generated source after a contract error. Assert Phase 4 overload grouping accepts ordinary
+  methods only and fields/constructors/predicates cannot enter it.
+- Retain Java-8 source compatibility tests (including a field named `_` if useful) with
+  `CompileTestHarness.compile(sources, 8)`, proving no host-JDK identifier/keyword validation
+  leaks into the frozen field-name rule.
+- Add a compile-only Java-8 generated-source fixture using `@Getter("a\"b")`. Assert the
+  generated `findGetter` Java literal is correctly escaped while preserving that raw lookup text,
+  then compile the generated adapter with `--release 8`; do not attempt a target invocation because
+  Java source cannot declare the quote-containing field. This must prove the common escaper is
+  used by a real generated adapter rather than merely unit-testing an emitter helper.
+
+**Gate:** exact marked target FQNs, never contract `.class` literals, feed field/constructor
+MethodTypes; emitted source remains Java 8 and exposes only allowed erased/Object signatures.
+
+### 6. Prove the published masked JAR from separated Java 8 sources
+
+Update only the smoke fixtures below
+`btrace-dist/src/test/resources/external-type-processor-smoke/`:
+
+- `target-src/example/target/ExternalParent.java` and `ExternalChild.java`: expose public
+  instance/static fields, a constructor, and discriminating child/type markers without any BTrace
+  dependency;
+- `extension-src/example/ParentApi.java` and `ChildApi.java`: declare getters/setters,
+  constructor, predicate/cast, and marked `Object` field/constructor positions without importing
+  target classes;
+- `extension-src/example/ExternalTypeSmoke.java`: invoke each required operation, predicate/cast
+  then a second adapter call, and print stable markers for field, constructor, and type paths.
+
+After clean `btrace.jar` creation, inspect it for all five nested annotation classes,
+`ExternalType`, `ExternalTypeResolutionException`, the processor and needed support classes, plus
+`META-INF/services/javax.annotation.processing.Processor`. Compile target sources first with
+`javac --release 8`; compile contracts/driver separately with the masked JAR as the sole
+classpath and processorpath. Assert generated adapters/classes exist, generated source uses
+`Object` at every marked boundary, contains the exact field/constructor lookup forms and predicate
+behavior, and contains no contract or target `.class` literal/leak. Run solely with extension
+classes, target classes, and the masked JAR.
+
+**Stop:** do not change `btrace-dist` packaging or add target output/sources to contract
+compilation. A missing annotation/service/processor entry is evidence for a narrow packaging
+review, not permission for broad jar restructuring.
+
+### 7. Add real staged client-agent-target integration coverage
+
+Modify the existing external-type scenario only:
+
+- `integration-tests/src/test/java/resources/ExternalData.java` (and an application-only child
+  fixture if required) exposes target-owned public state, a public constructor/factory scenario,
+  and distinct marker methods;
+- `btrace-extensions/btrace-ext-test/src/main/java/io/btrace/test/ext/ExternalDataType.java` and
+  a child contract declare the Phase 5 operations with `Object`/`Type` boundaries;
+- `ExternalTypeTestService.java` and `ExternalTypeTestServiceImpl.java` create/read/write then
+  predicate/cast a target value before a second generated adapter call, without target imports;
+- `integration-tests/src/test/btrace/ExternalTypeAdapterTest.java` emits discriminating
+  target-owned field/constructor/predicate markers;
+- `integration-tests/src/test/java/tests/ExternalTypeAdapterIntegrationTest.java` waits for and
+  asserts each marker.
+
+Keep `ExternalTypeAdapterExplicitTest` and its deterministic decoy-TCCL scenario dedicated to
+Phase 2. The test extension must still be staged through the existing extension path, excluded
+from release extension output, and compiled without the target application library. The proof must
+exercise the real client, agent, instrumentation, target JVM, protocol, and staged extension.
+
+**Gate:** a component/direct-adapter test cannot replace this end-to-end test. The observed marker
+must depend on actual field use, construction, and type narrowing in the target process.
+
+### 8. Document the exact contract and manual boundary
+
+Update `docs/BTraceExtensionDevelopmentGuide.md` as the normative guide and
+`docs/architecture/provided-style-extensions.md` as the concise manual-path pointer.
+
+- Show a complete contract for getter, setter, static field, constructor, `isInstance`, and
+  `cast`, including exact signatures, `@Type(ChildApi.class) Object`, receiver/loader forms, and
+  the two constructor/static-field forms.
+- Explain that fields and constructors use public exact lookup types; predicates/casts use the
+  non-null value's defining loader, follow `Class` null/cast semantics, and do not initialize on
+  resolution. Document field pair consistency, retryable resolution errors, target failure
+  transparency, and public/exported access restrictions.
+- Make unsupported scope explicit: generic/array target types, bulk/reflection-style operations,
+  fluent setters, constructor selectors, runtime overload choice/coercion, non-public/JPMS
+  bypass, and later security/access work retain the manual path. Avoid duplicating full guide
+  tables in the architecture pointer.
+
+**Gate:** documentation never suggests a target implements the contract, target classes are on the
+extension compile classpath, a `ClassLoader` control argument becomes a target constructor argument,
+or Phase 5 provides private/module bypass.
+
+## Verification and release-surface checklist
+
+Run from `/private/tmp/btrace-issue-931-phase5`. Redirect every Gradle command, inspect its
+filtered log, build the distribution before the integration test, and rerun only an affected
+command with the documented IPv4 options if the known address-selection failure occurs.
+
+```bash
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-core:test > /tmp/btrace-issue-931-phase5-core-test.log 2>&1
+rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|ExternalType" /tmp/btrace-issue-931-phase5-core-test.log
+
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-core:spotlessCheck > /tmp/btrace-issue-931-phase5-core-spotless.log 2>&1
+rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase5-core-spotless.log
+
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew clean :btrace-dist:btraceJar > /tmp/btrace-issue-931-phase5-masked-jar.log 2>&1
+rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|btraceJar" /tmp/btrace-issue-931-phase5-masked-jar.log
+
+rg --files btrace-dist/build/resources/main | rg '^btrace-dist/build/resources/main/v[^/]+/libs/btrace\.jar$' > /tmp/btrace-issue-931-phase5-jar-path.log
+test "$(rg -c '^' /tmp/btrace-issue-931-phase5-jar-path.log)" = 1
+BTRACE_931_PHASE5_JAR="$(rg -x 'btrace-dist/build/resources/main/v[^/]+/libs/btrace\.jar' /tmp/btrace-issue-931-phase5-jar-path.log)"
+jar tf "$BTRACE_931_PHASE5_JAR" > /tmp/btrace-issue-931-phase5-jar-entries.log
+for BTRACE_931_PHASE5_ENTRY in \
+  'io/btrace/core/extensions/ExternalType.class' \
+  'io/btrace/core/extensions/ExternalType$Getter.class' \
+  'io/btrace/core/extensions/ExternalType$Setter.class' \
+  'io/btrace/core/extensions/ExternalType$Constructor.class' \
+  'io/btrace/core/extensions/ExternalType$InstanceOf.class' \
+  'io/btrace/core/extensions/ExternalType$Cast.class' \
+  'io/btrace/core/extensions/ExternalType$Type.class' \
+  'io/btrace/core/extensions/ExternalType$Overload.class' \
+  'io/btrace/core/extensions/ExternalTypeResolutionException.class' \
+  'io/btrace/extension/processor/ExternalTypeProcessor.class' \
+  'META-INF/services/javax.annotation.processing.Processor'; do
+  rg -Fx "$BTRACE_931_PHASE5_ENTRY" /tmp/btrace-issue-931-phase5-jar-entries.log
+done
+unzip -p "$BTRACE_931_PHASE5_JAR" META-INF/services/javax.annotation.processing.Processor > /tmp/btrace-issue-931-phase5-processor-service.log
+rg -n '^io\.btrace\.extension\.processor\.ExternalTypeProcessor$' /tmp/btrace-issue-931-phase5-processor-service.log
+
+BTRACE_931_PHASE5_SMOKE=$(mktemp -d /tmp/btrace-issue-931-phase5-smoke.XXXXXX)
+javac --release 8 -d "$BTRACE_931_PHASE5_SMOKE/target-classes" btrace-dist/src/test/resources/external-type-processor-smoke/target-src/example/target/*.java > /tmp/btrace-issue-931-phase5-target-javac.log 2>&1
+rg -n 'error:|warning:' /tmp/btrace-issue-931-phase5-target-javac.log || true
+javac --release 8 -cp "$BTRACE_931_PHASE5_JAR" -processorpath "$BTRACE_931_PHASE5_JAR" -d "$BTRACE_931_PHASE5_SMOKE/extension-classes" -s "$BTRACE_931_PHASE5_SMOKE/generated" btrace-dist/src/test/resources/external-type-processor-smoke/extension-src/example/*.java > /tmp/btrace-issue-931-phase5-extension-javac.log 2>&1
+rg -n 'error:|warning:|ExternalType|ParentApi|ChildApi' /tmp/btrace-issue-931-phase5-extension-javac.log || true
+test -f "$BTRACE_931_PHASE5_SMOKE/generated/example/ParentApi\$Ext.java"
+test -f "$BTRACE_931_PHASE5_SMOKE/generated/example/ChildApi\$Ext.java"
+test -f "$BTRACE_931_PHASE5_SMOKE/extension-classes/example/ParentApi\$Ext.class"
+test -f "$BTRACE_931_PHASE5_SMOKE/extension-classes/example/ChildApi\$Ext.class"
+rg -n 'find(Getter|Setter|StaticGetter|StaticSetter|Constructor)|isInstance|cast|Object' "$BTRACE_931_PHASE5_SMOKE/generated"/example/*.java
+! rg -n 'ChildApi\.class|ParentApi\.class|ExternalChild\.class|ExternalParent\.class' "$BTRACE_931_PHASE5_SMOKE/generated"/example/*.java
+java -cp "$BTRACE_931_PHASE5_SMOKE/extension-classes:$BTRACE_931_PHASE5_SMOKE/target-classes:$BTRACE_931_PHASE5_JAR" example.ExternalTypeSmoke > /tmp/btrace-issue-931-phase5-external-run.log 2>&1
+rg -n '^external-type-field-ok$' /tmp/btrace-issue-931-phase5-external-run.log
+rg -n '^external-type-constructor-ok$' /tmp/btrace-issue-931-phase5-external-run.log
+rg -n '^external-type-predicate-ok$' /tmp/btrace-issue-931-phase5-external-run.log
+
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-dist:build > /tmp/btrace-issue-931-phase5-dist-build.log 2>&1
+rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Test" /tmp/btrace-issue-931-phase5-dist-build.log
+
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :btrace-extensions:btrace-ext-test:spotlessCheck > /tmp/btrace-issue-931-phase5-ext-spotless.log 2>&1
+rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase5-ext-spotless.log
+
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:spotlessCheck > /tmp/btrace-issue-931-phase5-integration-spotless.log 2>&1
+rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase5-integration-spotless.log
+
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew :integration-tests:test -Pintegration --tests tests.ExternalTypeAdapterIntegrationTest > /tmp/btrace-issue-931-phase5-integration.log 2>&1
+rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|ExternalTypeAdapterIntegrationTest|timed out" /tmp/btrace-issue-931-phase5-integration.log
+```
+
+Before every user-authorized push, unconditionally run root formatting in this dedicated worktree,
+inspect its exact diff, and repeat affected checks if it changes source. Do this even when the
+working tree appears formatted; a push is blocked until this gate succeeds:
+
+```bash
+GRADLE_USER_HOME=$(pwd)/.gradle-user ./gradlew spotlessApply > /tmp/btrace-issue-931-phase5-spotless-apply.log 2>&1
+rg -n "BUILD SUCCESSFUL|BUILD FAILED|FAILED|ERROR|Spotless" /tmp/btrace-issue-931-phase5-spotless-apply.log
+git diff --check
+git status --short
+```
+
+## Completion criteria
+
+Phase 5 is complete only when all five operations meet the exact declaration, loader,
+success-only-cache, public-access, failure, initialization, and target-type rules; focused tests
+cover every positive and rejection boundary; the external Java 8 masked-JAR proof is genuinely
+separated; the staged integration test proves field, construction, and type narrowing over the
+real client-agent-target protocol; docs explain use and limits; root formatting and every required
+check pass; and the final diff contains no unrelated change. This plan does not authorize Phase 6.

--- a/internal/specs/2026-08-08-issue-931-phase-5-fields-constructors-type-predicates.md
+++ b/internal/specs/2026-08-08-issue-931-phase-5-fields-constructors-type-predicates.md
@@ -1,0 +1,374 @@
+# Issue #931, Phase 5: public fields, constructors, and type predicates
+
+Date: 2026-08-08
+Status: design proposal; implementation and planning must wait for a CLEAN design review
+Baseline: `develop` after Phase 4 (#941, #942, #943, and #944)
+
+## Problem and goal
+
+Phases 1--4 make public methods, target-type positions, static-loader selection, and explicit
+method-overload groups available through generated adapters. A typical application API also exposes
+public state, factories expressed as constructors, and values that must be recognised or narrowed
+before another adapter is called. Today all four cases require a hand-written public lookup or
+`Class` operation.
+
+Phase 5 adds only the five operations required for those cases: public instance/static field get,
+public instance/static field set, public construction, `isInstance`, and `cast`. It is deliberately
+not a general member-description language. It preserves the Phase 1 successful-only cache,
+Phase 2 static-loader policy, Phase 3 target-type metadata, Phase 4 method-selector rules, and the
+existing public/exported access boundary.
+
+## Decision: five source-only operation markers
+
+Add these nested annotations to `ExternalType`, all retained only in source and targeted at a
+method declaration:
+
+```java
+@interface Getter { String value(); }
+@interface Setter { String value(); }
+@interface Constructor {}
+@interface InstanceOf {}
+@interface Cast {}
+```
+
+`Getter` and `Setter` bind to the named target field. `Constructor` binds to the owning external
+type's public `<init>`. `InstanceOf` and `Cast` bind to the owning external type itself, not to a
+member. Each marker is a distinct operation selector, so no `Overload` value or descriptor string
+is needed.
+
+```java
+@ExternalType("vendor.Widget")
+interface WidgetApi {
+  @ExternalType.Getter("name")
+  String name();
+
+  @ExternalType.Setter("name")
+  void setName(String name);
+
+  @ExternalType.Static
+  @ExternalType.Getter("DEFAULT")
+  @ExternalType.Type(ChildApi.class)
+  Object defaultChild();
+
+  @ExternalType.Constructor
+  Object create(String name);
+
+  @ExternalType.InstanceOf
+  boolean isWidget(Object value);
+
+  @ExternalType.Cast
+  Object castWidget(Object value);
+}
+```
+
+The generated calls are respectively `name(Object self)`, `setName(Object self, String)`,
+`defaultChild()` / `defaultChild(ClassLoader)`, `create(String)` /
+`create(ClassLoader, String)`, `isWidget(Object)`, and `castWidget(Object)`. The explicit
+`ClassLoader` parameter is adapter control data, as in Phase 2; it never enters a target field
+type, constructor `MethodType`, or invocation argument list.
+
+The markers are source-only processor input. The published masked JAR must expose their class
+files for external compilation, but generated adapters do not inspect annotations at runtime.
+
+### Why separate markers
+
+| Option | Decision | Reason |
+| --- | --- | --- |
+| Five narrow operation markers | Chosen | Java declarations continue to describe Java values; each marker supplies exactly the missing member kind and permits exhaustive processor validation. |
+| General `@ExternalType.Member(kind, name, descriptor)` | Rejected | Duplicates Java signatures, encourages reflection-like expansion, and would need a broad grammar, coercion policy, and migration rules. |
+| Encode fields and constructors as method names (`getX`, `<init>`) | Rejected | It is ambiguous, makes typo diagnostics poor, and Phase 4 correctly reserves method selectors for methods. |
+| Extend `MethodHandleCache` first | Rejected | Generated adapters need Phase 1's loader-safe `ClassValue`/weak-index lifecycle, while the manual helper intentionally retains strong owner keys. The manual API remains a direct public-lookup escape hatch in this phase. |
+
+## Contract validation
+
+All Phase 1--4 interface, non-empty-owner, abstract-method, generic-erasure, target-type-marker,
+generated-descriptor, and method-selector validation continues to apply unless a rule below
+supersedes it. A method has at most one operation marker. `Static` is legal only with `Getter` or
+`Setter` or an ordinary `METHOD`; it remains the sole way to select a static **field** and retains
+its existing meaning for a static target method. It is illegal with `CONSTRUCTOR`, `INSTANCE_OF`,
+or `CAST`. `Overload` is legal only on an ordinary method operation and is rejected on every Phase
+5 operation. `Type` is permitted only in the positions described below; existing unconsumed-marker
+diagnostics must continue to be source-positioned and no adapter is emitted for an invalid
+contract.
+
+The processor model gains an explicit `OperationKind`: `METHOD`, `GETTER`, `SETTER`,
+`CONSTRUCTOR`, `INSTANCE_OF`, or `CAST`. `MethodSpec` carries that kind and the operation-specific
+lookup metadata. Both Phase 4 Java method-name duplicate grouping and target-name grouping,
+including the rule that every member of a selected overload group carries `@Overload`, apply
+**only** to `METHOD` entries. A field name, `<init>`, or predicate operation is never a member of
+either Phase 4 group and cannot carry `Overload`. Exact target identity includes the operation
+kind, so an ordinary method and a field/predicate whose local or target text happens to coincide
+are not duplicate target members. Generated Java descriptor collision checking deliberately
+remains cross-kind and is the sole local-name-overlap restriction across operation kinds: two
+operations cannot emit the same Java method descriptor even when their target identities differ.
+
+Field names use the same frozen JVM-name validation as Phase 4 selectors: they are nonblank,
+unqualified names without `.`, `;`, `[`, or `/`, and are neither `<init>` nor `<clinit>`. Preserve
+a nonblank name exactly; do not use host-JDK identifier/keyword rules. A field marker outside an
+adapted abstract interface method, on a default/static-interface method, or combined with another
+operation marker is a processor error.
+
+One contract may declare one getter and one setter for the same target field. They must use the
+same `Static` state and the same exact lookup type (including a Phase 3 target FQN rather than the
+emitted `Object` when marked). This is the supported read/write pair. A second getter or second
+setter for the same target field is a rejected same-field alias, even when its local adapter name
+or ordinary Java type differs. A field name cannot be used once as static and once as instance in
+one contract. These checks are processor-owned and prevent redundant caches or a misleading
+appearance of multiple physical fields; runtime lookup remains the authority for whether the
+named public field actually exists.
+
+### Getter
+
+`@Getter("field")` requires a non-`void` return and no declared target parameters. Its return type
+is the exact erased target field type. A direct target-library field type uses the existing
+`@Type(OtherContract.class) Object` return marker; ordinary primitive, JDK, generic-erasure, and
+`Object` field types keep their existing meaning. The generated virtual form has `Object self` as
+its only parameter; `@Static` instead produces Phase 2 legacy and explicit-loader forms.
+
+### Setter
+
+`@Setter("field")` requires `void` return and exactly one declared target parameter. That parameter
+is the exact erased target field type and may use the existing direct-`Object` `@Type` marker. The
+generated virtual form is `(Object self, fieldValue)`; `@Static` has the existing zero-receiver
+legacy and explicit-loader forms. Fluent setters, multiple-field writes, and a getter/setter
+combined in one declaration are out of scope.
+
+### Constructor
+
+`@Constructor` requires direct `Object` return, no return `@Type` marker, and no `Static` or
+`Overload` annotation. The owning `@ExternalType` name itself is the produced target type, so a
+return marker would be redundant and misleading. Parameters use the ordinary exact erased types
+and may use Phase 3 direct-`Object` `@Type` markers.
+
+Construction has no target receiver. It therefore has the same two loader forms as a static
+operation: a legacy form that resolves through TCCL (falling back to the system loader only when
+TCCL is null), and an explicit form whose leading non-null `ClassLoader` selects the owner.
+Distinct constructor parameter signatures may use ordinary Java overloads under the same local
+adapter name; each signature directly forms its exact constructor `MethodType`, so no Phase 4
+selector/group is involved. They are valid only when **every** generated legacy and explicit-loader
+descriptor is distinct, including descriptors generated for another constructor or operation. For
+example, `create()` generates explicit `create(ClassLoader)`, which collides with the legacy form
+generated for `create(ClassLoader)`. The processor must reject that source with the established
+generated-descriptor collision diagnostic rather than emitting an ambiguous adapter. The same
+cross-kind generated-descriptor check rejects a real collision with another operation.
+
+### Type predicates and casts
+
+`@InstanceOf` requires `boolean` return and exactly one direct `Object` parameter.
+`@Cast` requires direct `Object` return and exactly one direct `Object` parameter. Neither permits
+`Static`, `Overload`, or `Type`: the adapted owner is already the target class and the argument is
+the value being tested or narrowed. At most one `InstanceOf` and one `Cast` operation may appear in
+one contract; aliases and multiple predicate variants would be general reflection surface without
+new capability.
+
+For non-null values, both operations resolve the owner with the candidate value's defining loader:
+
+```java
+Class<?> owner = Class.forName(OWNER, false, value.getClass().getClassLoader());
+```
+
+This is the virtual loader rule applied to the value that supplies the only meaningful application
+loader. It avoids an ambient TCCL choice and prevents a same-FQN class from a different isolated
+application loader being accepted. The resolved owner is then used as `owner.isInstance(value)` or
+`owner.cast(value)`.
+
+Null follows the corresponding `Class` operation exactly: `isInstance(null)` returns `false` and
+`cast(null)` returns `null`. Neither case attempts class resolution, so it cannot turn an ordinary
+null check into an availability failure. A non-null wrong-type `cast` throws the normal
+`ClassCastException`; it is not converted to `ExternalTypeResolutionException`.
+
+## Generated lookup and caching
+
+### Fields and constructors
+
+Every getter, setter, and constructor has one independent `ClassValue<ResolvedCall>` and uses the
+existing generated `ResolvedCall` layout. The value stores the owner and exact handle. Its compute
+function performs `Class.forName(OWNER, false, loader)`, resolves all Phase 3 marked field or
+constructor parameter types through `owner.getClassLoader()`, and then performs exactly one public
+lookup:
+
+```java
+lookup.findGetter(owner, fieldName, exactFieldType)
+lookup.findSetter(owner, fieldName, exactFieldType)
+lookup.findStaticGetter(owner, fieldName, exactFieldType)
+lookup.findStaticSetter(owner, fieldName, exactFieldType)
+lookup.findConstructor(owner, MethodType.methodType(void.class, exactParameterTypes))
+```
+
+Instance fields key their `ClassValue` with `self.getClass()` and retain the Phase 1 null-receiver
+behaviour. Static fields and constructors reuse, unchanged, the per-operation monitor,
+weak-identity loader-to-owner index, bootstrap/system sentinels, expunging, and owner-keyed
+`ClassValue` from Phases 1--2. The legacy and explicit forms share each successful entry. No
+strong loader key, FQN-only class cache, second target-type cache, negative cache, or new global
+runtime helper is permitted.
+
+This preserves success-only publication and retry: class, marked-type, field, constructor, or
+access failure places no `ClassValue`/loader-index entry. Static and constructor resolution remain
+single-flight under their per-operation monitor; virtual field and predicate first use makes no
+new single-flight promise.
+
+### Predicates and casts
+
+Each predicate/cast has a `ClassValue<Class<?>>` keyed by `value.getClass()`. Its computation loads
+the owner with that class's defining loader and validates that the owner is accessible to
+`MethodHandles.publicLookup()` by resolving the inherited public `Object.getClass` member without
+invoking it:
+
+```java
+MethodHandles.publicLookup().findVirtual(owner, "getClass", MethodType.methodType(Class.class));
+```
+
+The returned probe handle is discarded. Unlike `Lookup.in(owner)`, this lookup enforces that the
+owner is public and accessible/exported to public lookup. The class value is published only after
+both class load and probe succeed. The probe does not discover or invoke an arbitrary target
+member, initialize the target, or introduce a class-loader fallback.
+
+The successful class value naturally distinguishes same-FQN owners from isolated application
+loaders and is releasable with its key class. It contains no target values. Failures are not
+cached. Null predicate/cast calls bypass this cache according to the documented `Class` semantics.
+
+## Failure, initialization, access, and security
+
+All owner and Phase 3 marked-type loads use `Class.forName(..., false, loader)`. Handle lookup,
+the predicate access probe, and cache setup must not initialize a target class. Invoking a static
+field getter/setter or constructor may initialize the target class when the JVM normally requires
+it; that is ordinary target-operation behaviour and must not be hidden or pre-triggered during
+resolution. `isInstance` and `cast` do not initialize a resolved target class.
+
+`ClassNotFoundException`, `NoSuchFieldException`, `NoSuchMethodException`, and
+`IllegalAccessException` raised while resolving an owner, marked type, public operation, or the
+non-invoking predicate/cast access probe become the established cause-preserving
+`ExternalTypeResolutionException`. Its owner remains the contract's target FQN; its member is the
+selected field name, `<init>` for a constructor, or the literal operation name `isInstance`/`cast`
+for a predicate/cast. Update its JavaDoc to include the field exception type and predicate/cast
+access probe.
+
+Static/instance-kind mismatches, absent fields/constructors, final-field writes rejected by the
+lookup, non-public members, and inaccessible named-module packages are resolution failures under
+that rule. Normal invocation-time failures are deliberately not caught by resolution handling:
+field/constructor-triggered initializer errors, constructor-thrown exceptions, wrong-loader or
+wrong-type handle arguments, `ClassCastException` from `cast`, `SecurityException`, linkage
+errors, and a target-thrown `ExternalTypeResolutionException` propagate unchanged. There is no
+fallback to another field, constructor, loader, or compatible type.
+
+Phase 5 does not use `setAccessible`, core reflection fields/constructors, `privateLookupIn`,
+module-opening flags, instrumentation/module rewrites, classpath changes, an implementation
+loader, privileged lookup, or TCCL mutation. Only public members of an owner accessible to public
+lookup are supported.
+
+## Compatibility and published surface
+
+Existing contracts, generated class names, ordinary/overloaded method dispatch (including ordinary
+`@Static` methods), `Type` behaviour, virtual defining-loader selection, static legacy TCCL
+fallback, explicit static loader overloads, success-only caching, failure translation, and target
+exception propagation do not change. Already-built extensions retain their old generated output; a
+new operation requires a rebuild.
+
+The five nested source annotations are the only new public API. The generated API exposes only
+ordinary erased Java types and `Object`; it never exposes target-library types or contract class
+literals. Constructors return `Object` by design, and predicate/cast values remain opaque. The
+published masked `io.btrace:btrace` JAR must contain all five annotation class files, the processor
+service/implementation, `ExternalType`, `ExternalTypeResolutionException`, and all currently
+required processor support. No Gradle DSL, extension-loading, attach/protocol, permission, or
+packaging policy change is intended unless the external artifact proof identifies a specific
+omission.
+
+## Affected components
+
+- `btrace-core`: `ExternalType` and resolution-exception JavaDoc; processor validation/model;
+  `MethodSpec`/adapter specification as needed; generated emitter; focused processor/runtime
+  tests. Generated source stays Java 8 compatible.
+- `btrace-dist`: external processor smoke fixtures and masked-JAR assertions only, absent a
+  demonstrated packaging defect.
+- `btrace-extensions:btrace-ext-test` and `integration-tests`: a staged application-only fixture
+  that exercises a field, construction, and a predicate/cast through extension, client, agent,
+  target JVM, and protocol.
+- `docs/BTraceExtensionDevelopmentGuide.md` (normative) and
+  `docs/architecture/provided-style-extensions.md` (manual boundary/pointer). Update their
+  unsupported-feature tables and direct manual examples precisely.
+
+## Acceptance criteria
+
+1. External contracts can generate and invoke exact public instance and static getter/setter
+   handles, including primitive/JDK and Phase 3 direct-`Object` target field types. Static field
+   legacy and explicit-loader calls retain Phase 2 behaviour and share a successful cache entry.
+2. Contracts can construct a public target through `@Constructor Object localName(...)`, including
+   marked target-only parameter types. The two constructor loader forms are exact, reject a null
+   explicit loader before cache access, and never pass that loader to the target constructor.
+3. `isInstance(Object)` and `cast(Object)` use the non-null value's defining loader, distinguish
+   same-FQN types from isolated loaders, use no TCCL, and follow `Class.isInstance` / `Class.cast`
+   null and `ClassCastException` behaviour exactly.
+4. Field, constructor, predicate, and cast resolution remains loader-isolated, success-only,
+   unloadable under the existing `ClassValue`/weak-static-index topology, and retryable after a
+   mutable loader makes a missing class/member available. Hostile loader `equals`/`hashCode` is not
+   used.
+5. Diagnostics reject malformed field names; incompatible marker combinations; non-void getters;
+   malformed setters; invalid same-field aliases/read-write pairs; constructor
+   non-`Object`/return-marker/static forms; malformed predicate or cast signatures; duplicate
+   predicates/casts; Phase 4 selectors on special operations; and generated descriptor collisions.
+   Fixtures prove both Phase 4 local-Java-name and target-name overload grouping exclude fields,
+   constructors, and predicates; prove `create()` plus `create(ClassLoader)` fails because the
+   former's explicit form collides with the latter's legacy form; and prove a cross-kind descriptor
+   collision still fails. Invalid contracts emit no partial adapter.
+6. Missing owner/marked type/field/constructor, inaccessible field/constructor, or an inaccessible
+   predicate/cast owner rejected by the non-invoking public `getClass` lookup gives a
+   cause-preserving `ExternalTypeResolutionException` using the defined member text and is
+   retried. Target invocation failures, wrong-type arguments, cast failures, security/linkage
+   errors, and target initialization failures remain transparent.
+7. Resolution never initializes a target class. A fixture proves the class is uninitialized after
+   a successful lookup-only path and initialized only when a static field operation or constructor
+   is invoked, as required by JVM semantics.
+8. Existing Phase 1--4 processor/runtime coverage remains green: ordinary and selected methods,
+   ordinary `@Static` methods, target-type chains, legacy null-TCCL static dispatch, explicit
+   loader dispatch, and their cache/failure boundaries are unchanged. Add a regression fixture
+   proving an ordinary static method can coexist with Phase 5 operations and retains both generated
+   static forms.
+9. The real staged extension/client/agent/target path invokes an instance or static field,
+   constructs a target object, and performs an `isInstance`/cast before another adapter call,
+   producing a target-owned marker. The target library remains absent from the extension compile
+   classpath and the test extension remains unstaged from release output.
+10. A clean masked JAR contains all five annotation classes and processor support. A separated
+    `javac --release 8` smoke compiles target sources separately, then contracts/driver with only
+    that JAR on classpath and processorpath; generated descriptors contain `Object` rather than
+    target/contract class literals, and the driver runs solely with target output, extension
+    output, and the masked JAR.
+11. Documentation explains all five operation forms, their exact signatures, loader selection,
+    null/failure/initialization rules, static field and constructor forms, and the continuing
+    manual path for generic/array types, bulk/reflection-style operations, non-public/JPMS access,
+    and all deferred features.
+
+## Verification gates
+
+The implementation plan must run from the repository root with a workspace-local Gradle cache,
+redirect each Gradle invocation to `/tmp`, and filter it before inspection. Build distribution
+artifacts before the integration test:
+
+```text
+:btrace-core:test
+:btrace-core:spotlessCheck
+clean :btrace-dist:btraceJar
+:btrace-dist:build
+:btrace-extensions:btrace-ext-test:spotlessCheck
+:integration-tests:spotlessCheck
+:integration-tests:test -Pintegration --tests tests.ExternalTypeAdapterIntegrationTest
+```
+
+It must inspect the clean masked JAR and processor service, run the separated Java 8 external
+smoke described in acceptance criterion 10, and finish with `git diff --check`. Each positive
+operation test needs a discriminating rejection or unfixed-behaviour proof: e.g. a wrong-type
+field/constructor signature, isolated-loader cast, or missing-field retry. If the restricted
+environment hits the known address-selection failure, retry only the affected Gradle command with
+the repository's documented IPv4 `JAVA_TOOL_OPTIONS` setting.
+
+## Non-goals and completion boundary
+
+Phase 5 does not add static initializers, arbitrary reflection, field enumeration, bulk copying,
+array/generic target types, fluent setters, constructor selector groups, target-type wrappers,
+one-member method aliases, runtime overload/coercion, a `MethodHandleCache` lifecycle redesign,
+loader fallback or TCCL mutation, non-public/private access, JPMS bypasses, target classpath
+dependencies, or changes to extension loading and protocol behaviour.
+
+It is complete only when these five explicit operations preserve all Phase 1--4 loader, cache,
+exact-type, public-access, and failure boundaries; are externally compilable from the masked JAR;
+and are exercised across the real extension/client/agent/target path. It does not authorize Phase
+6 security/access work.


### PR DESCRIPTION
Closes #931.

## Summary

- Add source-only generated-adapter operations for public field reads/writes, construction, `isInstance`, and `cast`.
- Preserve exact public lookup, loader-safe success-only caches, opaque target-type boundaries, and existing static-loader behavior.
- Add processor diagnostics, masked-JAR Java 8 smoke coverage, real client-agent-target integration coverage, and canonical documentation.

## Compatibility

Existing method adapters and their static/loader behavior are unchanged. New operations are opt-in and require rebuilding the extension.

## Verification

- `:btrace-core:test`
- root `spotlessApply`
- clean `:btrace-dist:btraceJar` plus separated Java 8 masked-JAR smoke
- `:btrace-dist:build`
- `:integration-tests:test -Pintegration --tests tests.ExternalTypeAdapterIntegrationTest`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btraceio/btrace/945)
<!-- Reviewable:end -->
